### PR TITLE
:bug: Fix the learning rate scale

### DIFF
--- a/torch_uncertainty/routines/classification.py
+++ b/torch_uncertainty/routines/classification.py
@@ -481,6 +481,9 @@ class ClassificationEnsemble(ClassificationSingle):
             else:
                 loss = self.criterion(logits, targets, self.current_epoch)
 
+            # compensate for mean on the estimators
+            loss *= self.num_estimators
+
         self.log("train_loss", loss)
         return loss
 


### PR DESCRIPTION
Thanks again to @hanruisong00 for the remark. We have to discuss the best way to fix this scaling problem. The current solution is unsatisfactory as it scales all ensemble methods; however, BatchEnsembles and Masksembles should not be scaled according to their source code. Is the default automated scaling, and are BatchEnsembles/Masksembles anomalies? No, because MCDropout should not be scaled either. If it's 50/50, we could add a parameter to handle this question correctly.

Will resolve #59.