### PR TITLE
add cli-test-helpers to dependencies lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "huggingface-hub",
     "scikit-learn",
     "matplotlib",
+    "cli-test-helpers",
     "glest==0.0.1a0",
 ]
 
@@ -49,7 +50,6 @@ dev = [
     "pytest-cov",
     "pre-commit",
     "pre-commit-hooks",
-    "cli-test-helpers",
 ]
 docs = [
     "sphinx<6",


### PR DESCRIPTION
Thank you for providing such a fantastic library.
 When I tried running tutorials like `tutorial_mc_dropout.py`, I encountered an error stating that cli_test_helpers could not be found. Since it's necessary for running the tutorial, I believe that `cli-test-helpers` should be added to `dependencies` in pyproject.toml, rather than to `optional-dependencies`.