### PR TITLE
🐛 Fix small MUAD dataset URL

### DIFF
--- a/tests/datamodules/segmentation/test_muad.py
+++ b/tests/datamodules/segmentation/test_muad.py
@@ -35,3 +35,7 @@ class TestMUADDataModule:
         dm.setup()
         dm.train_dataloader()
         dm.val_dataloader()
+
+    def test_small_muad_accessibility(self):
+        dataset = MUAD(root="./data/", split="test", version="small", download=True)
+        assert len(dataset.samples) > 0, "Dataset is not found"

--- a/torch_uncertainty/datasets/muad.py
+++ b/torch_uncertainty/datasets/muad.py
@@ -41,7 +41,7 @@ class MUAD(VisionDataset):
         "val_depth": "0282030d281aeffee3335f713ba12373",
     }
 
-    small_muad_url = "fira7s/Muad2"
+    small_muad_url = "ENSTA-U2IS/miniMUAD"
 
     _num_samples = {
         "full": {


### PR DESCRIPTION
It was noticed that the URL for the small MUAD dataset is no longer available in https://huggingface.co/fira7s/Muad2, I suggest the new address is the account of U2IS: https://huggingface.co/datasets/ENSTA-U2IS/miniMUAD. This change causes issues when attempting to download the dataset using the current implementation

In this PR, I updated the URL and added a small test to verify the accessibility of the small MUAD dataset.

Feel free to modify or expand upon this PR as needed 😊 Perhaps, actual new URL is different 


### Context
A screenshot of the error is attached below for your reference

<img width="1083" alt="Screenshot 2024-12-25 at 02 17 45" src="https://github.com/user-attachments/assets/b10a08eb-76ad-4cf7-abb9-d8ee9667e8a8" />
