### PR TITLE
Bugfix `experiments/classification/mnsist/config/bayesian_lenet.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 .vscode/
+.idea/
 data/
 logs/
 lightning_logs/

--- a/experiments/classification/mnist/configs/bayesian_lenet.yaml
+++ b/experiments/classification/mnist/configs/bayesian_lenet.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       num_samples: 16
   num_classes: 10


### PR DESCRIPTION
### Bug
Executing the CLI command 
```
python lenet.py fit --config configs/bayesian_lenet.yaml
```
in `experimens/classification/mnist` throws the following error:

```
error: Parser key "model.model":
  Problem with given class_path 'torch_uncertainty.models.StochasticModel':
    Parser key "model":
      Problem with given class_path 'torch_uncertainty.models.lenet._LeNet':
        Validation failed: Key 'last_layer_dropout' is not expected
```

This is because the `__init__()` method of the `_LeNet` class does not expect the argument ` last_layer_dropout` specified in `configs/bayesian_lenet.yaml`:

```
class _LeNet(nn.Module):
    def __init__(
        self,
        in_channels: int,
        num_classes: int,
        linear_layer: type[nn.Module],
        conv2d_layer: type[nn.Module],
        layer_args: dict,
        activation: Callable,
        norm: type[nn.Module],
        groups: int,
        dropout_rate: float,
    ) -> None:
        super().__init__()
        ....
```

### Fix:
I simply removed that key from the config and the CLI fit command worked.