### PR TITLE
🐛 Fix minor bug with argument parsing in lenet.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 .vscode/
+.idea/
 data/
 logs/
 lightning_logs/

--- a/torch_uncertainty/models/lenet.py
+++ b/torch_uncertainty/models/lenet.py
@@ -20,7 +20,8 @@ class _LeNet(nn.Module):
         num_classes: int,
         linear_layer: type[nn.Module],
         conv2d_layer: type[nn.Module],
-        layer_args: dict,
+        linear_layer_args: dict,
+        conv2d_layer_args: dict,
         activation: Callable,
         norm: type[nn.Module],
         groups: int,
@@ -40,19 +41,19 @@ class _LeNet(nn.Module):
 
         self.dropout_rate = dropout_rate
 
-        self.conv1 = conv2d_layer(in_channels, 6, (5, 5), groups=groups, **layer_args)
+        self.conv1 = conv2d_layer(in_channels, 6, (5, 5), groups=groups, **conv2d_layer_args)
         if batchnorm:
             self.norm1 = norm(6)
         self.conv_dropout = nn.Dropout2d(p=dropout_rate)
-        self.conv2 = conv2d_layer(6, 16, (5, 5), groups=groups, **layer_args)
+        self.conv2 = conv2d_layer(6, 16, (5, 5), groups=groups, **conv2d_layer_args)
         if batchnorm:
             self.norm2 = norm(16)
         self.pooling = nn.AdaptiveAvgPool2d((4, 4))
-        self.fc1 = linear_layer(256, 120, **layer_args)
+        self.fc1 = linear_layer(256, 120, **linear_layer_args)
         self.fc_dropout = nn.Dropout(p=dropout_rate)
-        self.fc2 = linear_layer(120, 84, **layer_args)
+        self.fc2 = linear_layer(120, 84, **linear_layer_args)
         self.last_fc_dropout = nn.Dropout(p=dropout_rate)
-        self.fc3 = linear_layer(84, num_classes, **layer_args)
+        self.fc3 = linear_layer(84, num_classes, **linear_layer_args)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         out = self.conv_dropout(self.activation(self.norm1(self.conv1(x))))
@@ -72,7 +73,8 @@ def _lenet(
     stochastic: bool,
     in_channels: int,
     num_classes: int,
-    layer_args: dict,
+    linear_layer_args: dict,
+    conv2d_layer_args: dict,
     num_samples: int = 16,
     linear_layer: type[nn.Module] = nn.Linear,
     conv2d_layer: type[nn.Module] = nn.Conv2d,
@@ -89,7 +91,8 @@ def _lenet(
         activation=activation,
         norm=norm,
         groups=groups,
-        layer_args=layer_args,
+        linear_layer_args=linear_layer_args,
+        conv2d_layer_args=conv2d_layer_args,
         dropout_rate=dropout_rate,
     )
     if stochastic:
@@ -111,7 +114,8 @@ def lenet(
         num_classes=num_classes,
         linear_layer=nn.Linear,
         conv2d_layer=nn.Conv2d,
-        layer_args={},
+        linear_layer_args={},
+        conv2d_layer_args={},
         activation=activation,
         norm=norm,
         groups=groups,
@@ -137,7 +141,12 @@ def packed_lenet(
         linear_layer=PackedLinear,
         conv2d_layer=PackedConv2d,
         norm=norm,
-        layer_args={
+        linear_layer_args={
+            "num_estimators": num_estimators,
+            "alpha": alpha,
+            "gamma": gamma,
+        },
+        conv2d_layer_args={
             "num_estimators": num_estimators,
             "alpha": alpha,
             "gamma": gamma,
@@ -182,7 +191,8 @@ def bayesian_lenet(
         linear_layer=BayesLinear,
         conv2d_layer=BayesConv2d,
         norm=norm,
-        layer_args=layers_args,
+        linear_layer_args=layers_args,
+        conv2d_layer_args=layers_args,
         activation=activation,
         groups=groups,
         dropout_rate=dropout_rate,


### PR DESCRIPTION
### Bug Description:
The lenet.py file in the models directory had an issue where the `layer_args` dictionary was being used to pass arguments to both the linear and convolutional layers. This caused problems because the `layer_args` dictionary could only contain arguments that were shared across all layers. As a result, any additional arguments specific to either the linear or convolutional layers could not be set, leading to potential misconfigurations and errors.

### Fix Description:
The fix involved separating the `layer_args` dictionary into two distinct dictionaries: `linear_layer_args` and `conv2d_layer_args`. This ensures that each layer receives only the arguments it needs, avoiding any issues with unexpected keyword arguments. The `_LeNet` class and the functions that create instances of `_LeNet` were updated to accept and pass these separate dictionaries for linear and convolutional layer arguments.