### PR TITLE
:bug: Fix MNIST test dataloader for shifted data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 .vscode/
+.itea/
 data/
 logs/
 lightning_logs/

--- a/experiments/classification/mnist/configs/bayesian_lenet.yaml
+++ b/experiments/classification/mnist/configs/bayesian_lenet.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       num_samples: 16
   num_classes: 10

--- a/experiments/classification/mnist/configs/lenet.yaml
+++ b/experiments/classification/mnist/configs/lenet.yaml
@@ -38,7 +38,6 @@ model:
       norm: torch.nn.Identity
       groups: 1
       dropout_rate: 0
-      last_layer_dropout: false
       layer_args: {}
   num_classes: 10
   loss: CrossEntropyLoss

--- a/experiments/classification/mnist/configs/lenet_checkpoint_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet_checkpoint_ensemble.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       save_schedule:
         - 20

--- a/experiments/classification/mnist/configs/lenet_ema.yaml
+++ b/experiments/classification/mnist/configs/lenet_ema.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       momentum: 0.99
   num_classes: 10

--- a/experiments/classification/mnist/configs/lenet_swa.yaml
+++ b/experiments/classification/mnist/configs/lenet_swa.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       cycle_start: 19
       cycle_length: 5

--- a/experiments/classification/mnist/configs/lenet_swag.yaml
+++ b/experiments/classification/mnist/configs/lenet_swag.yaml
@@ -41,7 +41,6 @@ model:
           norm: torch.nn.Identity
           groups: 1
           dropout_rate: 0
-          last_layer_dropout: false
           layer_args: {}
       cycle_start: 10
       cycle_length: 5

--- a/tests/datamodules/classification/test_mnist.py
+++ b/tests/datamodules/classification/test_mnist.py
@@ -47,6 +47,7 @@ class TestMNISTDataModule:
             dm.setup("other")
 
         dm.eval_ood = True
+        dm.eval_shift = True
         dm.ood_transform = dm.test_transform
         dm.val_split = 0.1
         dm.prepare_data()

--- a/torch_uncertainty/datamodules/abstract.py
+++ b/torch_uncertainty/datamodules/abstract.py
@@ -15,6 +15,8 @@ class TUDataModule(ABC, LightningDataModule):
     val: Dataset
     test: Dataset
 
+    shift_severity = 1
+
     def __init__(
         self,
         root: str | Path,

--- a/torch_uncertainty/datamodules/classification/cifar10.py
+++ b/torch_uncertainty/datamodules/classification/cifar10.py
@@ -228,8 +228,7 @@ class CIFAR10DataModule(TUDataModule):
         r"""Get test dataloaders.
 
         Return:
-            list[DataLoader]: test set for in distribution data
-            and out-of-distribution data.
+            list[DataLoader]: test set for in distribution data, SVHN data, and/or CIFAR-10C data.
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:

--- a/torch_uncertainty/datamodules/classification/cifar100.py
+++ b/torch_uncertainty/datamodules/classification/cifar100.py
@@ -210,8 +210,8 @@ class CIFAR100DataModule(TUDataModule):
         r"""Get test dataloaders.
 
         Return:
-            list[DataLoader]: test set for in distribution data
-            and out-of-distribution data.
+            list[DataLoader]: test set for in distribution data, SVHN data, and/or
+            CIFAR-100C data.
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:

--- a/torch_uncertainty/datamodules/classification/imagenet.py
+++ b/torch_uncertainty/datamodules/classification/imagenet.py
@@ -289,8 +289,8 @@ class ImageNetDataModule(TUDataModule):
         """Get the test dataloaders for ImageNet.
 
         Return:
-            list[DataLoader]: ImageNet test set (in distribution data) and
-            Textures test split (out-of-distribution data).
+            list[DataLoader]: ImageNet test set (in distribution data), OOD dataset test split
+            (out-of-distribution data), and/or ImageNetC data.
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:

--- a/torch_uncertainty/datamodules/classification/mnist.py
+++ b/torch_uncertainty/datamodules/classification/mnist.py
@@ -171,10 +171,12 @@ class MNISTDataModule(TUDataModule):
 
         Return:
             list[DataLoader]: Dataloaders of the MNIST test set (in
-                distribution data) and FashionMNIST test split
+                distribution data), MNISTC (shifted data), and FashionMNIST test split
                 (out-of-distribution data).
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:
             dataloader.append(self._data_loader(self.ood))
+        if self.eval_shift:
+            dataloader.append(self._data_loader(self.shift))
         return dataloader

--- a/torch_uncertainty/datamodules/classification/mnist.py
+++ b/torch_uncertainty/datamodules/classification/mnist.py
@@ -171,8 +171,8 @@ class MNISTDataModule(TUDataModule):
 
         Return:
             list[DataLoader]: Dataloaders of the MNIST test set (in
-                distribution data), MNISTC (shifted data), and FashionMNIST test split
-                (out-of-distribution data).
+                distribution data), FashionMNIST or NotMNIST test split
+                (out-of-distribution data), and/or MNISTC (shifted data).
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:

--- a/torch_uncertainty/datamodules/classification/tiny_imagenet.py
+++ b/torch_uncertainty/datamodules/classification/tiny_imagenet.py
@@ -237,8 +237,8 @@ class TinyImageNetDataModule(TUDataModule):
         r"""Get test dataloaders for TinyImageNet.
 
         Return:
-            list[DataLoader]: test set for in distribution data
-            and out-of-distribution data.
+            list[DataLoader]: test set for in distribution data, OOD data, and/or
+            TinyImageNetC data.
         """
         dataloader = [self._data_loader(self.test)]
         if self.eval_ood:

--- a/torch_uncertainty/datasets/classification/mnist_c.py
+++ b/torch_uncertainty/datasets/classification/mnist_c.py
@@ -71,7 +71,6 @@ class MNISTC(VisionDataset):
         target_transform: Callable | None = None,
         split: Literal["train", "test"] = "test",
         subset: str = "all",
-        shift_severity: int = 1,
         download: bool = False,
     ) -> None:
         self.root = Path(root)
@@ -91,12 +90,6 @@ class MNISTC(VisionDataset):
         if subset not in ["all", *self.mnistc_subsets]:
             raise ValueError(f"The subset '{subset}' does not exist in MNIST-C.")
         self.subset = subset
-
-        self.shift_severity = shift_severity
-        if shift_severity not in list(range(1, 6)):
-            raise ValueError(
-                "Corruptions shift_severity should be chosen between 1 and 5 " "included."
-            )
 
         if split not in ["train", "test"]:
             raise ValueError(f"The split '{split}' should be either 'train' or 'test'.")

--- a/torch_uncertainty/datasets/classification/mnist_c.py
+++ b/torch_uncertainty/datasets/classification/mnist_c.py
@@ -23,7 +23,6 @@ class MNISTC(VisionDataset):
             takes in the target and transforms it. Defaults to None.
         subset (str): The subset to use, one of ``all`` or the keys in
             ``mnistc_subsets``.
-        shift_severity (int): The shift_severity of the corruption, between 1 and 5.
         download (bool, optional): If True, downloads the dataset from the
             internet and puts it in root directory. If dataset is already
             downloaded, it is not downloaded again. Defaults to False.

--- a/torch_uncertainty/datasets/classification/mnist_c.py
+++ b/torch_uncertainty/datasets/classification/mnist_c.py
@@ -23,6 +23,7 @@ class MNISTC(VisionDataset):
             takes in the target and transforms it. Defaults to None.
         subset (str): The subset to use, one of ``all`` or the keys in
             ``mnistc_subsets``.
+        shift_severity (int): The shift_severity of the corruption, between 1 and 5.
         download (bool, optional): If True, downloads the dataset from the
             internet and puts it in root directory. If dataset is already
             downloaded, it is not downloaded again. Defaults to False.
@@ -70,6 +71,7 @@ class MNISTC(VisionDataset):
         target_transform: Callable | None = None,
         split: Literal["train", "test"] = "test",
         subset: str = "all",
+        shift_severity: int = 1,
         download: bool = False,
     ) -> None:
         self.root = Path(root)
@@ -89,6 +91,12 @@ class MNISTC(VisionDataset):
         if subset not in ["all", *self.mnistc_subsets]:
             raise ValueError(f"The subset '{subset}' does not exist in MNIST-C.")
         self.subset = subset
+
+        self.shift_severity = shift_severity
+        if shift_severity not in list(range(1, 6)):
+            raise ValueError(
+                "Corruptions shift_severity should be chosen between 1 and 5 " "included."
+            )
 
         if split not in ["train", "test"]:
             raise ValueError(f"The split '{split}' should be either 'train' or 'test'.")

--- a/torch_uncertainty/routines/classification.py
+++ b/torch_uncertainty/routines/classification.py
@@ -606,9 +606,7 @@ class ClassificationRoutine(LightningModule):
 
         if self.eval_shift:
             tmp_metrics = self.test_shift_metrics.compute()
-            shift_severity = self.trainer.test_dataloaders[
-                2 if self.eval_ood else 1
-            ].dataset.shift_severity
+            shift_severity = self.trainer.datamodule.shift_severity
             tmp_metrics["shift/shift_severity"] = shift_severity
             self.log_dict(tmp_metrics, sync_dist=True)
             result_dict.update(tmp_metrics)


### PR DESCRIPTION
Testing on the `MNISTDataModule` inside a `ClassifcationRoutine` with `eval_shifted=True` set would raise a `ValueError("No samples to concatenate")`  when `self.test_shift_metrics.compute()`  was called inside the `ClassificationRoutine`, because `test_dataloader()` did not actually return the test dataloader with the shifter data.

Also, MNISTC was missing the property `shift_severity` which is referenced inside `ClassificationRoutine`.