### PR TITLE
✨ LeNet BatchEnsemble and Deep Ensemble + minor bugfixes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -201,6 +201,7 @@ Functions
     :toctree: generated/
     :nosignatures:
 
+    batch_ensemble
     deep_ensembles
     mc_dropout
 
@@ -212,6 +213,7 @@ Classes
     :nosignatures:
     :template: class.rst
 
+    BatchEnsemble
     CheckpointEnsemble
     EMA
     MCDropout

--- a/experiments/classification/mnist/configs/lenet_batch_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet_batch_ensemble.yaml
@@ -40,6 +40,7 @@ model:
       norm: torch.nn.BatchNorm2d
       groups: 1
       dropout_rate: 0
+      repeat_training_inputs: true
   num_classes: 10
   loss: CrossEntropyLoss
   is_ensemble: true

--- a/experiments/classification/mnist/configs/lenet_batch_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet_batch_ensemble.yaml
@@ -1,0 +1,67 @@
+# lightning.pytorch==2.1.3
+seed_everything: false
+eval_after_fit: true
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  devices: 1
+  precision: 16-mixed
+  max_epochs: 10
+  logger:
+    class_path: lightning.pytorch.loggers.TensorBoardLogger
+    init_args:
+      save_dir: logs/lenet_trajectory
+      name: batch_ensemble
+      default_hp_metric: false
+  callbacks:
+  - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+    init_args:
+      monitor: val/cls/Acc
+      mode: max
+      save_last: true
+  - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+    init_args:
+      logging_interval: step
+  - class_path: lightning.pytorch.callbacks.EarlyStopping
+    init_args:
+      monitor: val/cls/Acc
+      patience: 1000
+      check_finite: true
+model:  
+  # ClassificationRoutine
+  model:  
+    # BatchEnsemble
+    class_path: torch_uncertainty.models.lenet.batchensemble_lenet
+    init_args:
+      in_channels: 1
+      num_classes: 10
+      num_estimators: 5
+      activation: torch.nn.ReLU
+      norm: torch.nn.BatchNorm2d
+      groups: 1
+      dropout_rate: 0
+  num_classes: 10
+  loss: CrossEntropyLoss
+  is_ensemble: true
+  format_batch_fn:
+    class_path: torch_uncertainty.transforms.batch.RepeatTarget
+    init_args:
+      num_repeats: 5
+data:
+  root: ./data
+  batch_size: 128
+  num_workers: 127
+  eval_ood: true
+  eval_shift: true
+optimizer:
+  lr: 0.05
+  momentum: 0.9
+  weight_decay: 5e-4
+  nesterov: true
+lr_scheduler:
+  class_path: torch.optim.lr_scheduler.MultiStepLR
+  init_args:
+    milestones:
+    - 25
+    - 50
+    gamma: 0.1

--- a/experiments/classification/mnist/configs/lenet_checkpoint_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet_checkpoint_ensemble.yaml
@@ -67,7 +67,9 @@ optimizer:
   weight_decay: 5e-4
   nesterov: true
 lr_scheduler:
-  milestones:
-  - 25
-  - 50
-  gamma: 0.1
+  class_path: torch.optim.lr_scheduler.MultiStepLR
+  init_args:
+    milestones:
+    - 25
+    - 50
+    gamma: 0.1

--- a/experiments/classification/mnist/configs/lenet_deep_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet_deep_ensemble.yaml
@@ -1,0 +1,78 @@
+# lightning.pytorch==2.1.3
+seed_everything: false
+eval_after_fit: true
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  devices: 1
+  precision: 16-mixed
+  max_epochs: 10
+  logger:
+    class_path: lightning.pytorch.loggers.TensorBoardLogger
+    init_args:
+      save_dir: logs/lenet_trajectory
+      name: deep_ensemble
+      default_hp_metric: false
+  callbacks:
+  - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+    init_args:
+      monitor: val/cls/Acc
+      mode: max
+      save_last: true
+  - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+    init_args:
+      logging_interval: step
+  - class_path: lightning.pytorch.callbacks.EarlyStopping
+    init_args:
+      monitor: val/cls/Acc
+      patience: 1000
+      check_finite: true
+model:  
+  # ClassificationRoutine
+  model:  
+    # DeepEnsemble
+    class_path: torch_uncertainty.models.wrappers.deep_ensembles.deep_ensembles
+    init_args:
+      models:  
+        # LeNet
+        class_path: torch_uncertainty.models.lenet._LeNet
+        init_args:
+          in_channels: 1
+          num_classes: 10
+          linear_layer: torch.nn.Linear
+          conv2d_layer: torch.nn.Conv2d
+          activation: torch.nn.ReLU
+          norm: torch.nn.Identity
+          groups: 1
+          dropout_rate: 0
+          # last_layer_dropout: false
+          layer_args: {}
+      num_estimators: 5
+      task: classification
+      probabilistic: false
+      reset_model_parameters: true
+  num_classes: 10
+  loss: CrossEntropyLoss
+  is_ensemble: true
+  format_batch_fn:
+    class_path: torch_uncertainty.transforms.batch.RepeatTarget
+    init_args:
+      num_repeats: 5
+data:
+  root: ./data
+  batch_size: 128
+  num_workers: 127
+  eval_ood: true
+  eval_shift: true
+optimizer:
+  lr: 0.05
+  momentum: 0.9
+  weight_decay: 5e-4
+  nesterov: true
+lr_scheduler:
+  class_path: torch.optim.lr_scheduler.MultiStepLR
+  init_args:
+    milestones:
+    - 25
+    - 50
+    gamma: 0.1

--- a/experiments/classification/mnist/configs/lenet_ema.yaml
+++ b/experiments/classification/mnist/configs/lenet_ema.yaml
@@ -55,7 +55,9 @@ optimizer:
   weight_decay: 5e-4
   nesterov: true
 lr_scheduler:
-  milestones:
-  - 25
-  - 50
-  gamma: 0.1
+  class_path: torch.optim.lr_scheduler.MultiStepLR
+  init_args:
+    milestones:
+    - 25
+    - 50
+    gamma: 0.1

--- a/tests/layers/test_batch.py
+++ b/tests/layers/test_batch.py
@@ -33,6 +33,17 @@ class TestBatchLinear:
         out = layer(feat_input)
         assert out.shape == torch.Size([4, 2])
 
+    def test_convert_from_linear(self, feat_input: torch.Tensor):
+        linear = torch.nn.Linear(6, 3)
+        layer = BatchLinear.from_linear(linear, num_estimators=2)
+        assert layer.linear.weight.shape == torch.Size([3, 6])
+        assert layer.linear.bias is None
+        assert layer.r_group.shape == torch.Size([2, 6])
+        assert layer.s_group.shape == torch.Size([2, 3])
+        assert layer.bias.shape == torch.Size([2, 3])
+        out = layer(feat_input)
+        assert out.shape == torch.Size([4, 3])
+
 
 class TestBatchConv2d:
     """Testing the BatchConv2d layer class."""
@@ -47,3 +58,14 @@ class TestBatchConv2d:
         layer = BatchConv2d(6, 2, num_estimators=2, kernel_size=1)
         out = layer(img_input)
         assert out.shape == torch.Size([5, 2, 3, 3])
+
+    def test_convert_from_conv2d(self, img_input: torch.Tensor):
+        conv = torch.nn.Conv2d(6, 3, 1)
+        layer = BatchConv2d.from_conv2d(conv, num_estimators=2)
+        assert layer.conv.weight.shape == torch.Size([3, 6, 1, 1])
+        assert layer.conv.bias is None
+        assert layer.r_group.shape == torch.Size([2, 6])
+        assert layer.s_group.shape == torch.Size([2, 3])
+        assert layer.bias.shape == torch.Size([2, 3])
+        out = layer(img_input)
+        assert out.shape == torch.Size([5, 3, 3, 3])

--- a/tests/models/test_lenet.py
+++ b/tests/models/test_lenet.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch import nn
 
-from torch_uncertainty.models.lenet import bayesian_lenet, lenet, packed_lenet
+from torch_uncertainty.models.lenet import batchensemble_lenet, bayesian_lenet, lenet, packed_lenet
 
 
 class TestLeNet:
@@ -18,6 +18,7 @@ class TestLeNet:
         model.eval()
         model(torch.randn(1, 1, 20, 20))
 
+        batchensemble_lenet(1, 1)
         packed_lenet(1, 1)
         bayesian_lenet(1, 1)
         bayesian_lenet(

--- a/tests/models/wrappers/test_batch_ensemble.py
+++ b/tests/models/wrappers/test_batch_ensemble.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch import nn
 
@@ -6,7 +5,7 @@ from torch_uncertainty.models.wrappers.batch_ensemble import BatchEnsemble
 
 
 # Define a simple model for testing wrapper functionality (disregarding the actual BatchEnsemble architecture)
-class SimpleModel(nn.Module):
+class _DummyModel(nn.Module):
     def __init__(self, in_features, out_features):
         super().__init__()
         self.fc = nn.Linear(in_features, out_features)
@@ -18,19 +17,15 @@ class SimpleModel(nn.Module):
         return self.fc(x)
 
 
-# Test the BatchEnsemble wrapper
-def test_batch_ensemble():
-    in_features = 10
-    out_features = 5
-    num_estimators = 3
-    model = SimpleModel(in_features, out_features)
-    wrapped_model = BatchEnsemble(model, num_estimators)
+class TestBatchEnsembleModel:
+    def test_forward_pass(self):
+        in_features = 10
+        out_features = 5
+        num_estimators = 3
+        model = _DummyModel(in_features, out_features)
+        wrapped_model = BatchEnsemble(model, num_estimators)
 
-    # Test forward pass
-    x = torch.randn(2, in_features)  # Batch size of 2
-    logits = wrapped_model(x)
-    assert logits.shape == (2 * num_estimators, out_features)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])
+        # Test forward pass
+        x = torch.randn(2, in_features)  # Batch size of 2
+        logits = wrapped_model(x)
+        assert logits.shape == (2 * num_estimators, out_features)

--- a/tests/models/wrappers/test_batch_ensemble.py
+++ b/tests/models/wrappers/test_batch_ensemble.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+from torch import nn
+
+from torch_uncertainty.models.wrappers.batch_ensemble import BatchEnsemble
+
+
+# Define a simple model for testing wrapper functionality (disregarding the actual BatchEnsemble architecture)
+class SimpleModel(nn.Module):
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.fc = nn.Linear(in_features, out_features)
+        self.r_group = nn.Parameter(torch.randn(in_features))
+        self.s_group = nn.Parameter(torch.randn(out_features))
+        self.bias = nn.Parameter(torch.randn(out_features))
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+# Test the BatchEnsemble wrapper
+def test_batch_ensemble():
+    in_features = 10
+    out_features = 5
+    num_estimators = 3
+    model = SimpleModel(in_features, out_features)
+    wrapped_model = BatchEnsemble(model, num_estimators)
+
+    # Test forward pass
+    x = torch.randn(2, in_features)  # Batch size of 2
+    logits = wrapped_model(x)
+    assert logits.shape == (2 * num_estimators, out_features)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/models/wrappers/test_batch_ensemble.py
+++ b/tests/models/wrappers/test_batch_ensemble.py
@@ -1,31 +1,82 @@
+import pytest
 import torch
 from torch import nn
 
+from torch_uncertainty.layers import BatchConv2d, BatchLinear
 from torch_uncertainty.models.wrappers.batch_ensemble import BatchEnsemble
+
+
+@pytest.fixture()
+def img_input() -> torch.Tensor:
+    return torch.rand((5, 6, 3, 3))
 
 
 # Define a simple model for testing wrapper functionality (disregarding the actual BatchEnsemble architecture)
 class _DummyModel(nn.Module):
     def __init__(self, in_features, out_features):
         super().__init__()
-        self.fc = nn.Linear(in_features, out_features)
-        self.r_group = nn.Parameter(torch.randn(in_features))
-        self.s_group = nn.Parameter(torch.randn(out_features))
-        self.bias = nn.Parameter(torch.randn(out_features))
+        self.conv = nn.Conv2d(in_features, out_features, 3)
+        self.fc = nn.Linear(out_features, out_features)
 
     def forward(self, x):
+        x = self.conv(x)
+        x = x.flatten(1)
+        return self.fc(x)
+
+
+class _DummyBEModel(nn.Module):
+    def __init__(self, in_features, out_features, num_estimators):
+        super().__init__()
+        self.conv = BatchConv2d(in_features, out_features, 3, num_estimators)
+        self.fc = BatchLinear(out_features, out_features, num_estimators=num_estimators)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = x.flatten(1)
         return self.fc(x)
 
 
 class TestBatchEnsembleModel:
-    def test_forward_pass(self):
-        in_features = 10
-        out_features = 5
+    def test_convert_layers(self):
+        in_features = 6
+        out_features = 4
         num_estimators = 3
-        model = _DummyModel(in_features, out_features)
-        wrapped_model = BatchEnsemble(model, num_estimators)
 
-        # Test forward pass
-        x = torch.randn(2, in_features)  # Batch size of 2
-        logits = wrapped_model(x)
-        assert logits.shape == (2 * num_estimators, out_features)
+        model = _DummyModel(in_features, out_features)
+        wrapped_model = BatchEnsemble(model, num_estimators, convert_layers=True)
+        assert wrapped_model.num_estimators == num_estimators
+        assert isinstance(wrapped_model.model.conv, BatchConv2d)
+        assert isinstance(wrapped_model.model.fc, BatchLinear)
+
+    def test_forward_pass(self, img_input):
+        batch_size = img_input.size(0)
+        in_features = img_input.size(1)
+        out_features = 4
+        num_estimators = 3
+        model = _DummyBEModel(in_features, out_features, num_estimators)
+        # with repeat_training_inputs=False
+        wrapped_model = BatchEnsemble(model, num_estimators, repeat_training_inputs=False)
+        # test forward pass for training
+        logits = wrapped_model(img_input)
+        assert logits.shape == (img_input.size(0), out_features)
+        # test forward pass for evaluation
+        wrapped_model.eval()
+        logits = wrapped_model(img_input)
+        assert logits.shape == (batch_size * num_estimators, out_features)
+        # with repeat_training_inputs=True
+        wrapped_model = BatchEnsemble(model, num_estimators, repeat_training_inputs=True)
+        # test forward pass for training
+        logits = wrapped_model(img_input)
+        assert logits.shape == (batch_size * num_estimators, out_features)
+        # test forward pass for evaluation
+        wrapped_model.eval()
+        logits = wrapped_model(img_input)
+        assert logits.shape == (batch_size * num_estimators, out_features)
+
+    def test_errors(self):
+        with pytest.raises(ValueError):
+            BatchEnsemble(_DummyBEModel(10, 5, 1), 0)
+        with pytest.raises(ValueError):
+            BatchEnsemble(_DummyModel(10, 5), 1)
+        with pytest.raises(ValueError):
+            BatchEnsemble(nn.Identity(), 2, convert_layers=True)

--- a/torch_uncertainty/layers/batch_ensemble.py
+++ b/torch_uncertainty/layers/batch_ensemble.py
@@ -79,7 +79,13 @@ class BatchLinear(nn.Module):
               :math:`H_{out} = \text{out_features}`.
 
         Warning:
-            Make sure that :attr:`num_estimators` divides :attr:`out_features` when calling :func:`forward()`.
+            Ensure that `batch_size` is divisible by :attr:`num_estimators` when calling :func:`forward()`.
+            In a BatchEnsemble architecture, the input batch is typically **repeated** `num_estimators`
+            times along the first axis. Incorrect batch size may lead to unexpected results.
+
+            To simplify batch handling, wrap your model with `BatchEnsembleWrapper`, which automatically
+            repeats the batch before passing it through the network. See `BatchEnsembleWrapper` for details.
+
 
         Examples:
             >>> # With three estimators
@@ -273,8 +279,12 @@ class BatchConv2d(nn.Module):
                 {\text{stride}[1]} + 1\right\rfloor
 
         Warning:
-            Make sure that :attr:`num_estimators` divides :attr:`out_channels` when calling :func:`forward()`.
+            Ensure that `batch_size` is divisible by :attr:`num_estimators` when calling :func:`forward()`.
+            In a BatchEnsemble architecture, the input batch is typically **repeated** `num_estimators`
+            times along the first axis. Incorrect batch size may lead to unexpected results.
 
+            To simplify batch handling, wrap your model with `BatchEnsembleWrapper`, which automatically
+            repeats the batch before passing it through the network. See `BatchEnsembleWrapper` for details.
 
         Examples:
             >>> # With square kernels, four estimators and equal stride

--- a/torch_uncertainty/models/__init__.py
+++ b/torch_uncertainty/models/__init__.py
@@ -5,9 +5,11 @@ from .wrappers import (
     STEP_UPDATE_MODEL,
     SWA,
     SWAG,
+    BatchEnsemble,
     CheckpointEnsemble,
     MCDropout,
     StochasticModel,
+    batch_ensemble,
     deep_ensembles,
     mc_dropout,
 )

--- a/torch_uncertainty/models/lenet.py
+++ b/torch_uncertainty/models/lenet.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from torch_uncertainty.layers.batch_ensemble import BatchConv2d, BatchLinear
 from torch_uncertainty.layers.bayesian import BayesConv2d, BayesLinear
 from torch_uncertainty.layers.mc_batch_norm import MCBatchNorm2d
 from torch_uncertainty.layers.packed import PackedConv2d, PackedLinear
@@ -129,22 +128,22 @@ def batchensemble_lenet(
     norm: type[nn.Module] = nn.BatchNorm2d,
     groups: int = 1,
     dropout_rate: float = 0.0,
+    repeat_training_inputs: bool = False,
 ) -> _LeNet:
-    model = _lenet(
-        stochastic=False,
+    model = lenet(
         in_channels=in_channels,
         num_classes=num_classes,
-        linear_layer=BatchLinear,
-        conv2d_layer=BatchConv2d,
-        layer_args={
-            "num_estimators": num_estimators,
-        },
         activation=activation,
         norm=norm,
         groups=groups,
         dropout_rate=dropout_rate,
     )
-    return BatchEnsemble(model, num_estimators)
+    return BatchEnsemble(
+        model=model,
+        num_estimators=num_estimators,
+        repeat_training_inputs=repeat_training_inputs,
+        convert_layers=True,
+    )
 
 
 def packed_lenet(

--- a/torch_uncertainty/models/wrappers/__init__.py
+++ b/torch_uncertainty/models/wrappers/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401
+from .batch_ensemble import BatchEnsemble, batch_ensemble
 from .checkpoint_ensemble import (
     CheckpointEnsemble,
 )

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -83,7 +83,9 @@ class BatchEnsemble(nn.Module):
         _batch_ensemble_checks(filtered_modules, num_estimators)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Repeats the input batch and passes it through the model."""
+        """Repeat the input if `self.training == False` or `repeat_training_inputs==True` and pass
+        it through the model.
+        """
         if not self.training or self.repeat_training_inputs:
             x = repeat(x, "b ... -> (m b) ...", m=self.num_estimators)
         return self.model(x)

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -31,5 +31,6 @@ class BatchEnsemble(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Repeats the input batch and passes it through the model."""
-        x = x.repeat(self.num_estimators, 1, 1, 1)
+        repeat_shape = [self.num_estimators] + [1] * (x.dim() - 1)
+        x = x.repeat(repeat_shape)
         return self.model(x)

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -26,21 +26,21 @@ class BatchEnsemble(nn.Module):
             BatchEnsemble counterparts. Default is `False`.
 
     Raises:
-        ValueError: If neither `BatchLinear` nor `BatchConv2d` layers are found in the model at the
+        ValueError: If neither ``BatchLinear`` nor ``BatchConv2d`` layers are found in the model at the
             end of initialization.
-        ValueError: If `num_estimators` is less than or equal to 0.
-        ValueError: If `convert_layers=True` and neither `nn.Linear` nor `nn.Conv2d` layers are
+        ValueError: If ``num_estimators`` is less than or equal to ``0``.
+        ValueError: If ``convert_layers=True`` and neither ``nn.Linear`` nor ``nn.Conv2d`` layers are
             found in the model.
 
     Warning:
-        If `convert_layers==True`, the wrapper will attempt to convert all `nn.Linear` and `nn.Conv2d`
+        If ``convert_layers==True``, the wrapper will attempt to convert all ``nn.Linear`` and ``nn.Conv2d``
         layers in the model to their BatchEnsemble counterparts. If the model contains other types of
-        layers, the conversion won't happen for these layers. If don't have any `nn.Linear` or `nn.Conv2d`
+        layers, the conversion won't happen for these layers. If don't have any ``nn.Linear`` or ``nn.Conv2d``
         layers in the model, the wrapper will raise an error during conversion.
 
     Warning:
-        If `repeat_training_inputs==True` and you want to use one of the `torch_uncertainty.routines`
-        for training, be sure to set `format_batch_fn=RepeatTarget(num_repeats=num_estimators)` when
+        If ``repeat_training_inputs==True`` and you want to use one of the ``torch_uncertainty.routines``
+        for training, be sure to set ``format_batch_fn=RepeatTarget(num_repeats=num_estimators)`` when
         initializing the routine.
 
     Example:
@@ -83,8 +83,8 @@ class BatchEnsemble(nn.Module):
         _batch_ensemble_checks(filtered_modules, num_estimators)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Repeat the input if `self.training == False` or `repeat_training_inputs==True` and pass
-        it through the model.
+        """Repeat the input if ``self.training==False`` or ``repeat_training_inputs==True`` and
+        pass it through the model.
         """
         if not self.training or self.repeat_training_inputs:
             x = repeat(x, "b ... -> (m b) ...", m=self.num_estimators)

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -18,7 +18,7 @@ class BatchEnsemble(nn.Module):
     wrapped_model = BatchEnsembleWrapper(model, num_estimators=5)
     logits = wrapped_model(x)  # `x` is automatically repeated `num_estimators` times
     ```
-    
+
     Args:
         model (nn.Module): The BatchEnsemble model.
         num_estimators (int): Number of ensemble members.

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -1,0 +1,34 @@
+import torch
+from torch import nn
+
+class BatchEnsemble(nn.Module):
+    """Wraps a BatchEnsemble model to ensure correct batch replication.
+
+    In a BatchEnsemble architecture, each estimator operates on a **sub-batch**
+    of the input. This means that the input batch must be **repeated**
+    :attr:`num_estimators` times before being processed.
+
+    This wrapper automatically **duplicates the input batch** along the first axis,
+    ensuring that each estimator receives the correct data format.
+
+    **Usage Example:**
+    ```python
+    model = lenet(in_channels=1, num_classes=10)
+    wrapped_model = BatchEnsembleWrapper(model, num_estimators=5)
+    logits = wrapped_model(x)  # `x` is automatically repeated `num_estimators` times
+    ```
+    
+    Args:
+        model (nn.Module): The BatchEnsemble model.
+        num_estimators (int): Number of ensemble members.
+    """
+
+    def __init__(self, model: nn.Module, num_estimators: int):
+        super().__init__()
+        self.model = model
+        self.num_estimators = num_estimators
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Repeats the input batch and passes it through the model."""
+        x = x.repeat(self.num_estimators, 1, 1, 1)
+        return self.model(x)

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -3,7 +3,7 @@ from torch import nn
 
 
 class BatchEnsemble(nn.Module):
-    """Wraps a BatchEnsemble model to ensure correct batch replication.
+    """Wrap a BatchEnsemble model to ensure correct batch replication.
 
     In a BatchEnsemble architecture, each estimator operates on a **sub-batch**
     of the input. This means that the input batch must be **repeated**

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -1,6 +1,7 @@
 import torch
 from torch import nn
 
+
 class BatchEnsemble(nn.Module):
     """Wraps a BatchEnsemble model to ensure correct batch replication.
 

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -22,6 +22,9 @@ class BatchEnsemble(nn.Module):
     Args:
         model (nn.Module): The BatchEnsemble model.
         num_estimators (int): Number of ensemble members.
+
+    Note:
+        This wrapper assumes that the model uses **BatchEnsemble layers** (see `torchensemble.layers.batch_ensemble`).
     """
 
     def __init__(self, model: nn.Module, num_estimators: int):

--- a/torch_uncertainty/models/wrappers/batch_ensemble.py
+++ b/torch_uncertainty/models/wrappers/batch_ensemble.py
@@ -1,5 +1,8 @@
 import torch
+from einops import repeat
 from torch import nn
+
+from torch_uncertainty.layers import BatchConv2d, BatchLinear
 
 
 class BatchEnsemble(nn.Module):
@@ -12,28 +15,140 @@ class BatchEnsemble(nn.Module):
     This wrapper automatically **duplicates the input batch** along the first axis,
     ensuring that each estimator receives the correct data format.
 
-    **Usage Example:**
-    ```python
-    model = lenet(in_channels=1, num_classes=10)
-    wrapped_model = BatchEnsembleWrapper(model, num_estimators=5)
-    logits = wrapped_model(x)  # `x` is automatically repeated `num_estimators` times
-    ```
-
     Args:
         model (nn.Module): The BatchEnsemble model.
         num_estimators (int): Number of ensemble members.
+        repeat_training_inputs (optional, bool): Whether to repeat the input batch during training.
+            If `True`, the input batch is repeated during both training and evaluation. If `False`,
+            the input batch is repeated only during evaluation. Default is `False`.
+        convert_layers (optional, bool): Whether to convert the model's layers to BatchEnsemble layers.
+            If `True`, the wrapper will convert all `nn.Linear` and `nn.Conv2d` layers to their
+            BatchEnsemble counterparts. Default is `False`.
 
-    Note:
-        This wrapper assumes that the model uses **BatchEnsemble layers** (see `torchensemble.layers.batch_ensemble`).
+    Raises:
+        ValueError: If neither `BatchLinear` nor `BatchConv2d` layers are found in the model at the
+            end of initialization.
+        ValueError: If `num_estimators` is less than or equal to 0.
+        ValueError: If `convert_layers=True` and neither `nn.Linear` nor `nn.Conv2d` layers are
+            found in the model.
+
+    Warning:
+        If `convert_layers==True`, the wrapper will attempt to convert all `nn.Linear` and `nn.Conv2d`
+        layers in the model to their BatchEnsemble counterparts. If the model contains other types of
+        layers, the conversion won't happen for these layers. If don't have any `nn.Linear` or `nn.Conv2d`
+        layers in the model, the wrapper will raise an error during conversion.
+
+    Warning:
+        If `repeat_training_inputs==True` and you want to use one of the `torch_uncertainty.routines`
+        for training, be sure to set `format_batch_fn=RepeatTarget(num_repeats=num_estimators)` when
+        initializing the routine.
+
+    Example:
+        >>> model = nn.Sequential(
+        ...     nn.Linear(10, 5),
+        ...     nn.ReLU(),
+        ...     nn.Linear(5, 2)
+        ... )
+        >>> model = BatchEnsemble(model, num_estimators=4, convert_layers=True)
+        >>> model
+        BatchEnsemble(
+          (model): Sequential(
+            (0): BatchLinear(in_features=10, out_features=5, num_estimators=4)
+            (1): ReLU()
+            (2): BatchLinear(in_features=5, out_features=2, num_estimators=4)
+          )
+        )
     """
 
-    def __init__(self, model: nn.Module, num_estimators: int):
+    def __init__(
+        self,
+        model: nn.Module,
+        num_estimators: int,
+        repeat_training_inputs: bool = False,
+        convert_layers: bool = False,
+    ) -> None:
         super().__init__()
         self.model = model
         self.num_estimators = num_estimators
+        self.repeat_training_inputs = repeat_training_inputs
+
+        if convert_layers:
+            self._convert_layers()
+
+        filtered_modules = [
+            module
+            for module in self.model.modules()
+            if isinstance(module, BatchLinear | BatchConv2d)
+        ]
+        _batch_ensemble_checks(filtered_modules, num_estimators)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Repeats the input batch and passes it through the model."""
-        repeat_shape = [self.num_estimators] + [1] * (x.dim() - 1)
-        x = x.repeat(repeat_shape)
+        if not self.training or self.repeat_training_inputs:
+            x = repeat(x, "b ... -> (m b) ...", m=self.num_estimators)
         return self.model(x)
+
+    def _convert_layers(self) -> None:
+        """Converts the model's layers to BatchEnsemble layers."""
+        no_valid_layers = True
+        for name, layer in self.model.named_modules():
+            if isinstance(layer, nn.Linear):
+                setattr(
+                    self.model,
+                    name,
+                    BatchLinear.from_linear(layer, num_estimators=self.num_estimators),
+                )
+                no_valid_layers = False
+            elif isinstance(layer, nn.Conv2d):
+                setattr(
+                    self.model,
+                    name,
+                    BatchConv2d.from_conv2d(layer, num_estimators=self.num_estimators),
+                )
+                no_valid_layers = False
+        if no_valid_layers:
+            raise ValueError(
+                "No valid layers found in the model. "
+                "Please use `nn.Linear` or `nn.Conv2d` layers to apply BatchEnsemble."
+            )
+
+
+def _batch_ensemble_checks(filtered_modules, num_estimators):
+    """Check if the model contains the required number of dropout modules."""
+    if len(filtered_modules) == 0:
+        raise ValueError(
+            "No BatchEnsemble layers found in the model. "
+            "Please use `BatchLinear` or `BatchConv2d` layers in your model "
+            "or set `convert_layers=True` when initializing the wrapper."
+        )
+    if num_estimators <= 0:
+        raise ValueError("`num_estimators` must be greater than 0.")
+
+
+def batch_ensemble(
+    model: nn.Module,
+    num_estimators: int,
+    repeat_training_inputs: bool = False,
+    convert_layers: bool = False,
+) -> BatchEnsemble:
+    """BatchEnsemble wrapper for a model.
+
+    Args:
+        model (nn.Module): model to wrap
+        num_estimators (int): number of ensemble members
+        repeat_training_inputs (bool, optional): whether to repeat the input batch during training.
+            If `True`, the input batch is repeated during both training and evaluation. If `False`,
+            the input batch is repeated only during evaluation. Default is `False`.
+        convert_layers (bool, optional): whether to convert the model's layers to BatchEnsemble layers.
+            If `True`, the wrapper will convert all `nn.Linear` and `nn.Conv2d` layers to their
+            BatchEnsemble counterparts. Default is `False`.
+
+    Returns:
+        BatchEnsemble: BatchEnsemble wrapper for the model
+    """
+    return BatchEnsemble(
+        model=model,
+        num_estimators=num_estimators,
+        repeat_training_inputs=repeat_training_inputs,
+        convert_layers=convert_layers,
+    )

--- a/torch_uncertainty/routines/classification.py
+++ b/torch_uncertainty/routines/classification.py
@@ -123,6 +123,14 @@ class ClassificationRoutine(LightningModule):
         Warning:
             You must define :attr:`optim_recipe` if you do not use the Lightning CLI.
 
+        Warning:
+            When using an ensemble model, you must:
+            1. Set :attr:`is_ensemble` to ``True``.
+            2. Set :attr:`format_batch_fn` to :class:`torch_uncertainty.transforms.RepeatTarget(num_repeats=num_estimators)`.
+            3. Ensure that the model's forward pass outputs a tensor of shape :math:`(M \times B, C)`, where :math:`M` is the number of estimators, :math:`B` is the batch size, :math:`C` is the number of classes.
+
+            For automated batch handling, consider using the available model wrappers in `torch_uncertainty.models.wrappers`.
+
         Note:
             :attr:`optim_recipe` can be anything that can be returned by
             :meth:`LightningModule.configure_optimizers()`. Find more details
@@ -475,7 +483,7 @@ class ClassificationRoutine(LightningModule):
         """
         inputs, targets = batch
         logits = self.forward(inputs, save_feats=self.eval_grouping_loss)
-        logits = rearrange(logits, "(n b) c -> b n c", b=targets.size(0))
+        logits = rearrange(logits, "(m b) c -> b m c", b=targets.size(0))
         probs_per_est = torch.sigmoid(logits) if self.binary_cls else F.softmax(logits, dim=-1)
         probs = probs_per_est.mean(dim=1)
         confs = probs.max(-1)[0]

--- a/torch_uncertainty/transforms/batch.py
+++ b/torch_uncertainty/transforms/batch.py
@@ -1,5 +1,5 @@
 import torch
-from einops import rearrange
+from einops import rearrange, repeat
 from torch import Tensor, nn
 
 
@@ -21,7 +21,7 @@ class RepeatTarget(nn.Module):
 
     def forward(self, batch: tuple[Tensor, Tensor]) -> tuple[Tensor, Tensor]:
         inputs, targets = batch
-        return inputs, targets.repeat(self.num_repeats, *[1] * (targets.ndim - 1))
+        return inputs, repeat(targets, "b ... -> (m b) ...", m=self.num_repeats)
 
 
 class MIMOBatchFormat(nn.Module):
@@ -79,6 +79,6 @@ class MIMOBatchFormat(nn.Module):
             [torch.index_select(targets, dim=0, index=indices) for indices in shuffle_indices],
             dim=0,
         )
-        inputs = rearrange(inputs, "m b c h w -> (m b) c h w", m=self.num_estimators)
+        inputs = rearrange(inputs, "m b ... -> (m b) ...", m=self.num_estimators)
         targets = rearrange(targets, "m b -> (m b)", m=self.num_estimators)
         return inputs, targets


### PR DESCRIPTION
This PR introduces the following improvements and fixes:

- **Bug Fixes:** Address minor issues in some of the existing LeNet configs.
- **BatchEnsemble Wrapper:** Implements a wrapper that replicates the input batch `num_estimator` times, eliminating the need to hardcode this for each model.
- **Documentation Updates:** Enhances the documentation to reflect the usage of batch ensemble layers and the classification routine, aligning with available wrappers and transforms.
- **LeNet BatchEnsemble Implementation:** Adds BatchEnsemble support for LeNet, along with new experiment configurations for both Deep Ensemble and BatchEnsemble models (tested manually).