### PR TITLE
:hammer: Use `kornia`'s motion blur instead of `Wand`'s Gaussian motion blur

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ dependencies = [
 [project.optional-dependencies]
 image = [
     "scikit-image", 
+    "kornia",
     "h5py",
     "opencv-python",
-    "Wand",
 ]
 tabular = ["pandas"]
 dev = [

--- a/tests/transforms/test_corruption.py
+++ b/tests/transforms/test_corruption.py
@@ -88,6 +88,10 @@ class TestCorruptions:
         transform = MotionBlur(0)
         transform(inputs)
 
+        inputs = torch.rand(1, 3, 32, 32)
+        transform = MotionBlur(1)
+        transform(inputs)
+
     def test_zoom_blur(self):
         inputs = torch.rand(3, 32, 32)
         transform = ZoomBlur(1)

--- a/torch_uncertainty/transforms/corruption.py
+++ b/torch_uncertainty/transforms/corruption.py
@@ -225,8 +225,8 @@ class MotionBlur(TUCorruption):
         """Apply a motion blur corruption on the image.
 
         Note:
-            Originally, Hendrycks et al. used gaussian motion blur. To remove the dependency with
-            with wand we changed the transform to a simpler motion blur and kept the values of
+            Originally, Hendrycks et al. used Gaussian motion blur. To remove the dependency with
+            with `Wand` we changed the transform to a simpler motion blur and kept the values of
             sigma as the new half kernel sizes.
         """
         super().__init__(severity)


### PR DESCRIPTION
The replacement is not exact, this means that the MotionBlur and Snow transformation will be more different from Hendryck's than in the previous version. Indeed - unless mistaken - `kornia` doesn't implement Gaussian Motion Blur. However, I've made sure that the results were qualitatively similar.

Closes #138 and finishes #131. 