### PR TITLE
:books: Update Dockerfile documentation

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,71 +1,88 @@
-# :whale: Docker image for contributors
+# 🐋 Docker image for contributors
 
-### Pre-built Docker image
-1. To pull the pre-built image from Docker Hub, simply run:
-    ```bash
-    docker pull docker.io/tonyzamyatin/torch-uncertainty:latest
-    ```
+This Docker image is designed for users and contributors who want to run experiments with `torch-uncertainty` on remote virtual machines with GPU support. It is particularly useful for those who do not have access to a local GPU and need a pre-configured environment for development and experimentation.
 
-    This image includes:
-    - PyTorch with CUDA support
-    - OpenGL (for visualization tasks)
-    - Git, OpenSSH, and all Python dependencies
+---
+## How to Use The Docker Image
+### Step 1: Fork the Repository
 
-    Checkout the [registry on Docker Hub](https://hub.docker.com/repository/docker/tonyzamyatin/torch-uncertainty/general) for all available images.
+Before proceeding, ensure you have forked the `torch-uncertainty` repository to your own GitHub account. You can do this by visiting the [torch-uncertainty GitHub repository](https://github.com/ENSTA-U2IS-AI/torch-uncertainty) and clicking the **Fork** button in the top-right corner.
 
-2. To start a container using this image, set up the necessary environment variables and run:
-    ```bash
-    docker run --rm -it --gpus all -p 8888:8888 -p 22:22 \
-        -e VM_SSH_PUBLIC_KEY="your-public-key" \
-        -e GITHUB_SSH_PRIVATE_KEY="your-github-key" \
-        -e GITHUB_USER="your-github-username" \
-        -e GIT_USER_EMAIL="your-git-email" \
-        -e GIT_USER_NAME="your-git-name" \
-        docker.io/tonyzamyatin/torch-uncertainty
-    ```
+Once forked, clone your forked repository to your local machine:
+```bash
+git clone git@github.com:<your-username>/torch-uncertainty.git
+cd torch-uncertainty
+```
 
-    Optionally, you can also set `-e USER_COMPACT_SHELL_PROMPT="true"`  
-    to make the VM's shell prompts compact and colorized.
+> ### ⚠️ IMPORTANT NOTE: Keep Your Fork Synced
+> 
+> **To ensure that you are working with the latest stable version and bug fixes, you must manually sync your fork with the upstream repository before building the Docker image. Failure to sync your fork may result in outdated dependencies or missing bug fixes in the Docker image.**
 
-    **Note:** Some cloud providers offer templates, in which you can preconfigure  
-    in advance which Docker image to pull and which environment variables to set.  
-    In this case, the provider will pull the image, set all environment variables,  
-    and start the container for you.
+### Step 2: Build the Docker image locally
+Build the modified image locally and push it to a Docker registry:
+```
+docker build -t my-torch-uncertainty-docker:version .
+docker push my-dockerhub-user/my-torch-uncertainty-image:version
+```
+### Step 3: Set environment variables on your VM
+Connect to you VM and set the following environment variables:
+```bash
+export VM_SSH_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)"
+export GITHUB_SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
+export GITHUB_USER="your-github-username"
+export GIT_USER_EMAIL="your-email@example.com"
+export GIT_USER_NAME="Your Name"
+export USE_COMPACT_SHELL_PROMPT=true
+```
 
-3. Once your cloud provider has deployed the VM, it will display the host address and SSH port.  
-    You can connect to the container via SSH using:
-    ```bash
-    ssh -i /path/to/private_key root@<VM_HOST> -p <VM_PORT>
-    ```
+Here is a brief explanation of the environment variables used in the Docker setup:
+- **`VM_SSH_PUBLIC_KEY`**: The public SSH key used to authenticate with the container via SSH.
+- **`GITHUB_SSH_PRIVATE_KEY`**: The private SSH key used to authenticate with GitHub for cloning and pushing repositories.
+- **`GITHUB_USER`**: The GitHub username used to clone the repository during the first-time setup.
+- **`GIT_USER_EMAIL`**: The email address associated with the Git configuration for commits.
+- **`GIT_USER_NAME`**: The name associated with the Git configuration for commits.
+- **`USE_COMPACT_SHELL_PROMPT`** (optional): Enables a compact and colorized shell prompt inside the container if set to `"true"`.
 
-    Replace `<VM_HOST>` and `<VM_PORT>` with the values provided by your cloud provider,  
-    and `/path/to/private_key` with the private key that corresponds to `VM_SSH_PUBLIC_KEY`.
+### Step 4: Run the Docker container
+First, authenticate with your Docker registry if you use a private registry.
+Then run the following command to run the Docker image from your docker registriy
+```bash
+docker run --rm -it --gpus all -p 8888:8888 -p 22:22 \
+    -e VM_SSH_PUBLIC_KEY \
+    -e GITHUB_SSH_PRIVATE_KEY \
+    -e GITHUB_USER \
+    -e GIT_USER_EMAIL \
+    -e GIT_USER_NAME \
+    -e USE_COMPACT_SHELL_PROMPT \
+    docker.io/my-dockerhub-user/my-torch-uncertainty-image:version
+```
 
-4. The container exposes port `8888` in case you want to run Jupyter Notebooks or TensorBoard.
+### Step 5: Connect to your container
+Once the container is up and running, you can connect to it via SSH:  
+```bash
+ssh -i /path/to/private_key root@<VM_HOST> -p <VM_PORT>
+```
+Replace `<VM_HOST>` and `<VM_PORT>` with the host and port of your VM,  
+and `/path/to/private_key` with the private key that corresponds to `VM_SSH_PUBLIC_KEY`.
 
-    **Note:** The `/workspace` directory is mounted from your local machine or cloud storage,  
-    so changes persist across container restarts.  
-    If using a cloud provider, ensure your network volume is correctly attached to avoid losing data.
+The container exposes port `8888` in case you want to run Jupyter Notebooks or TensorBoard.
 
-### Modifying and publishing custom Docker image
+**Note:** The `/workspace` directory is mounted from your local machine or cloud storage,  
+so changes persist across container restarts.  
+If using a cloud provider, ensure your network volume is correctly attached to avoid losing data.
 
-If you want to make changes to the Dockerfile, follow these steps:
-1. Edit the Dockerfile to fit your needs.
+## Remote Development
 
-2. Build the modified image:
-    ```
-    docker build -t my-custom-image .
-    ```
+This Docker setup also allows for remote development on the VM, since GitHub SSH access is set up and the whole repo is cloned to the VM from your GitHub fork.
+For example, you can seamlessly connect your VS Code editor to your remote VM and run experiments, as if on your local machine but with the GPU acceleration of your VM. 
+See [VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) for further details.
 
-3. Push to a Docker registry (if you want to use it on another VM):
-    ```
-    docker tag my-custom-image mydockerhubuser/my-custom-image:tag
-    docker push mydockerhubuser/my-custom-image:tag
-    ```
-    
-4. Pull the custom image onto your VM:
-    ```
-    docker pull mydockerhubuser/my-custom-image
-    ```
-    
-5. Run the container using the same docker run command with the new image name.
+## Streamline setup with your Cloud provider of choice
+
+Many cloud providers offer "templates" where you can specify a Docker image to use as a base. This means you can:
+
+1. Specify the Docker image from your Docker registry as the base image.
+2. Preconfigure the necessary environment variables in the template.
+3. Reuse the template any time you need to spin up a virtual machine for experiments.
+
+The cloud provider will handle setting the environment variables, pulling the Docker image, and spinning up the container for you. This approach simplifies the process and ensures consistency across experiments.


### PR DESCRIPTION
Related to issue #159.

I updated the documentation of the Dockerfile to include a note that GitHub forks need be synced manually if the Dockerfile is used. Otherwise version updates of the `torch-uncertainty` library are not reflected in the Docker container.