### PR TITLE
:construction: Rename model to routine in yaml

### DIFF
--- a/experiments/classification/cifar10/configs/resnet.yaml
+++ b/experiments/classification/cifar10/configs/resnet.yaml
@@ -20,7 +20,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet18/batched.yaml
+++ b/experiments/classification/cifar10/configs/resnet18/batched.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet18/masked.yaml
+++ b/experiments/classification/cifar10/configs/resnet18/masked.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet18/mimo.yaml
+++ b/experiments/classification/cifar10/configs/resnet18/mimo.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet18/packed.yaml
+++ b/experiments/classification/cifar10/configs/resnet18/packed.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet18/standard.yaml
+++ b/experiments/classification/cifar10/configs/resnet18/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet50/batched.yaml
+++ b/experiments/classification/cifar10/configs/resnet50/batched.yaml
@@ -22,7 +22,7 @@ trainer:
       monitor: val/cls/Acc
       patience: 1000
       check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet50/masked.yaml
+++ b/experiments/classification/cifar10/configs/resnet50/masked.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet50/mimo.yaml
+++ b/experiments/classification/cifar10/configs/resnet50/mimo.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet50/packed.yaml
+++ b/experiments/classification/cifar10/configs/resnet50/packed.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/resnet50/standard.yaml
+++ b/experiments/classification/cifar10/configs/resnet50/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10.yaml
@@ -21,7 +21,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10/batched.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10/batched.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10/masked.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10/masked.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10/mimo.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10/mimo.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10/packed.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10/packed.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar10/configs/wideresnet28x10/standard.yaml
+++ b/experiments/classification/cifar10/configs/wideresnet28x10/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet.yaml
+++ b/experiments/classification/cifar100/configs/resnet.yaml
@@ -20,7 +20,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 10
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet18/batched.yaml
+++ b/experiments/classification/cifar100/configs/resnet18/batched.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet18/masked.yaml
+++ b/experiments/classification/cifar100/configs/resnet18/masked.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet18/mimo.yaml
+++ b/experiments/classification/cifar100/configs/resnet18/mimo.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet18/packed.yaml
+++ b/experiments/classification/cifar100/configs/resnet18/packed.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet18/standard.yaml
+++ b/experiments/classification/cifar100/configs/resnet18/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet50/batched.yaml
+++ b/experiments/classification/cifar100/configs/resnet50/batched.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet50/masked.yaml
+++ b/experiments/classification/cifar100/configs/resnet50/masked.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet50/mimo.yaml
+++ b/experiments/classification/cifar100/configs/resnet50/mimo.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet50/packed.yaml
+++ b/experiments/classification/cifar100/configs/resnet50/packed.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/resnet50/standard.yaml
+++ b/experiments/classification/cifar100/configs/resnet50/standard.yaml
@@ -22,7 +22,7 @@ trainer:
       monitor: val/cls/Acc
       patience: 1000
       check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/cifar100/configs/wideresnet28x10/standard.yaml
+++ b/experiments/classification/cifar100/configs/wideresnet28x10/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/mnist/configs/lenet/batch_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet/batch_ensemble.yaml
@@ -23,7 +23,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   # ClassificationRoutine
   model:
     # BatchEnsemble

--- a/experiments/classification/mnist/configs/lenet/bayesian.yaml
+++ b/experiments/classification/mnist/configs/lenet/bayesian.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_lenet
     init_args:

--- a/experiments/classification/mnist/configs/lenet/checkpoint_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet/checkpoint_ensemble.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.CheckpointCollector
     init_args:

--- a/experiments/classification/mnist/configs/lenet/checkpoint_ensemble_cycle.yaml
+++ b/experiments/classification/mnist/configs/lenet/checkpoint_ensemble_cycle.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.CheckpointCollector
     init_args:

--- a/experiments/classification/mnist/configs/lenet/conformal.yaml
+++ b/experiments/classification/mnist/configs/lenet/conformal.yaml
@@ -28,7 +28,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.lenet
     init_args:

--- a/experiments/classification/mnist/configs/lenet/deep_ensemble.yaml
+++ b/experiments/classification/mnist/configs/lenet/deep_ensemble.yaml
@@ -23,7 +23,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   # ClassificationRoutine
   model:
     # DeepEnsemble

--- a/experiments/classification/mnist/configs/lenet/ema.yaml
+++ b/experiments/classification/mnist/configs/lenet/ema.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.EMA
     init_args:

--- a/experiments/classification/mnist/configs/lenet/sghmc.yaml
+++ b/experiments/classification/mnist/configs/lenet/sghmc.yaml
@@ -23,7 +23,7 @@ trainer:
         patience: 1000
         check_finite: true
   gradient_clip_val: 5
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.CheckpointCollector
     init_args:

--- a/experiments/classification/mnist/configs/lenet/sgld.yaml
+++ b/experiments/classification/mnist/configs/lenet/sgld.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.CheckpointCollector
     init_args:

--- a/experiments/classification/mnist/configs/lenet/standard.yaml
+++ b/experiments/classification/mnist/configs/lenet/standard.yaml
@@ -28,7 +28,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.lenet
     init_args:

--- a/experiments/classification/mnist/configs/lenet/swa.yaml
+++ b/experiments/classification/mnist/configs/lenet/swa.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.SWA
     init_args:

--- a/experiments/classification/mnist/configs/lenet/swag.yaml
+++ b/experiments/classification/mnist/configs/lenet/swag.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.SWAG
     init_args:

--- a/experiments/classification/mnist/configs/lenet/tta_zero.yaml
+++ b/experiments/classification/mnist/configs/lenet/tta_zero.yaml
@@ -26,7 +26,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.wrappers.Zero
     init_args:

--- a/experiments/classification/tiny-imagenet/configs/resnet18/standard.yaml
+++ b/experiments/classification/tiny-imagenet/configs/resnet18/standard.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/cls/Acc
         patience: 1000
         check_finite: true
-model:
+routine:
   num_classes: 100
   in_channels: 3
   loss: CrossEntropyLoss

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/adiac/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/adiac/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/beef/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/beef/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketx/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketx/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/crickety/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/crickety/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/cricketz/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/cricketz/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/inline-skate/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/inline-skate/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/lightning7/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/lightning7/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/mallat/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/mallat/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/batch_ensemble.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.batched_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/bayesian.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.bayesian_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/deep_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/mc_dropout.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/mimo.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.mimo_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/packed_ensembles.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.packed_inception_time
     init_args:

--- a/experiments/classification/ucr-uea/configs/two-patterns/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/two-patterns/inception-time/standard.yaml
@@ -13,7 +13,7 @@ trainer:
       default_hp_metric: false
   callbacks:
     - class_path: torch_uncertainty.callbacks.TUClsCheckpoint
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.classification.inception_time
     init_args:

--- a/experiments/depth/kitti/configs/bts.yaml
+++ b/experiments/depth/kitti/configs/bts.yaml
@@ -21,7 +21,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   loss:
     class_path: torch_uncertainty.metrics.SILog
     init_args:

--- a/experiments/depth/nyu/configs/bts.yaml
+++ b/experiments/depth/nyu/configs/bts.yaml
@@ -21,7 +21,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   loss:
     class_path: torch_uncertainty.metrics.SILog
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/batch_ensemble.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/batch_ensemble.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.batched_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/bayesian.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/bayesian.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.bayesian_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/cauchy.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/cauchy.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/deep_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/deep_ensembles.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/masksemble.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/masksemble.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.masked_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/mc_dropout.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/mc_dropout.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/mimo.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/mimo.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mimo_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/packed_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/packed_ensembles.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.packed_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/student.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/student.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/batch_ensemble.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/batch_ensemble.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.batched_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/bayesian.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/bayesian.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.bayesian_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/cauchy.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/cauchy.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/deep_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/deep_ensembles.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/laplace.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/mc_dropout.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/mc_dropout.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/mimo.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/mimo.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mimo_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/normal.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/packed_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/packed_ensembles.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.packed_mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/concrete/mlp/student.yaml
+++ b/experiments/regression/uci_datasets/configs/concrete/mlp/student.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mlp.mlp
     init_args:

--- a/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/energy-efficiency/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/kin8nm/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/kin8nm/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/kin8nm/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/kin8nm/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/kin8nm/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/kin8nm/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 8
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 16
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 16
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/naval-propulsion-plant/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 16
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/power-plant/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/power-plant/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 4
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/power-plant/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/power-plant/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 4
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/power-plant/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/power-plant/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 4
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/protein/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/protein/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 9
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/protein/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/protein/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 9
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/protein/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/protein/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 9
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 11
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 11
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/wine-quality-red/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 11
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/yacht/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/yacht/mlp/laplace.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 6
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/yacht/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/yacht/mlp/normal.yaml
@@ -24,7 +24,7 @@ trainer:
         monitor: val/reg/NLL
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 6
   hidden_dims:

--- a/experiments/regression/uci_datasets/configs/yacht/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/yacht/mlp/point_wise.yaml
@@ -22,7 +22,7 @@ trainer:
         monitor: val/reg/MSE
         patience: 1000
         check_finite: true
-model:
+routine:
   output_dim: 1
   in_features: 6
   hidden_dims:

--- a/experiments/segmentation/camvid/configs/deeplab.yaml
+++ b/experiments/segmentation/camvid/configs/deeplab.yaml
@@ -17,7 +17,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   num_classes: 11
   loss: CrossEntropyLoss
   version: std

--- a/experiments/segmentation/camvid/configs/segformer.yaml
+++ b/experiments/segmentation/camvid/configs/segformer.yaml
@@ -15,7 +15,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   num_classes: 11
   loss: CrossEntropyLoss
   version: std

--- a/experiments/segmentation/cityscapes/configs/deeplab.yaml
+++ b/experiments/segmentation/cityscapes/configs/deeplab.yaml
@@ -17,7 +17,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   num_classes: 19
   loss: CrossEntropyLoss
   version: std

--- a/experiments/segmentation/cityscapes/configs/segformer.yaml
+++ b/experiments/segmentation/cityscapes/configs/segformer.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   num_classes: 19
   loss: CrossEntropyLoss
   version: std

--- a/experiments/segmentation/muad/configs/muad/deeplab/deeplabv3+.yaml
+++ b/experiments/segmentation/muad/configs/muad/deeplab/deeplabv3+.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.deep_lab_v3_resnet
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/batch_ensemble.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/batch_ensemble.yaml
@@ -17,7 +17,7 @@ trainer:
   - class_path: lightning.pytorch.callbacks.LearningRateMonitor
     init_args:
       logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.batched_unet
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/deep_ensembles.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/deep_ensembles.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.deep_ensembles
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/masksemble.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/masksemble.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.masked_unet
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/mc_dropout.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/mc_dropout.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/mimo.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/mimo.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.mimo_unet
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/packed.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/packed.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.packed_unet
     init_args:

--- a/experiments/segmentation/muad/configs/muad/unet/standard.yaml
+++ b/experiments/segmentation/muad/configs/muad/unet/standard.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.unet
     init_args:

--- a/experiments/segmentation/muad/configs/muad_small/unet/mc_dropout.yaml
+++ b/experiments/segmentation/muad/configs/muad_small/unet/mc_dropout.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.mc_dropout
     init_args:

--- a/experiments/segmentation/muad/configs/muad_small/unet/standard.yaml
+++ b/experiments/segmentation/muad/configs/muad_small/unet/standard.yaml
@@ -16,7 +16,7 @@ trainer:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
         logging_interval: step
-model:
+routine:
   model:
     class_path: torch_uncertainty.models.segmentation.small_unet
     init_args:

--- a/experiments/segmentation/muad/configs/segformer.yaml
+++ b/experiments/segmentation/muad/configs/segformer.yaml
@@ -5,7 +5,7 @@ trainer:
   accelerator: gpu
   devices: 1
   max_steps: 160000
-model:
+routine:
   num_classes: 19
   loss: CrossEntropyLoss
   version: std


### PR DESCRIPTION
This solution works, but is surely brittle, and we should probably pin the minor version of lightning.