### PR TITLE
📚 Remove MCDropout class from docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -221,7 +221,6 @@ Classes
     BatchEnsemble
     CheckpointCollector
     EMA
-    MCDropout
     StochasticModel
     SWA
     SWAG


### PR DESCRIPTION
MCDropout class has been made private, and removed from [torch_uncertainty/models/\_\_init\_\_.py](https://github.com/ENSTA-U2IS-AI/torch-uncertainty/blob/e9f63301d94a986d0e7c252ba9517fb8355f0d68/torch_uncertainty/models/__init__.py)
Therefore, it is not available in the Classes list any more, which results in a warning during documentation generation:

> WARNING: [autosummary] failed to import torch_uncertainty.models.MCDropout