### PR TITLE
📚 Fix cropped plot axis text (#55)

### DIFF
--- a/auto_tutorial_source/Bayesian_Methods/tutorial_bayesian.py
+++ b/auto_tutorial_source/Bayesian_Methods/tutorial_bayesian.py
@@ -16,8 +16,7 @@ seen as Dirac distributions on the weights).
 For more information on Bayesian Neural Networks, we refer to the following resources:
 
 - Weight Uncertainty in Neural Networks `ICML2015 <https://arxiv.org/pdf/1505.05424.pdf>`_
-- Hands-on Bayesian Neural Networks - a Tutorial for Deep Learning Users `IEEE Computational Intelligence Magazine
-    <https://arxiv.org/pdf/2007.06823.pdf>`_
+- Hands-on Bayesian Neural Networks - a Tutorial for Deep Learning Users `IEEE Computational Intelligence Magazine <https://arxiv.org/pdf/2007.06823.pdf>`_
 
 Training a Bayesian LeNet using TorchUncertainty models and Lightning
 ---------------------------------------------------------------------

--- a/auto_tutorial_source/Post_Hoc_Methods/tutorial_scaler.py
+++ b/auto_tutorial_source/Post_Hoc_Methods/tutorial_scaler.py
@@ -101,6 +101,7 @@ print(f"ECE before scaling - {ece.compute():.3%}.")
 # We also compute and plot the top-label calibration figure. We see that the
 # model is not well calibrated.
 fig, ax = ece.plot()
+fig.tight_layout()
 fig.show()
 
 # %%
@@ -143,6 +144,7 @@ print(
 # that the model is now better calibrated. If the temperature is greater than 1,
 # the final model is less confident than before.
 fig, ax = ece.plot()
+fig.tight_layout()
 fig.show()
 
 # %%


### PR DESCRIPTION
If my understanding of issue #55 is correct, it is related to the plot axis text being cropped in the official docs. The only instance where I noticed this problem is in tutorial_scaler.html . Adding **fig.tight_layout()** ensures that the plot elements fit neatly within the available space, preventing any cropping.

Before:
<img width="1136" height="399" alt="image" src="https://github.com/user-attachments/assets/e8199c46-249c-474e-a1c6-7a571d3b21d7" />
After:
<img width="1143" height="434" alt="image" src="https://github.com/user-attachments/assets/5cdfce85-eb4b-4fba-8a2f-a8a195639468" />

Additionally, fixed a broken link.