### PR TITLE
:bug:  Fix test workflow passing while it should fail

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,34 +38,72 @@ jobs:
         id: changed-files-specific
         uses: tj-actions/changed-files@v47
         with:
+          since_last_remote_commit: 'true'
           files: |
             auto_tutorials_source/**
             data/**
             experiments/**
             docs/**
-            *.md
-            *.yaml
-            *.yml
+            **.md
+            **.yaml
+            **.yml
             LICENSE
             .gitignore
+      
+      - name: Check previous commit workflow result
+        id: prev
+        run: |
+          result=$(gh api \
+            repos/${{ github.repository }}/commits/${{ github.event.before }}/check-runs \
+            --jq '.check_runs[] | select(.name | test("^build")) | .conclusion' \
+            | head -n1)
+
+          echo "result=$result" >> $GITHUB_OUTPUT
+          echo "result=$result"
+          echo "only_changed=${{ steps.changed-files-specific.outputs.only_changed }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+
+      - name: Fail if previous tests failed and nothing important changed
+        if: |
+          github.event.before != '' &&
+          steps.prev.outputs.result == 'failure' &&
+          steps.changed-files-specific.outputs.only_changed == 'true' &&
+          github.event_name != 'workflow_dispatch'
+          
+        run: |
+          echo "Previous tests failed and no important files changed."
+          exit 1
+
+      - name: Decide test mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "mode=full" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.changed-files-specific.outputs.only_changed }}" != "true" ]]; then
+            echo "mode=full" >> $GITHUB_OUTPUT
+          else
+            echo "mode=minimal" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install the project
-        if: steps.changed-files-specific.outputs.only_changed != 'true'
+        if: steps.mode.outputs.mode == 'full'
         run: uv sync --locked --dev --extra cpu
 
       - name: Check that torch-uncertainty can be imported
-        if: steps.changed-files-specific.outputs.only_changed != 'true'
+        if: steps.mode.outputs.mode == 'full'
         run: |
           uv run python -c "import torch_uncertainty; from torch_uncertainty.datamodules import MNISTDataModule"
 
       - name: Check style & format
-        if: steps.changed-files-specific.outputs.only_changed != 'true'
+        if: steps.mode.outputs.mode == 'full'
         run: |
           uv run ruff check src/torch_uncertainty --no-fix --statistics
           uv run ruff format src/torch_uncertainty --check
 
       - name: Test with pytest and compute coverage
-        if: steps.changed-files-specific.outputs.only_changed != 'true'
+        if: steps.mode.outputs.mode == 'full'
         run: |
           uv run --frozen pytest tests --cov --cov-report xml --cov-report term --durations 10 --junitxml=junit.xml
 
@@ -75,7 +113,7 @@ jobs:
           echo "PYTHON_VERSION=$(uv run python -c "import platform; print(platform.python_version())")" >> $GITHUB_ENV
 
       - name: Upload coverage to Codecov
-        if: steps.changed-files-specific.outputs.only_changed != 'true' && (github.event_name != 'pull_request' || github.base_ref == 'dev')
+        if: steps.mode.outputs.mode == 'full' && (github.event_name != 'pull_request' || github.base_ref == 'dev')
         uses: codecov/codecov-action@v4
         continue-on-error: true
         with:
@@ -86,7 +124,7 @@ jobs:
           env_vars: PYTHON_VERSION
 
       - name: Upload test results to Codecov
-        if: steps.changed-files-specific.outputs.only_changed != 'true' && (github.event_name != 'pull_request' || github.base_ref == 'dev')
+        if: steps.mode.outputs.mode == 'full' && (github.event_name != 'pull_request' || github.base_ref == 'dev')
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:
@@ -96,6 +134,6 @@ jobs:
           report_type: test_results
 
       - name: Test sphinx build without tutorials
-        if: steps.changed-files-specific.outputs.only_changed != 'true'
+        if: steps.mode.outputs.mode == 'full'
         run: |
           cd docs && make clean && make html-noplot


### PR DESCRIPTION
This PR solves that: if the previous test fails and the next commit adds code that does not alter the library's behavior, the last test would be considered passed. We could therefore push failing code to main.

Fixes #249.