### PR TITLE
:art:(docstrings): clean type hints and fix some typos

### DIFF
--- a/auto_tutorial_source/Segmentation/tutorial_muad_deep_en.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_deep_en.py
@@ -157,14 +157,12 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         https://arxiv.org/abs/1606.02147
 
     Args:
-        dataloader (``data.Dataloader``): A data loader to iterate over the
-            dataset.
-        num_classes (``int``): The number of classes.
-        c (``int``): An additional hyper-parameter which restricts
-            the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``): A list of indexes to ignore
+        dataloader: A data loader to iterate over the dataset.
+        num_classes: The number of classes.
+        c: An additional hyper-parameter which restricts
+            the interval of values for the weights. Defaults to `1.02`.
+        ignore_indexes: A list of indexes to ignore
             when computing the weights. Default to `None`.
-
     """
     class_count = 0
     total = 0

--- a/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
@@ -149,14 +149,12 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         https://arxiv.org/abs/1606.02147
 
     Args:
-        dataloader (``data.Dataloader``): A data loader to iterate over the
-            dataset.
-        num_classes (``int``): The number of classes.
-        c (``int``): An additional hyper-parameter which restricts
-            the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``): A list of indexes to ignore
-            when computing the weights. Default to `None`.
-
+        dataloader (``data.Dataloader``): A data loader to iterate over the dataset.
+        num_classes: The number of classes.
+        c: An additional hyper-parameter which restricts
+            the interval of values for the weights. Defaults to `1.02`.
+        ignore_indexes: A list of indexes to ignore
+            when computing the weights. Defaults to `None`.
     """
     class_count = 0
     total = 0

--- a/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
@@ -149,7 +149,7 @@ def enet_weighting(dataloader, num_classes, c=1.02):
         https://arxiv.org/abs/1606.02147
 
     Args:
-        dataloader (``data.Dataloader``): A data loader to iterate over the dataset.
+        dataloader: A data loader to iterate over the dataset.
         num_classes: The number of classes.
         c: An additional hyper-parameter which restricts
             the interval of values for the weights. Defaults to `1.02`.

--- a/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
@@ -135,7 +135,7 @@ model = packed_small_unet(
 # %%
 # 4. Compute class weights to mitigate class inbalance
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-def enet_weighing(dataloader, num_classes, c=1.02):
+def enet_weighting(dataloader, num_classes, c=1.02):
     """Computes class weights as described in the ENet paper.
 
         w_class = 1 / (ln(c + p_class)),

--- a/auto_tutorial_source/Segmentation/tutorial_muad_seg.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_seg.py
@@ -150,13 +150,12 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         https://arxiv.org/abs/1606.02147
 
     Args:
-        dataloader (``data.Dataloader``): A data loader to iterate over the
-            dataset.
-        num_classes (``int``): The number of classes.
-        c (``int``): An additional hyper-parameter which restricts
-            the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``): A list of indexes to ignore
-            when computing the weights. Default to `None`.
+        dataloader: A data loader to iterate over the dataset.
+        num_classes: The number of classes.
+        c: An additional hyper-parameter which restricts
+            the interval of values for the weights. Defaults to `1.02`.
+        ignore_indexes: A list of indexes to ignore
+            when computing the weights. Defaults to `None`.
 
     """
     class_count = 0

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,10 +10,10 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@uv run $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@uv run --no-sync $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 html-noplot:
-	@uv run $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@uv run --no-sync $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx_codeautolink",
     "sphinx_gallery.gen_gallery",
     # "sphinx_gallery.load_style",
+    "sphinx_autodoc_typehints",
     "sphinx_design",
 ]
 mathjax3_config = {
@@ -84,8 +85,11 @@ sphinx_gallery_conf = {
 autoclass_content = "init"
 
 autosummary_generate = True
+napoleon_google_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_use_param = True
 napoleon_use_ivar = True
-
+napoleon_use_rtype = True
 
 # Disable docstring inheritance
 autodoc_inherit_docstrings = False

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -48,7 +48,7 @@ and its parameters.
       eval_grouping_loss: bool = False,
       ood_criterion: TUOODCriterion | str = "msp",
       log_plots: bool = False,
-      save_in_csv: bool = False,
+      save_to_csv: bool = False,
     ) -> None:
       ...
 

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/batch_ensemble.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/batch_ensemble.yaml
@@ -24,7 +24,7 @@ routine:
   is_ensemble: true
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/bayesian.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/bayesian.yaml
@@ -23,7 +23,7 @@ routine:
   is_ensemble: true
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
 data:
   dataset_name: OliveOil
   batch_size: 16

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/deep_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/deep_ensembles.yaml
@@ -27,7 +27,7 @@ routine:
   num_classes: 3
   loss: CrossEntropyLoss
   is_ensemble: true
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mc_dropout.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mc_dropout.yaml
@@ -29,7 +29,7 @@ routine:
   is_ensemble: true
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
 data:
   dataset_name: OliveOil
   batch_size: 16

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mimo.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/mimo.yaml
@@ -23,7 +23,7 @@ routine:
   is_ensemble: true
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.MIMOBatchFormat
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/packed_ensembles.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/packed_ensembles.yaml
@@ -24,7 +24,7 @@ routine:
   is_ensemble: true
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/classification/ucr-uea/configs/olive-oil/inception-time/standard.yaml
+++ b/experiments/classification/ucr-uea/configs/olive-oil/inception-time/standard.yaml
@@ -21,7 +21,7 @@ routine:
       num_classes: 3
   num_classes: 3
   loss: CrossEntropyLoss
-  save_in_csv: true
+  save_to_csv: true
 data:
   dataset_name: OliveOil
   batch_size: 16

--- a/experiments/regression/uci_datasets/configs/boston/mlp/batch_ensemble.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/batch_ensemble.yaml
@@ -37,7 +37,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/bayesian.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/bayesian.yaml
@@ -43,7 +43,7 @@ routine:
       num_samples: 3
       dist_family: normal
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/cauchy.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/cauchy.yaml
@@ -37,7 +37,7 @@ routine:
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: cauchy
   dist_estimate: mode
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/deep_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/deep_ensembles.yaml
@@ -42,7 +42,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/laplace.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/laplace.yaml
@@ -36,7 +36,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: laplace
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/masksemble.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/masksemble.yaml
@@ -38,7 +38,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/mc_dropout.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/mc_dropout.yaml
@@ -44,7 +44,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/mimo.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/mimo.yaml
@@ -37,7 +37,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.MIMOBatchFormat
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/normal.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/normal.yaml
@@ -36,7 +36,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/packed_ensembles.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/packed_ensembles.yaml
@@ -38,7 +38,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: normal
-  save_in_csv: true
+  save_to_csv: true
   format_batch_fn:
     class_path: torch_uncertainty.transforms.RepeatTarget
     init_args:

--- a/experiments/regression/uci_datasets/configs/boston/mlp/point_wise.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/point_wise.yaml
@@ -32,7 +32,7 @@ routine:
         - 50
   output_dim: 1
   loss: MSELoss
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/experiments/regression/uci_datasets/configs/boston/mlp/student.yaml
+++ b/experiments/regression/uci_datasets/configs/boston/mlp/student.yaml
@@ -36,7 +36,7 @@ routine:
   output_dim: 1
   loss: torch_uncertainty.losses.DistributionNLLLoss
   dist_family: student
-  save_in_csv: true
+  save_to_csv: true
 data:
   root: ./data
   batch_size: 128

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
   "sphinx-design",
   "sphinx-codeautolink",
   "sphinx_design",
+  "sphinx_autodoc_typehints",
   "sphinxcontrib-sass",
 ]
 

--- a/src/torch_uncertainty/callbacks/checkpoint.py
+++ b/src/torch_uncertainty/callbacks/checkpoint.py
@@ -58,7 +58,11 @@ class _TUCheckpoint(Checkpoint):
 
     @property
     def best_model_path(self) -> str:
-        """Return the path to the best model checkpoint based on the primary metric."""
+        """Return the path to the best model checkpoint based on the primary metric.
+
+        Raises:
+            NotImplementedError: Implementations must provide the best model path.
+        """
         raise NotImplementedError
 
 
@@ -68,10 +72,10 @@ class TUClsCheckpoint(_TUCheckpoint):
         Expected Calibration Error, Brier-Score and Negative Log-Likelihood.
 
         Args:
-            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
+            save_last: When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
-                manner. Default to ``False``.
+                manner. Defaults to ``False``.
         """
         super().__init__()
         self.callbacks = {
@@ -107,10 +111,10 @@ class TUSegCheckpoint(_TUCheckpoint):
         over Union, Expected Calibration Error, Brier-Score and Negative Log-Likelihood.
 
         Args:
-            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
+            save_last: When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
-                manner. Default to ``False``.
+                manner. Defaults to ``False``.
         """
         super().__init__()
         self.callbacks = {
@@ -154,12 +158,12 @@ class TURegCheckpoint(_TUCheckpoint):
         Error, and eventually the Negative Log-Likelihood and Quantile Calibration Error.
 
         Args:
-            probabilistic (bool): If ``True``, also tracks the Negative Log-Likelihood and
-                the Quantile Calibration Error. Default to ``False``.
-            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
+            probabilistic: If ``True``, also tracks the Negative Log-Likelihood and
+                the Quantile Calibration Error. Defaults to ``False``.
+            save_last: When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
-                manner. Default to ``False``.
+                manner. Defaults to ``False``.
         """
         super().__init__()
         self.callbacks = {

--- a/src/torch_uncertainty/callbacks/compound_checkpoint.py
+++ b/src/torch_uncertainty/callbacks/compound_checkpoint.py
@@ -27,29 +27,28 @@ class CompoundCheckpoint(ModelCheckpoint):
         r"""Save the checkpoints maximizing or minimizing a given linear form on the metric values.
 
         Args:
-            compound_metric_dict (dict): A dictionary mapping metric names (key) to their
+            compound_metric_dict: A dictionary mapping metric names (key) to their
                 corresponding factors (value) in the linear form:
 
                 .. math:: \sum_{i} \text{metric}_i \times \text{value}_i
 
-            dirpath (str | Path | None): The directory to save the checkpoints in.
-                Defaults to ``None``.
-            verbose (bool): Whether to print verbose output. Defaults to False.
-            save_last (bool | Literal["link"]): Whether to save the last checkpoint.
+            dirpath: The directory to save the checkpoints in. Defaults to ``None``.
+            verbose: Whether to print verbose output. Defaults to ``False``.
+            save_last: Whether to save the last checkpoint.
                 Defaults to ``False``.
-            save_top_k (int): The number of best checkpoints to save. Defaults to ``1``.
-            save_weights_only (bool): Whether to save only the weights. Defaults to
+            save_top_k: The number of best checkpoints to save. Defaults to ``1``.
+            save_weights_only: Whether to save only the weights. Defaults to
                 ``False``.
-            mode (str): The mode to optimize the compound metric. Defaults to ``"min"``.
-            every_n_train_steps (int | None): The number of training steps to wait
+            mode: The mode to optimize the compound metric. Defaults to ``"min"``.
+            every_n_train_steps: The number of training steps to wait
                 between saving checkpoints. Defaults to ``None``.
-            train_time_interval (timedelta | None): The time interval to wait between
+            train_time_interval: The time interval to wait between
                 saving checkpoints. Defaults to ``None``.
-            every_n_epochs (int | None): The number of epochs to wait between saving
+            every_n_epochs: The number of epochs to wait between saving
                 checkpoints. Defaults to ``None``.
-            save_on_train_epoch_end (bool | None): Whether to save the checkpoint at the
+            save_on_train_epoch_end: Whether to save the checkpoint at the
                 end of each training epoch. Defaults to ``None``.
-            enable_version_counter (bool): Whether to enable the version counter for the
+            enable_version_counter: Whether to enable the version counter for the
                 saved checkpoints. Defaults to ``True``.
         """
         self.compound_metric_dict = compound_metric_dict

--- a/src/torch_uncertainty/datamodules/abstract.py
+++ b/src/torch_uncertainty/datamodules/abstract.py
@@ -50,17 +50,17 @@ class TUDataModule(LightningDataModule, ABC):
         logic. It also provide the basic argparse arguments for the datamodules.
 
         Args:
-            root (str): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
-                and test). Set to batch_size if None.
-            val_split (float | None): Share of samples to use for validation.
-            num_workers (int): Number of workers to use for data loading.
-            pin_memory (bool): Whether to pin memory.
-            persistent_workers (bool): Whether to use persistent workers.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            postprocess_set (str): Which split to use as post-processing set to fit the
-                post-processing method. Defaults to ``val``.
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val and test).
+                Set to batch_size if ``None``.
+            val_split: Share of samples to use for validation.
+            num_workers: Number of workers to use for data loading.
+            pin_memory: Whether to pin memory.
+            persistent_workers: Whether to use persistent workers.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            postprocess_set: Which split to use as post-processing set to fit the
+                post-processing method. Defaults to ``"val"``.
 
         Warning:
             Please ensure that the :attr:`batch_size` is a multiple of :attr:`num_tta`.
@@ -90,7 +90,7 @@ class TUDataModule(LightningDataModule, ABC):
 
     @abstractmethod
     def setup(self, stage: str | None = None) -> None:
-        pass
+        """Prepare the datasets for the requested stage."""
 
     def get_train_set(self) -> Dataset:
         """Get the training set."""
@@ -157,10 +157,9 @@ class TUDataModule(LightningDataModule, ABC):
         """Create a dataloader for a given dataset.
 
         Args:
-            dataset (Dataset): Dataset to create a dataloader for.
-            training (bool): Whether it is a training or evaluation dataloader.
-            shuffle (bool): Whether to shuffle the dataset. Defaults
-                to False.
+            dataset: Dataset to create a dataloader for.
+            training: Whether it is a training or evaluation dataloader.
+            shuffle: Whether to shuffle the dataset. Defaults to ``False``.
 
         Return:
             DataLoader: Dataloader for the given dataset.
@@ -179,9 +178,11 @@ class TUDataModule(LightningDataModule, ABC):
     # It is generally "Dataset.samples" or "Dataset.data"
     # They are used for constructing cross validation splits
     def _get_train_data(self) -> ArrayLike:
+        """Return the training inputs used to build cross-validation splits."""
         raise NotImplementedError
 
     def _get_train_targets(self) -> ArrayLike:
+        """Return the training targets used to build cross-validation splits."""
         raise NotImplementedError
 
     def make_cross_val_splits(self, n_splits: int = 10, train_over: int = 4) -> list:

--- a/src/torch_uncertainty/datamodules/classification/cifar10.py
+++ b/src/torch_uncertainty/datamodules/classification/cifar10.py
@@ -54,37 +54,36 @@ class CIFAR10DataModule(TUDataModule):
         """DataModule for CIFAR10.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to batch_size if ``None``. Defaults to ``None``.
-            eval_ood (bool): Whether to evaluate on out-of-distribution data. Defaults to ``False``.
-            eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
-            val_split (float): Share of samples to use for validation. Defaults
+            eval_ood: Whether to evaluate on out-of-distribution data. Defaults to ``False``.
+            eval_shift: Whether to evaluate on shifted data. Defaults to ``False``.
+            val_split: Share of samples to use for validation. Defaults
                 to ``0.0``.
-            postprocess_set (str): The post-hoc calibration dataset to
+            postprocess_set: The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
-            num_workers (int): Number of workers to use for data loading. Defaults
-                to ``1``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
-                to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            num_workers: Number of workers to use for data loading. Defaults to ``1``.
+            train_transform: Custom training transform. Defaults to ``None``. If not provided,
+                a default transform is used.
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            cutout (int): Size of cutout to apply to images. Defaults to ``None``.
+            cutout: Size of cutout to apply to images. Defaults to ``None``.
                 Only used if ``train_transform`` is not provided.
-            randaugment (bool): Whether to apply RandAugment. Defaults to
+            randaugment: Whether to apply RandAugment. Defaults to
                 ``False``. Only used if ``train_transform`` is not provided.
-            auto_augment (str): Which auto-augment to apply. Defaults to ``None``.
+            auto_augment: Which auto-augment to apply. Defaults to ``None``.
                 Only used if ``train_transform`` is not provided.
-            test_alt (str): Which test set to use. Defaults to ``None``.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            shift_severity (int): Severity of corruption to apply for
+            test_alt: Which test set to use. Defaults to ``None``.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            shift_severity: Severity of corruption to apply for
                 CIFAR10-C. Defaults to ``1``.
-            num_dataloaders (int): Number of dataloaders to use. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            num_dataloaders: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/cifar100.py
+++ b/src/torch_uncertainty/datamodules/classification/cifar100.py
@@ -53,33 +53,33 @@ class CIFAR100DataModule(TUDataModule):
         """DataModule for CIFAR100.
 
         Args:
-            root (str): Root directory of the datasets.
-            eval_ood (bool): Whether to evaluate out-of-distribution performance.
-            eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            eval_ood: Whether to evaluate out-of-distribution performance.
+            eval_shift: Whether to evaluate on shifted data. Defaults to ``False``.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to batch_size if ``None``. Defaults to ``None``.
-            val_split (float): Share of samples to use for validation. Defaults
+            val_split: Share of samples to use for validation. Defaults
                 to ``0.0``.
-            postprocess_set (str): The post-hoc calibration dataset to
+            postprocess_set: The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``. Only used if train_transform is not provided.
-            cutout (int): Size of cutout to apply to images. Defaults to ``None``.
+            cutout: Size of cutout to apply to images. Defaults to ``None``.
                 Only used if train_transform is not provided.
-            randaugment (bool): Whether to apply RandAugment. Defaults to
+            randaugment: Whether to apply RandAugment. Defaults to
                 ``False``. Only used if train_transform is not provided.
-            auto_augment (str): Which auto-augment to apply. Defaults to ``None``.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            shift_severity (int): Severity of corruption to apply to CIFAR100-C. Defaults to ``1``.
-            num_dataloaders (int): Number of dataloaders to use. Defaults to ``1``.
-            num_workers (int): Number of workers to use for data loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            auto_augment: Which auto-augment to apply. Defaults to ``None``.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            shift_severity: Severity of corruption to apply to CIFAR100-C. Defaults to ``1``.
+            num_dataloaders: Number of dataloaders to use. Defaults to ``1``.
+            num_workers: Number of workers to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/imagenet.py
+++ b/src/torch_uncertainty/datamodules/classification/imagenet.py
@@ -74,40 +74,40 @@ class ImageNetDataModule(TUDataModule):
         ImageNet-0, SVHN or DTD as Out-of-distribution dataset and ImageNet-C as shifted dataset.
 
         Args:
-            root (str): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to batch_size if ``None``. Defaults to ``None``.
-            eval_ood (bool): Whether to evaluate out-of-distribution performance. Defaults to ``False``.
-            eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            shift_severity (int): Severity of the shift. Defaults to ``1``.
+            eval_ood: Whether to evaluate out-of-distribution performance. Defaults to ``False``.
+            eval_shift: Whether to evaluate on shifted data. Defaults to ``False``.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            shift_severity: Severity of the shift. Defaults to ``1``.
             val_split (float or Path): Share of samples to use for validation
                 or path to a yaml file containing a list of validation images
                 ids. Defaults to ``0.0``.
-            postprocess_set (str): The post-hoc calibration dataset to
+            postprocess_set: The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            ood_ds (str): Which out-of-distribution dataset to use. Defaults to
+            ood_ds: Which out-of-distribution dataset to use. Defaults to
                 ``"openimage-o"``.
-            test_alt (str): Which test set to use. Defaults to ``None``.
-            procedure (str): Which procedure to use. Defaults to ``None``.
+            test_alt: Which test set to use. Defaults to ``None``.
+            procedure: Which procedure to use. Defaults to ``None``.
                 Only used if ``train_transform`` is not provided.
-            train_size (int): Size of training images. Defaults to ``224``.
-            interpolation (str): Interpolation method for the Resize Crops.
+            train_size: Size of training images. Defaults to ``224``.
+            interpolation: Interpolation method for the Resize Crops.
                 Defaults to ``"bilinear"``. Only used if ``train_transform`` is not
                 provided.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            rand_augment_opt (str): Which RandAugment to use. Defaults to ``None``.
+            rand_augment_opt: Which RandAugment to use. Defaults to ``None``.
                 Only used if ``train_transform`` is not provided.
-            num_workers (int): Number of workers to use for data loading. Defaults
+            num_workers: Number of workers to use for data loading. Defaults
                 to ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=Path(root),
@@ -353,7 +353,7 @@ def read_indices(path: Path) -> list[str]:  # coverage: ignore
     """Read a file and return its lines as a list.
 
     Args:
-        path (Path): Path to the file.
+        path: Path to the file.
 
     Returns:
         list[str]: list of filenames.

--- a/src/torch_uncertainty/datamodules/classification/mnist.py
+++ b/src/torch_uncertainty/datamodules/classification/mnist.py
@@ -45,32 +45,32 @@ class MNISTDataModule(TUDataModule):
         """DataModule for MNIST.
 
         Args:
-            root (str): Root directory of the datasets.
-            eval_ood (bool): Whether to evaluate on out-of-distribution data. Defaults to ``False``.
-            eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            eval_ood: Whether to evaluate on out-of-distribution data. Defaults to ``False``.
+            eval_shift: Whether to evaluate on shifted data. Defaults to ``False``.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            ood_ds (str): Which out-of-distribution dataset to use. Defaults to
+            ood_ds: Which out-of-distribution dataset to use. Defaults to
                 ``"fashion"``; `fashion` stands for FashionMNIST and `notMNIST` for notMNIST.
-            val_split (float): Share of samples to use for validation. Defaults to ``0.0``.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            postprocess_set (str): The post-hoc calibration dataset to
+            val_split: Share of samples to use for validation. Defaults to ``0.0``.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            postprocess_set: The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
-            num_workers (int): Number of workers to use for data loading. Defaults
+            num_workers: Number of workers to use for data loading. Defaults
                 to ``1``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            ood_transform (nn.Module | None): Custom transform for out-of-distribution
+            ood_transform: Custom transform for out-of-distribution
                 datasets. Defaults to ``None``. If not provided, a default transform
                 is used.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``.
-            cutout (int): Size of cutout to apply to images. Defaults to ``None``.
-            pin_memory (bool): Whether to pin memory. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            cutout: Size of cutout to apply to images. Defaults to ``None``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/tiny_imagenet.py
+++ b/src/torch_uncertainty/datamodules/classification/tiny_imagenet.py
@@ -57,34 +57,34 @@ class TinyImageNetDataModule(TUDataModule):
         SVHN or DTD as Out-of-distribution dataset and Tiny-ImageNet-C as shifted dataset.
 
         Args:
-            root (str): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            eval_ood (bool): Whether to evaluate out-of-distribution performance. Defaults to ``False``.
-            eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
-            num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            shift_severity (int): Severity of the shift. Defaults to ``1``.
+            eval_ood: Whether to evaluate out-of-distribution performance. Defaults to ``False``.
+            eval_shift: Whether to evaluate on shifted data. Defaults to ``False``.
+            num_tta: Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
+            shift_severity: Severity of the shift. Defaults to ``1``.
             val_split (float or Path): Share of samples to use for validation
                 or path to a yaml file containing a list of validation images
                 ids. Defaults to ``0.0``.
-            postprocess_set (str): The post-hoc calibration dataset to
+            postprocess_set: The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            ood_ds (str): Which out-of-distribution dataset to use. Defaults to
+            ood_ds: Which out-of-distribution dataset to use. Defaults to
                 ``"openimage-o"``.
-            test_alt (str): Which test set to use. Defaults to ``None``.
-            procedure (str): Which procedure to use. Defaults to ``None``.
-            train_size (int): Size of training images. Defaults to ``224``.
-            interpolation (str): Interpolation method for the Resize Crops. Defaults to ``"bilinear"``.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to ``True``.
-            rand_augment_opt (str): Which RandAugment to use. Defaults to ``None``.
-            num_workers (int): Number of workers to use for data loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            test_alt: Which test set to use. Defaults to ``None``.
+            procedure: Which procedure to use. Defaults to ``None``.
+            train_size: Size of training images. Defaults to ``224``.
+            interpolation: Interpolation method for the Resize Crops. Defaults to ``"bilinear"``.
+            basic_augment: Whether to apply base augmentations. Defaults to ``True``.
+            rand_augment_opt: Which RandAugment to use. Defaults to ``None``.
+            num_workers: Number of workers to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/bank_marketing.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/bank_marketing.py
@@ -21,21 +21,16 @@ class BankMarketingDataModule(UCIClassificationDataModule):
         """The Bank Marketing UCI classification datamodule.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the
-                non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data
-                loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults
-                to ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to perform binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/dota2_games.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/dota2_games.py
@@ -21,16 +21,16 @@ class DOTA2GamesDataModule(UCIClassificationDataModule):
         """The Dota2 Games UCI classification datamodule.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults to ``True``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/htru2.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/htru2.py
@@ -21,16 +21,16 @@ class HTRU2DataModule(UCIClassificationDataModule):
         """The HTRU2 UCI classification datamodule.
 
         Args:
-            root (string): Root directory of the datasets.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults to ``True``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/online_shoppers.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/online_shoppers.py
@@ -21,21 +21,16 @@ class OnlineShoppersDataModule(UCIClassificationDataModule):
         """The online shoppers intention UCI classification datamodule.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the
-                non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data
-                loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults
-                to ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to use binary classification. Defaults to ``True``.
 
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/classification/uci/spam_base.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/spam_base.py
@@ -21,21 +21,16 @@ class SpamBaseDataModule(UCIClassificationDataModule):
         """The Bank Marketing UCI classification datamodule.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
-                and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the
-                non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data
-                loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults
-                to ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
+            root: Root directory of the datasets.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val and test). Set to
+                :attr:`batch_size` if ``None``. Defaults to ``None``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/uci_classification.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/uci_classification.py
@@ -25,22 +25,17 @@ class UCIClassificationDataModule(TUDataModule):
         """The UCI classification datamodule base class.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            dataset (type[Dataset]): The UCI classification dataset class.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
-                and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples among the
-                non-test samples. Defaults to ``0``.
-            test_split (float): Share of test samples. Defaults to ``0.2``.
-            num_workers (int): How many subprocesses to use for data
-                loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults
-                to ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
+            root: Root directory of the datasets.
+            dataset: The UCI classification dataset class.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val and test). Set to
+                :attr:`batch_size` if ``None``. Defaults to ``None``.
+            val_split: Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split: Share of test samples. Defaults to ``0.2``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            binary: Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,
@@ -64,7 +59,7 @@ class UCIClassificationDataModule(TUDataModule):
         """Split the datasets into train, val, and test.
 
         Args:
-            stage (str | None): Stage to set up. Defaults to ``None``.
+            stage: Stage to set up. Defaults to ``None``.
         """
         if stage == "fit" or stage is None:
             full = self.dataset(

--- a/src/torch_uncertainty/datamodules/classification/ucr_uea.py
+++ b/src/torch_uncertainty/datamodules/classification/ucr_uea.py
@@ -25,19 +25,18 @@ class UCRUEADataModule(TUDataModule):
         """Initialize the UCR/UEA dataset.
 
         Args:
-            dataset_name (str): Name of the dataset to load.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None): Number of samples per batch during evaluation (val and
+            dataset_name: Name of the dataset to load.
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val and
                 test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float | None): Share of validation samples. Defaults to ``0``.
-            eval_ood (bool): Whether to evaluate on out-of-distribution (OOD) data. Defaults to
+            val_split: Share of validation samples. Defaults to ``0``.
+            eval_ood: Whether to evaluate on out-of-distribution (OOD) data. Defaults to
                 ``False``.
-            num_workers (int): How many subprocesses to use for data loading. Defaults
+            num_workers: How many subprocesses to use for data loading. Defaults
                 to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
-            split_seed (int): The seed to use for splitting the dataset.
-                Defaults to ``42``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            split_seed: The seed to use for splitting the dataset. Defaults to ``42``.
         """
         super().__init__(
             root=f"~/.tslearn/datasets/UCR_UEA/{dataset_name}",

--- a/src/torch_uncertainty/datamodules/depth/base.py
+++ b/src/torch_uncertainty/datamodules/depth/base.py
@@ -34,15 +34,15 @@ class DepthDataModule(TUDataModule):
         r"""Base depth datamodule.
 
         Args:
-            dataset (type[VisionDataset]): Dataset class to use.
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            dataset: Dataset class to use.
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                     and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float): Minimum depth value for evaluation.
-            max_depth (float): Maximum depth value for training and
+            min_depth: Minimum depth value for evaluation.
+            max_depth: Maximum depth value for training and
                 evaluation.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,22 +50,21 @@ class DepthDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``None``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided. Otherwise
                 has no effect. Defaults to ``None``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None): Share of training samples to use
-                for validation.
-            num_workers (int): Number of dataloaders to use.
-            pin_memory (bool):  Whether to pin memory.
-            persistent_workers (bool): Whether to use persistent workers.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory:  Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/depth/kitti.py
+++ b/src/torch_uncertainty/datamodules/depth/kitti.py
@@ -28,15 +28,13 @@ class KITTIDataModule(DepthDataModule):
         r"""Depth DataModule for the KITTI-Depth dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float): Minimum depth value for evaluation.
-                Defaults to ``1e-3``.
-            max_depth (float): Maximum depth value for training and
-                evaluation. Defaults to ``80.0``.
-            crop_size (sequence or int): Desired input image and
+            min_depth: Minimum depth value for evaluation. Defaults to ``1e-3``.
+            max_depth: Maximum depth value for training and evaluation. Defaults to ``80.0``.
+            crop_size: Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -44,25 +42,21 @@ class KITTIDataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``(375, 1242)``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(375, 1242)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None): Share of training samples to use
-                for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
-                ``1``.
-            pin_memory (bool):  Whether to pin memory. Defaults to
-                ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory:  Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             dataset=KITTIDepth,

--- a/src/torch_uncertainty/datamodules/depth/muad.py
+++ b/src/torch_uncertainty/datamodules/depth/muad.py
@@ -31,14 +31,14 @@ class MUADDataModule(DepthDataModule):
         r"""Depth DataModule for the MUAD dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                     and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float): Minimum depth value for evaluation
-            max_depth (float): Maximum depth value for training and
+            min_depth: Minimum depth value for evaluation
+            max_depth: Maximum depth value for training and
                 evaluation.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -46,25 +46,21 @@ class MUADDataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(1024,2048)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None): Share of training samples to use
-                for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
-                ``1``.
-            pin_memory (bool):  Whether to pin memory. Defaults to
-                ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory:  Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
         """
         super().__init__(
             dataset=MUAD,

--- a/src/torch_uncertainty/datamodules/depth/nyu.py
+++ b/src/torch_uncertainty/datamodules/depth/nyu.py
@@ -28,15 +28,15 @@ class NYUv2DataModule(DepthDataModule):
         r"""Depth DataModule for the NYUv2 dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float): Minimum depth value for evaluation.
+            min_depth: Minimum depth value for evaluation.
                 Defaults to ``1e-3``.
-            max_depth (float): Maximum depth value for training and
+            max_depth: Maximum depth value for training and
                 evaluation. Defaults to ``10.0``.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -44,24 +44,24 @@ class NYUv2DataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``(416, 544)``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(480, 640)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None): Share of training samples to use
+            val_split: Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
+            num_workers: Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool):  Whether to pin memory. Defaults to
+            pin_memory:  Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
+            persistent_workers: Whether to use persistent workers.
                 Defaults to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/segmentation/camvid.py
+++ b/src/torch_uncertainty/datamodules/segmentation/camvid.py
@@ -38,11 +38,11 @@ class CamVidDataModule(TUDataModule):
         r"""DataModule for the CamVid dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,29 +50,25 @@ class CamVidDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``640``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 segmentation mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(720,960)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            group_classes (bool): Whether to group the 32 classes into
+            group_classes: Whether to group the 32 classes into
                 11 superclasses. Default: ``True``.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            val_split (float or None): Share of training samples to use
-                for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
-                ``1``.
-            pin_memory (bool):  Whether to pin memory. Defaults to
-                ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory:  Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
 
         Note:
             By default this datamodule injects the following transforms into the training and

--- a/src/torch_uncertainty/datamodules/segmentation/cityscapes.py
+++ b/src/torch_uncertainty/datamodules/segmentation/cityscapes.py
@@ -38,11 +38,11 @@ class CityscapesDataModule(TUDataModule):
         r"""DataModule for the Cityscapes dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,27 +50,23 @@ class CityscapesDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 segmentation mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(1024,2048)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
+            train_transform: Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
+            test_transform: Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            basic_augment (bool): Whether to apply base augmentations. Defaults to
+            basic_augment: Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            val_split (float or None): Share of training samples to use
-                for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
-                ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to
-                ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
 
         Note:
             By default this datamodule injects the following transforms into the training and

--- a/src/torch_uncertainty/datamodules/segmentation/muad.py
+++ b/src/torch_uncertainty/datamodules/segmentation/muad.py
@@ -40,16 +40,16 @@ class MUADDataModule(TUDataModule):
         r"""Segmentation DataModule for the MUAD dataset.
 
         Args:
-            root (str or Path): Root directory of the datasets.
-            batch_size (int): Number of samples per batch during training.
-            version (str): Version of the dataset to use. Can be either
+            root: Root directory of the datasets.
+            batch_size: Number of samples per batch during training.
+            version: Version of the dataset to use. Can be either
                 ``full`` or ``small``. Defaults to ``full``.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            eval_ood (bool): Whether to evaluate on the OOD dataset. Defaults to
+            eval_ood: Whether to evaluate on the OOD dataset. Defaults to
                 ``False``. If set to ``True``, the OOD dataset will be used for
                 evaluation in addition of the test dataset.
-            crop_size (sequence or int): Desired input image and
+            crop_size: Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -57,25 +57,21 @@ class MUADDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int): Desired input image and
+            eval_size: Desired input image and
                 segmentation mask sizes during inference. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
                 :math:`(\text{size}\times\text{height}/\text{width},\text{size})`.
                 Has to be provided if :attr:`test_transform` is not provided.
                 Otherwise has no effect. Defaults to ``(1024,2048)``.
-            train_transform (nn.Module | None): Custom training transform. Defaults
-                to ``None``. If not provided, a default transform is used.
-            test_transform (nn.Module | None): Custom test transform. Defaults to
-                ``None``. If not provided, a default transform is used.
-            val_split (float or None): Share of training samples to use
-                for validation. Defaults to ``None``.
-            num_workers (int): Number of dataloaders to use. Defaults to
-                ``1``.
-            pin_memory (bool): Whether to pin memory. Defaults to
-                ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
+            train_transform: Custom training transform. Defaults to ``None``. If not provided, a
+                default transform is used.
+            test_transform: Custom test transform. Defaults to ``None``. If not provided, a default
+                transform is used.
+            val_split: Share of training samples to use for validation. Defaults to ``None``.
+            num_workers: Number of dataloaders to use. Defaults to ``1``.
+            pin_memory: Whether to pin memory. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
 
         Note:
             By default this datamodule injects the following transforms into the training and

--- a/src/torch_uncertainty/datamodules/uci_regression.py
+++ b/src/torch_uncertainty/datamodules/uci_regression.py
@@ -28,26 +28,20 @@ class UCIRegressionDataModule(TUDataModule):
         """The UCI regression datasets.
 
         Args:
-            root (string): Root directory of the datasets.
-            dataset_name (string): The name of the dataset. One of
+            root: Root directory of the datasets.
+            dataset_name: The name of the dataset. One of
                 ``boston-housing``, ``concrete``, ``energy``, ``kin8nm``,
                 ``naval-propulsion-plant``, ``power-plant``, ``protein``,
                 ``wine-quality-red``, and ``yacht``.
-            batch_size (int): The batch size for training and testing.
-            eval_batch_size (int | None) : Number of samples per batch during evaluation (val
+            batch_size: The batch size for training and testing.
+            eval_batch_size: Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float): Share of validation samples. Defaults
-                to ``0``.
-            num_workers (int): How many subprocesses to use for data
-                loading. Defaults to ``1``.
-            pin_memory (bool): Whether to pin memory in the GPU. Defaults
-                to ``True``.
-            persistent_workers (bool): Whether to use persistent workers.
-                Defaults to ``True``.
-            input_shape (tuple): The shape of the input data. Defaults to
-                ``None``.
-            split_seed (int): The seed to use for splitting the dataset.
-                Defaults to ``42``.
+            val_split: Share of validation samples. Defaults to ``0``.
+            num_workers: How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory: Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers: Whether to use persistent workers. Defaults to ``True``.
+            input_shape: The shape of the input data. Defaults to ``None``.
+            split_seed: The seed to use for splitting the dataset. Defaults to ``42``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datasets/aggregated_dataset.py
+++ b/src/torch_uncertainty/datasets/aggregated_dataset.py
@@ -3,21 +3,21 @@ from torch.utils.data import Dataset
 
 
 class AggregatedDataset(Dataset):
-    def __init__(self, dataset: Dataset, n_dataloaders: int) -> None:
+    def __init__(self, dataset: Dataset, num_dataloaders: int) -> None:
         """A class to help aggregating datasets.
 
         Virtually interlace multiple copies of a dataset to train ensembles with
         different batch orders.
 
         Args:
-            dataset (Dataset): The dataset to be interlaced.
-            n_dataloaders (int): The number of dataloaders to be used for training.
+            dataset: The dataset to be interlaced.
+            num_dataloaders: The number of dataloaders to be used for training.
         """
         super().__init__()
         self.dataset = dataset
-        self.n_dataloaders = n_dataloaders
+        self.num_dataloaders = num_dataloaders
         self.dataset_size = len(dataset)
-        self.offset = self.dataset_size // self.n_dataloaders
+        self.offset = self.dataset_size // self.num_dataloaders
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
         """Get the samples and targets of the dataset.
@@ -28,7 +28,7 @@ class AggregatedDataset(Dataset):
         inputs, targets = zip(
             *[
                 self.dataset[(idx + i * self.offset) % self.dataset_size]
-                for i in range(self.n_dataloaders)
+                for i in range(self.num_dataloaders)
             ],
             strict=True,
         )

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_c.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_c.py
@@ -73,12 +73,12 @@ class CIFAR10C(VisionDataset):
         """The corrupted CIFAR-10-C Dataset.
 
         Args:
-            root (str): Root directory of the datasets.
-            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to ``None``.
-            subset (str): The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
-            shift_severity (int): The shift_severity of the corruption, between ``1`` and ``5``.
-            download (bool): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
+            root: Root directory of the datasets.
+            transform: A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform: A function/transform that takes in the target and transforms it. Defaults to ``None``.
+            subset: The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
+            shift_severity: The shift_severity of the corruption, between ``1`` and ``5``.
+            download: If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
 
         References:
             [1] `Benchmarking neural network robustness to common corruptions and perturbations. Dan Hendrycks and Thomas Dietterich. In ICLR, 2019 <https://arxiv.org/abs/1903.12261>`_.
@@ -120,10 +120,10 @@ class CIFAR10C(VisionDataset):
         in the dataset.
 
         Args:
-            root (Path): The path to the dataset.
-            subset (str): The name of the corruption subset to be used. Choose
+            root: The path to the dataset.
+            subset: The name of the corruption subset to be used. Choose
                 `all` for the dataset to contain all subsets.
-            shift_severity (int): The shift_severity of the corruption applied to the
+            shift_severity: The shift_severity of the corruption applied to the
                 images.
 
         Returns:
@@ -159,7 +159,7 @@ class CIFAR10C(VisionDataset):
         """Get the samples and targets of the dataset.
 
         Args:
-            index (int): The index of the sample to get.
+            index: The index of the sample to get.
         """
         sample, target = (
             self.samples[index],
@@ -228,12 +228,12 @@ class CIFAR100C(CIFAR10C):
         """The corrupted CIFAR-100-C Dataset.
 
         Args:
-            root (str): Root directory of the datasets.
-            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to None.
-            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to None.
-            subset (str): The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
-            shift_severity (int): The shift_severity of the corruption, between 1 and 5.
-            download (bool): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to False.
+            root: Root directory of the datasets.
+            transform: A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform: A function/transform that takes in the target and transforms it. Defaults to ``None``.
+            subset: The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
+            shift_severity: The shift_severity of the corruption, between 1 and 5.
+            download: If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to False.
             kwargs: Additional keyword arguments passed to the parent class (CIFAR-10-C).
 
         .. seealso::

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_h.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_h.py
@@ -24,16 +24,16 @@ class CIFAR10H(CIFAR10):
         """`CIFAR-10H <https://github.com/jcpeterson/cifar-10h>`_ Dataset.
 
         Args:
-            root (str): Root directory of dataset where file
+            root: Root directory of dataset where file
                 ``cifar-10h-probs.npy`` exists or will be saved to if download
                 is set to ``True``.
-            train (bool): For API consistency, not used.
-            transform (callable): A function/transform that takes in
+            train: For API consistency, not used.
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that
+            target_transform: A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_n.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_n.py
@@ -35,18 +35,18 @@ class CIFAR10N(CIFAR10):
         """`CIFAR-10N <https://github.com/UCSC-REAL/cifar-10-100n>`_ Dataset.
 
         Args:
-            root (str): Root directory of dataset where file
+            root: Root directory of dataset where file
                 ``cifar-10h-probs.npy`` exists or will be saved to if download
                 is set to ``True``.
-            train (bool): For API consistency, not used.
-            file_arg (str): The type of label noise to use. One of the following:
+            train: For API consistency, not used.
+            file_arg: The type of label noise to use. One of the following:
                 ``"aggre_label"``, ``"worse_label"``, ``"random_label1"``, ``"random_label2"``, ``"random_label3"``.
-            transform (callable): A function/transform that takes in
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that
+            target_transform: A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """
@@ -106,18 +106,18 @@ class CIFAR100N(CIFAR100):
         """`CIFAR-100N <https://github.com/UCSC-REAL/cifar-10-100n>`_ Dataset.
 
         Args:
-            root (string): Root directory of dataset where file
+            root: Root directory of dataset where file
                 ``cifar-100h-probs.npy`` exists or will be saved to if download
                 is set to True.
-            train (bool): For API consistency, not used.
-            file_arg (str): The type of label noise to use. One of the following:
+            train: For API consistency, not used.
+            file_arg: The type of label noise to use. One of the following:
                 ``"fine_label"``, ``"coarse_label"``.
-            transform (callable): A function/transform that takes in
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that
+            target_transform: A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool): If True, downloads the dataset from the
+            download: If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/cub.py
+++ b/src/torch_uncertainty/datasets/classification/cub.py
@@ -27,17 +27,18 @@ class CUB(ImageFolder):
         """The Caltech-UCSD Birds-200-2011 dataset.
 
         Args:
-            root (str): Root directory of the dataset.
-            train (bool): If True, creates dataset from training set, otherwise creates
-                from test set. Defaults to True.
-            transform (callable): A function/transform that takes in an PIL image and
-                returns a transformed version. E.g, transforms.RandomCrop. Defaults to None.
-            target_transform (callable): A function/transform that takes in the target
-                and transforms it. Defaults to None.
-            return_attributes (bool): If True, returns the attributes instead of the images.
-                Defaults to False.
-            download (bool): If True, downloads the dataset from the internet and puts it
+            root: Root directory of the dataset.
+            train: If True, creates dataset from training set, otherwise creates
+                from test set. Defaults to ``True``.
+            transform: A function/transform that takes in an PIL image and
+                returns a transformed version. E.g, transforms.RandomCrop. Defaults to ``None``.
+            target_transform: A function/transform that takes in the target
+                and transforms it. Defaults to ``None``.
+            return_attributes: If ``True``, returns the attributes instead of the images.
+                Defaults to ``False``.
+            download: If ``True``, downloads the dataset from the internet and puts it
                 in root directory. If dataset is already downloaded, it is not downloaded again.
+                Defaults to ``None``
 
         References:
         [1] `Wah, C. and Branson, S. and Welinder, P. and Perona, P. and Belongie, S. Caltech-UCSD Birds 200

--- a/src/torch_uncertainty/datasets/classification/imagenet/base.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/base.py
@@ -32,14 +32,14 @@ class ImageNetVariation(ImageFolder):
         """Virtual base class for ImageNet variations.
 
         Args:
-        root (str | Path): Root directory of the datasets.
-        split (str): For API consistency. Defaults to ``None``.
-        transform (callable): A function/transform that takes in
+        root: Root directory of the datasets.
+        split: For API consistency. Defaults to ``None``.
+        transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-        target_transform (callable): A function/transform that
+        target_transform: A function/transform that
             takes in the target and transforms it. Defaults to ``None``.
-        download (bool): If ``True``, downloads the dataset from the
+        download: If ``True``, downloads the dataset from the
             internet and puts it in root directory. If dataset is already
             downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_a.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_a.py
@@ -15,13 +15,13 @@ class ImageNetA(ImageNetVariation):
         Args:
             kwargs: Additional keyword arguments passed to the superclass, including:
 
-                - root (str): Root directory of the datasets.
-                - split (str): For API consistency. Defaults to ``None``.
-                - transform (callable): A function/transform that takes in a PIL image and
+                - root: Root directory of the datasets.
+                - split: For API consistency. Defaults to ``None``.
+                - transform: A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable): A function/transform that takes in the target
+                - target_transform: A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool): If ``True``, downloads the dataset from the internet
+                - download: If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_c.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_c.py
@@ -42,13 +42,13 @@ class ImageNetC(ImageNetVariation):
         Args:
             kwargs: Additional keyword arguments passed to the superclass, including:
 
-                - root (str): Root directory of the datasets.
-                - split (str): For API consistency. Defaults to ``None``.
-                - transform (callable): A function/transform that takes in a PIL image and
+                - root: Root directory of the datasets.
+                - split: For API consistency. Defaults to ``None``.
+                - transform: A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable): A function/transform that takes in the target
+                - target_transform: A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool): If ``True``, downloads the dataset from the internet
+                - download: If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_o.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_o.py
@@ -15,13 +15,13 @@ class ImageNetO(ImageNetVariation):
         Args:
             kwargs: Additional keyword arguments passed to the superclass, including:
 
-                - root (str): Root directory of the datasets.
-                - split (str): For API consistency. Defaults to ``None``.
-                - transform (callable): A function/transform that takes in a PIL image and
+                - root: Root directory of the datasets.
+                - split: For API consistency. Defaults to ``None``.
+                - transform: A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable): A function/transform that takes in the target
+                - target_transform: A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool): If ``True``, downloads the dataset from the internet
+                - download: If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_r.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_r.py
@@ -15,13 +15,13 @@ class ImageNetR(ImageNetVariation):
         Args:
             kwargs: Additional keyword arguments passed to the superclass, including:
 
-                - root (str): Root directory of the datasets.
-                - split (str): For API consistency. Defaults to ``None``.
-                - transform (callable): A function/transform that takes in a PIL image and
+                - root: Root directory of the datasets.
+                - split: For API consistency. Defaults to ``None``.
+                - transform: A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable): A function/transform that takes in the target
+                - target_transform: A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool): If ``True``, downloads the dataset from the internet
+                - download: If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet.py
@@ -65,7 +65,7 @@ class TinyImageNet(Dataset):
         """Get the samples and targets of the dataset.
 
         Args:
-            index (int): The index of the sample to get.
+            index: The index of the sample to get.
         """
         sample = self.samples[index]
         target = self.label_data[index]

--- a/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet_c.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet_c.py
@@ -52,16 +52,16 @@ class TinyImageNetC(ImageFolder):
         """The corrupted TinyImageNet-C Dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            transform (callable): A function/transform that takes in
+            root: Root directory of the datasets.
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that
+            target_transform: A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            subset (str): The subset to use, one of ``all`` or the keys in
+            subset: The subset to use, one of ``all`` or the keys in
                 ``cifarc_subsets``.
-            shift_severity (int): The shift_severity of the corruption, between ``1`` and ``5``.
-            download (bool): If True, downloads the dataset from the
+            shift_severity: The shift_severity of the corruption, between ``1`` and ``5``.
+            download: If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
 
@@ -102,9 +102,9 @@ class TinyImageNetC(ImageFolder):
         in the dataset.
 
         Args:
-            subset (str): The name of the corruption subset to be used. Choose
+            subset: The name of the corruption subset to be used. Choose
                 `all` for the dataset to contain all subsets.
-            shift_severity (int): The shift_severity of the corruption applied to the
+            shift_severity: The shift_severity of the corruption applied to the
                 images.
         """
         if subset == "all":

--- a/src/torch_uncertainty/datasets/classification/mnist_c.py
+++ b/src/torch_uncertainty/datasets/classification/mnist_c.py
@@ -47,16 +47,16 @@ class MNISTC(VisionDataset):
         """The corrupted MNIST-C Dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            transform (callable): A function/transform that takes in
+            root: Root directory of the datasets.
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
-                ``transforms.RandomCrop``. Defaults to None.
-            target_transform (callable): A function/transform that
-                takes in the target and transforms it. Defaults to None.
-            split (str): The split to use, either 'train' or 'test'.
-            subset (str): The subset to use, one of ``all`` or the keys in
+                ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform: A function/transform that
+                takes in the target and transforms it. Defaults to ``None``.
+            split: The split to use, either 'train' or 'test'.
+            subset: The subset to use, one of ``all`` or the keys in
                 ``mnistc_subsets``.
-            download (bool): If True, downloads the dataset from the
+            download: If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to False.
 
@@ -110,10 +110,10 @@ class MNISTC(VisionDataset):
         in the dataset.
 
         Args:
-            root (Path): The path to the dataset.
-            subset (str): The name of the corruption subset to be used. Choose
+            root: The path to the dataset.
+            subset: The name of the corruption subset to be used. Choose
                 `all` for the dataset to contain all subsets.
-            split (str): The split to be used, either `train` or `test`.
+            split: The split to be used, either `train` or `test`.
 
         Returns:
             tuple[np.ndarray, np.ndarray]: The samples and labels of the chosen.
@@ -142,7 +142,7 @@ class MNISTC(VisionDataset):
         """Get the samples and targets of the dataset.
 
         Args:
-            index (int): The index of the sample to get.
+            index: The index of the sample to get.
         """
         sample, target = (
             self.samples[index],

--- a/src/torch_uncertainty/datasets/classification/not_mnist.py
+++ b/src/torch_uncertainty/datasets/classification/not_mnist.py
@@ -30,14 +30,14 @@ class NotMNIST(ImageFolder):
         """The notMNIST dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            subset (str): The subset to use, one of ``small`` or ``large``.
-            transform (callable): A function/transform that takes in
+            root: Root directory of the datasets.
+            subset: The subset to use, one of ``small`` or ``large``.
+            transform: A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that
+            target_transform: A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
 

--- a/src/torch_uncertainty/datasets/classification/openimage_o.py
+++ b/src/torch_uncertainty/datasets/classification/openimage_o.py
@@ -25,11 +25,11 @@ class OpenImageO(ImageFolder):
         """OpenImage-O dataset.
 
         Args:
-            root (str): Root directory of the datasets.
-            split (str): Unused, for API consistency. Defaults to ``None``.
-            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to ``None``.
-            download (bool): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
+            root: Root directory of the datasets.
+            split: Unused, for API consistency. Defaults to ``None``.
+            transform: A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform: A function/transform that takes in the target and transforms it. Defaults to ``None``.
+            download: If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
 
         References:
             [1] `Original dataset: The open images dataset v4: Unified image classification, object detection, and visual relationship detection at scale. Kuznetsova, A., et al. The International Journal of Computer Vision

--- a/src/torch_uncertainty/datasets/classification/uci/bank_marketing.py
+++ b/src/torch_uncertainty/datasets/classification/uci/bank_marketing.py
@@ -34,14 +34,14 @@ class BankMarketing(UCIClassificationDataset):
         """The bank Marketing UCI classification dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If True, creates dataset from training set, otherwise creates from test set.
-            transform (callable): A function/transform that takes in a numpy array and returns a transformed version.
-            target_transform (callable): A function/transform that takes in the target and transforms it.
-            download (bool): If true, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
-            binary (bool): Whether to use binary classification. Defaults to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-            split_seed (int): The random seed for splitting the dataset. Defaults to ``21893027``.
+            root: Root directory of the datasets.
+            train: If True, creates dataset from training set, otherwise creates from test set.
+            transform: A function/transform that takes in a numpy array and returns a transformed version.
+            target_transform: A function/transform that takes in the target and transforms it.
+            download: If true, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
+            binary: Whether to use binary classification. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             The licenses of the datasets may differ from TorchUncertainty's license. Check before use.

--- a/src/torch_uncertainty/datasets/classification/uci/dota2_games.py
+++ b/src/torch_uncertainty/datasets/classification/uci/dota2_games.py
@@ -32,22 +32,19 @@ class DOTA2Games(UCIClassificationDataset):
         """The DOTA 2 Games UCI classification dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If ``True``, creates dataset from training set,
+            root: Root directory of the datasets.
+            train: If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable): A function/transform that takes in a
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``. Defaults to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-                Defaults to ``0.2``.
-            split_seed (int): The random seed for splitting the dataset.
-                Defaults to ``21893027``.
+            binary: Whether to use binary classification. Defaults to ``True``. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set. Defaults to ``0.2``.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note - License:
             The licenses of the datasets may differ from TorchUncertainty's

--- a/src/torch_uncertainty/datasets/classification/uci/htru2.py
+++ b/src/torch_uncertainty/datasets/classification/uci/htru2.py
@@ -28,22 +28,19 @@ class HTRU2(UCIClassificationDataset):
         """The HTRU2 UCI classification dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If ``True``, creates dataset from training set,
+            root: Root directory of the datasets.
+            train: If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable): A function/transform that takes in a
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-                Defaults to ``0.2``.
-            split_seed (int): The random seed for splitting the dataset.
-                Defaults to ``21893027``.
+            binary: Whether to use binary classification. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set. Defaults to ``0.2``.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             The licenses of the datasets may differ from TorchUncertainty's

--- a/src/torch_uncertainty/datasets/classification/uci/online_shoppers.py
+++ b/src/torch_uncertainty/datasets/classification/uci/online_shoppers.py
@@ -28,22 +28,19 @@ class OnlineShoppers(UCIClassificationDataset):
         """The Online Shoppers Intention UCI classification dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If ``True``, creates dataset from training set,
+            root: Root directory of the datasets.
+            train: If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable): A function/transform that takes in a
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-                Defaults to ``0.2``.
-            split_seed (int): The random seed for splitting the dataset.
-                Defaults to ``21893027``.
+            binary: Whether to use binary classification. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set. Defaults to ``0.2``.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             License: The licenses of the datasets may differ from TorchUncertainty's

--- a/src/torch_uncertainty/datasets/classification/uci/spam_base.py
+++ b/src/torch_uncertainty/datasets/classification/uci/spam_base.py
@@ -28,22 +28,19 @@ class SpamBase(UCIClassificationDataset):
         """The SpamBase UCI classification dataset.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If ``True``, creates dataset from training set,
+            root: Root directory of the datasets.
+            train: If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable): A function/transform that takes in a
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-                Defaults to ``0.2``.
-            split_seed (int): The random seed for splitting the dataset.
-                Defaults to ``21893027``.
+            binary: Whether to use binary classification. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set. Defaults to ``0.2``.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             License: The licenses of the datasets may differ from TorchUncertainty's

--- a/src/torch_uncertainty/datasets/classification/uci/uci_classification.py
+++ b/src/torch_uncertainty/datasets/classification/uci/uci_classification.py
@@ -34,22 +34,19 @@ class UCIClassificationDataset(Dataset, ABC):
         """The UCI classification dataset base class.
 
         Args:
-            root (str | Path): Root directory of the datasets.
-            train (bool): If ``True``, creates dataset from training set,
+            root: Root directory of the datasets.
+            train: If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable): A function/transform that takes in a
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool): Whether to use binary classification. Defaults
-                to ``True``.
-            test_split (float): The fraction of the dataset to use as test set.
-                Defaults to ``0.2``.
-            split_seed (int): The random seed for splitting the dataset.
-                Defaults to ``21893027``.
+            binary: Whether to use binary classification. Defaults to ``True``.
+            test_split: The fraction of the dataset to use as test set. Defaults to ``0.2``.
+            split_seed: The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             The licenses of the datasets may differ from TorchUncertainty's
@@ -127,7 +124,7 @@ class UCIClassificationDataset(Dataset, ABC):
         """Get sample and target for a given index.
 
         Args:
-            index (int): Index
+            index: Index
 
         Returns:
             tuple: (sample, target) where sample is a tensor and target is a tensor

--- a/src/torch_uncertainty/datasets/classification/ucr_uea.py
+++ b/src/torch_uncertainty/datasets/classification/ucr_uea.py
@@ -27,13 +27,13 @@ class UCRUEADataset(Dataset):
         """UCR/UEA Time Series Classification Dataset.
 
         Args:
-            dataset_name (str): Name of the dataset to load.
-            split (str): Split to use (``"train"``, ``"test"`` or ``"ood"``). Defaults to ``"train"``.
-            transform (Callable | None): Transform to apply to the input data. Defaults
+            dataset_name: Name of the dataset to load.
+            split: Split to use (``"train"``, ``"test"`` or ``"ood"``). Defaults to ``"train"``.
+            transform: Transform to apply to the input data. Defaults
                 to ``None``.
-            target_transform (Callable | None): Transform to apply to the target data.
+            target_transform: Transform to apply to the target data.
                 Defaults to ``None``.
-            create_ood (bool): Whether to create an out-of-distribution (OOD) dataset based
+            create_ood: Whether to create an out-of-distribution (OOD) dataset based
                 on the last class in the dataset. Defaults to ``False``.
 
         Raises:
@@ -80,7 +80,7 @@ class UCRUEADataset(Dataset):
         """Get a data sample from the dataset.
 
         Args:
-            index (int): The index of the sample to retrieve.
+            index: The index of the sample to retrieve.
 
         Returns:
             tuple[torch.Tensor, torch.Tensor]: A tuple containing the input tensor and the target tensor.

--- a/src/torch_uncertainty/datasets/corrupted.py
+++ b/src/torch_uncertainty/datasets/corrupted.py
@@ -23,11 +23,11 @@ class CorruptedDataset(VisionDataset):
         """Generate the corrupted version of any VisionDataset.
 
         Args:
-            core_dataset (VisionDataset): dataset to be corrupted.
-            shift_severity (int): intensity of the corruption. Should be in [1, 5].
-            generate (bool): Equivalent of the download attributes of the dataset. If ``True``,
+            core_dataset: dataset to be corrupted.
+            shift_severity: intensity of the corruption. Should be in [1, 5].
+            generate: Equivalent of the download attributes of the dataset. If ``True``,
                 generate a new dataset with all the corrupted images. Defaults to ``False``.
-            on_the_fly (bool): Generate the corrupted version of the dataset on the fly, without
+            on_the_fly: Generate the corrupted version of the dataset on the fly, without
                 saving the images on disk. This is discouraged since the experiment won't be fully
                 reproducible. Defaults to ``False``.
 
@@ -100,8 +100,8 @@ class CorruptedDataset(VisionDataset):
         """Save all images with the given corruption on the disk.
 
         Args:
-            root (Path): The path where to save the images.
-            corruption (nn.Module): The corruption module to apply on the images.
+            root: The path where to save the images.
+            corruption: The corruption module to apply on the images.
         """
         for i in trange(self.core_length, leave=False):
             img, tgt = self.core_dataset[i]
@@ -118,7 +118,7 @@ class CorruptedDataset(VisionDataset):
         """Get the corrupted image and the target.
 
         Args:
-            idx (int): Index of the image to retrieve.
+            idx: Index of the image to retrieve.
         """
         if self.on_the_fly:
             corrupt = corruption_transforms[idx // len(self.core_dataset)]

--- a/src/torch_uncertainty/datasets/fractals.py
+++ b/src/torch_uncertainty/datasets/fractals.py
@@ -26,12 +26,10 @@ class Fractals(ImageFolder):
         """Dataset used for PixMix augmentations.
 
         Args:
-            root (str | Path): Root directory of dataset.
-            transform (Callable[..., Any] | None): Transform to apply to the input samples.
-                Defaults to ``None``.
-            target_transform (Callable[..., Any] | None): Transform to apply to the target labels.
-                Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset if not present. Defaults to ``False``.
+            root: Root directory of dataset.
+            transform: Transform to apply to the input samples. Defaults to ``None``.
+            target_transform: Transform to apply to the target labels. Defaults to ``None``.
+            download: If ``True``, downloads the dataset if not present. Defaults to ``False``.
 
         Note:
             There is no information on the license of the dataset. It may not
@@ -73,6 +71,6 @@ class Fractals(ImageFolder):
         """Get the samples and targets of the dataset.
 
         Args:
-            index (int): The index of the sample to get.
+            index: The index of the sample to get.
         """
         return super().__getitem__(index)[0]

--- a/src/torch_uncertainty/datasets/frost.py
+++ b/src/torch_uncertainty/datasets/frost.py
@@ -36,11 +36,9 @@ class FrostImages(VisionDataset):
         and each sample consists only of an image.
 
         Args:
-            transform (Callable[..., Any] | None): A function/transform
-                applied to the input image. Default: ``None``.
-            target_transform (Callable[..., Any] | None): A function/transform
-                applied to the target. Since no targets are provided, this argument is
-                kept for API compatibility. Default: ``None``.
+            transform: A function/transform applied to the input image. Defaults to ``None``.
+            target_transform: A function/transform applied to the target. Since no targets are provided, this
+                argument is kept for API compatibility. Defaults to ``None``.
 
         Raises:
             ImportError: If the ``torch-uncertainty-assets`` package with image
@@ -68,7 +66,7 @@ class FrostImages(VisionDataset):
         """Get the samples of the dataset.
 
         Args:
-            index (int): Index
+            index: Index of the image to get.
 
         Returns:
             tuple: (sample, target) where target is class_index of the target class.

--- a/src/torch_uncertainty/datasets/kitti.py
+++ b/src/torch_uncertainty/datasets/kitti.py
@@ -58,18 +58,18 @@ class KITTIDepth(VisionDataset):
                         leftDepth/*.png
 
         Args:
-            root (str or Path): Root directory where the dataset will be stored.
-            split (Literal["train", "val"]): Dataset split to use.
-            min_depth (float, default=0.0): Minimum valid depth value (in meters). Depth values
-                smaller than or equal to this threshold are set to NaN.
-            max_depth (float, default=80.0): Maximum valid depth value (in meters). Depth values
-                greater than this threshold are set to NaN.
-            transforms (Callable): A function/transform that takes an ``(image, target)``
+            root: Root directory where the dataset will be stored.
+            split: Dataset split to use.
+            min_depth: Minimum valid depth value (in meters). Depth values
+                smaller than or equal to this threshold are set to NaN. Defaults to ``0.0``.
+            max_depth: Maximum valid depth value (in meters). Depth values
+                greater than this threshold are set to NaN. Defaults to ``80.0``.
+            transforms: A function/transform that takes an ``(image, target)``
                 pair and returns the transformed pair.
-            download (bool, default=False): If True, downloads and restructures the depth
-                annotations and raw KITTI data if not already present.
-            remove_unused (bool, default=False): If True, removes the extracted raw files after
-                restructuring to save disk space.
+            download: If True, downloads and restructures the depth
+                annotations and raw KITTI data if not already present. Defaults to ``False``.
+            remove_unused: If True, removes the extracted raw files after
+                restructuring to save disk space. Defaults to ``False``.
 
         Returns:
             tuple[tv_tensors.Image, tv_tensors.Mask]:
@@ -135,7 +135,7 @@ class KITTIDepth(VisionDataset):
         """Get the sample at the given index.
 
         Args:
-            index (int): Index
+            index: Index
 
         Returns:
             tuple: (image, target) where target is a depth map.

--- a/src/torch_uncertainty/datasets/muad.py
+++ b/src/torch_uncertainty/datasets/muad.py
@@ -119,23 +119,20 @@ class MUAD(VisionDataset):
         """The MUAD Dataset.
 
         Args:
-            root (str | Path): Root directory of dataset where directory ``leftImg8bit`` and ``leftLabel``
+            root: Root directory of dataset where directory ``leftImg8bit`` and ``leftLabel``
                 or ``leftDepth`` are located.
-            split (str): The image split to use, ``train``, ``val``, ``test`` or ``ood``.
-            version (str): The version of the dataset to use, ``small`` or ``full``.
-                Defaults to ``full``.
-            min_depth (float): The maximum depth value to use if target_type is ``depth``.
-                Defaults to ``None``.
-            max_depth (float): The maximum depth value to use if target_type is ``depth``.
-                Defaults to ``None``.
-            target_type (str): The type of target to use, ``semantic`` or ``depth``.
-                Defaults to ``semantic``.
-            transforms (callable): A function/transform that takes in a tuple of PIL
+            split: The image split to use, ``train``, ``val``, ``test`` or ``ood``.
+            version: The version of the dataset to use, ``small`` or ``full``.
+                Defaults to ``"full"``.
+            min_depth: The maximum depth value to use if target_type is ``depth``. Defaults to ``None``.
+            max_depth: The maximum depth value to use if target_type is ``depth``. Defaults to ``None``.
+            target_type: The type of target to use, ``semantic`` or ``depth``. Defaults to ``semantic``.
+            transforms: A function/transform that takes in a tuple of PIL
                 images and returns a transformed version. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the internet and puts
+            download: If ``True``, downloads the dataset from the internet and puts
                 it in root directory. If dataset is already downloaded, it is not downloaded again.
                 Defaults to ``False``.
-            use_train_ids (bool): If ``True``, uses the train ids instead of the original
+            use_train_ids: If ``True``, uses the train ids instead of the original
                 ids. Defaults to ``True``. Note that this is only used for the ``semantic`` target
                 type.
 
@@ -227,7 +224,7 @@ class MUAD(VisionDataset):
         """Get the sample at the given index.
 
         Args:
-            index (int): Index
+            index: Index
 
         Returns:
             tuple: (image, target) where target is either a segmentation mask
@@ -271,7 +268,7 @@ class MUAD(VisionDataset):
         """Create a list of samples and targets.
 
         Args:
-            path (Path): The path to the dataset.
+            path: The path to the dataset.
         """
         if "depth" in path.name:
             raise NotImplementedError(

--- a/src/torch_uncertainty/datasets/nyu.py
+++ b/src/torch_uncertainty/datasets/nyu.py
@@ -53,12 +53,12 @@ class NYUv2(VisionDataset):
         """NYUv2 depth dataset.
 
         Args:
-            root (Path | str): Root directory where dataset is stored.
-            split (Literal["train", "val"]): Dataset split.
-            transforms (Callable | None): Transform to apply to samples & targets. Defaults to ``None``.
-            min_depth (float): Minimum depth value. Defaults to ``1e-3``.
-            max_depth (float): Maximum depth value. Defaults to ``10``.
-            download (bool): Download dataset if not found. Defaults to ``False``.
+            root: Root directory where dataset is stored.
+            split: Dataset split.
+            transforms: Transform to apply to samples & targets. Defaults to ``None``.
+            min_depth: Minimum depth value. Defaults to ``1e-3``.
+            max_depth: Maximum depth value. Defaults to ``10``.
+            download: Download dataset if not found. Defaults to ``False``.
         """
         if not cv2_installed:  # coverage: ignore
             raise ImportError(
@@ -98,7 +98,7 @@ class NYUv2(VisionDataset):
         """Return image and target at index.
 
         Args:
-            index (int): Index of the sample.
+            index: Index of the sample.
         """
         image = tv_tensors.Image(Image.open(self.samples[index]).convert("RGB"))
         target = Image.fromarray(

--- a/src/torch_uncertainty/datasets/regression/toy.py
+++ b/src/torch_uncertainty/datasets/regression/toy.py
@@ -14,14 +14,11 @@ class Cubic(TensorDataset):
         """A dataset of samples drawn from the cube fct. with homoscedastic noise.
 
         Args:
-            lower_bound (float): Lower bound of the samples. Defaults to
-                ``-4.0``.
-            upper_bound (float): Upper bound of the samples. Defaults to
-                ``4.0``.
-            num_samples (int): Number of samples. Defaults to ``5000``.
-            noise_mean (float): Mean of the noise. Defaults to ``0.0``.
-            noise_std (float): Standard deviation of the noise. Defaults
-                to ``3.0``.
+            lower_bound: Lower bound of the samples. Defaults to ``-4.0``.
+            upper_bound: Upper bound of the samples. Defaults to ``4.0``.
+            num_samples: Number of samples. Defaults to ``5000``.
+            noise_mean: Mean of the noise. Defaults to ``0.0``.
+            noise_std: Standard deviation of the noise. Defaults to ``3.0``.
         """
         noise = (noise_mean, noise_std)
 

--- a/src/torch_uncertainty/datasets/regression/uci_regression.py
+++ b/src/torch_uncertainty/datasets/regression/uci_regression.py
@@ -116,22 +116,20 @@ class UCIRegression(Dataset):
         """The UCI regression datasets.
 
         Args:
-            root (str): Root directory of the datasets.
-            transform (callable): A function/transform that takes in a
+            root: Root directory of the datasets.
+            transform: A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable): A function/transform that takes
+            target_transform: A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            dataset_name (str): The name of the dataset. One of
+            dataset_name: The name of the dataset. One of
                 ``boston-housing``, ``concrete``, ``energy``, ``kin8nm``,
                 ``naval-propulsion-plant``, ``power-plant``, ``protein``,
                 ``wine-quality-red``, and ``yacht``. Defaults to ``energy``.
-            download (bool): If ``True``, downloads the dataset from the
+            download: If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            seed (int): The random seed for shuffling the dataset.
-                Defaults to ``42``.
-            shuffle (bool): If ``True``, shuffles the dataset.
-                Defaults to ``True``.
+            seed: The random seed for shuffling the dataset. Defaults to ``42``.
+            shuffle: If ``True``, shuffles the dataset. Defaults to ``True``.
 
         Note:
             You may want to avoid using the boston-housing dataset because of

--- a/src/torch_uncertainty/datasets/segmentation/camvid.py
+++ b/src/torch_uncertainty/datasets/segmentation/camvid.py
@@ -118,11 +118,11 @@ class CamVid(VisionDataset):
         """`CamVid <http://web4.cs.ucl.ac.uk/staff/g.brostow/MotionSegRecData/>`_ Dataset.
 
         Args:
-            root (str | Path): Root directory of dataset where ``camvid/`` exists or will be saved to if download is set to ``True``.
-            group_classes (bool): Whether to group the 32 classes into 11 superclasses. Defaults to ``True``.
-            split (str): The dataset split, supports ``train``, ``val`` and ``test``. Defaults to ``None``.
-            transforms (callable): A function/transform that takes input sample and its target as entry and returns a transformed version. Defaults to ``None``.
-            download (bool): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
+            root: Root directory of dataset where ``camvid/`` exists or will be saved to if download is set to ``True``.
+            group_classes: Whether to group the 32 classes into 11 superclasses. Defaults to ``True``.
+            split: The dataset split, supports ``train``, ``val`` and ``test``. Defaults to ``None``.
+            transforms: A function/transform that takes input sample and its target as entry and returns a transformed version. Defaults to ``None``.
+            download: If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
                 Defaults to ``False``.
         """
         if split not in ["train", "val", "test", None]:
@@ -232,7 +232,7 @@ class CamVid(VisionDataset):
         """Get the image and target at the given index.
 
         Args:
-            index (int): Sample index.
+            index: Sample index.
 
         Returns:
             tuple[tv_tensors.Image, tv_tensors.Mask]: Image and target.

--- a/src/torch_uncertainty/datasets/segmentation/cityscapes.py
+++ b/src/torch_uncertainty/datasets/segmentation/cityscapes.py
@@ -44,32 +44,26 @@ class Cityscapes(TVCityscapes):
         target_transform: Callable[..., Any] | None = None,
         transforms: Callable[..., Any] | None = None,
     ) -> None:
-        """Cityscapes dataset wrapper with train ID color mapping.
+        """Cityscapes dataset wrapper with train-ID color mapping.
 
-        This class extends the `TVCityscapes` dataset to provide a fixed
-        color palette for visualization and encode/decode utilities for
-        semantic segmentation targets using Cityscapes train IDs. It also
-        sets up mapping from train IDs to RGB colors for easier interpretation
-        of predicted masks.
+        Extends :class:`torchvision.datasets.Cityscapes` to provide a
+        stable color palette for visualization and convenience helpers to
+        encode and decode semantic segmentation targets using Cityscapes
+        train IDs. A tensor mapping train IDs to RGB colors is constructed
+        on initialization for decoding predicted masks.
 
         Attributes:
-            color_palette (list[tuple[int, int, int]]):
-                List of RGB tuples for each class label in the Cityscapes dataset.
-            train_id_to_color (torch.Tensor):
-                Tensor mapping train IDs to RGB colors for output decoding.
+            color_palette: List of RGB tuples for each class label in Cityscapes.
+            train_id_to_color: Tensor mapping train IDs to RGB colors for decoding.
 
         Args:
-            root (str): Root directory of the Cityscapes dataset.
-            split (str): Dataset split to use, such as "train", "val", or "test".
-            mode (str): Annotation mode, e.g., "fine" or "coarse".
-            target_type (list[str] | str):
-                One or more target types to load ("instance", "semantic", etc.).
-            transform (Callable[..., Any] | None):
-                Transformation applied to the input image.
-            target_transform (Callable[..., Any] | None):
-                Transformation applied to the target.
-            transforms (Callable[..., Any] | None):
-                Combined transformation for image and target.
+            root: Root directory of the Cityscapes dataset.
+            split: Dataset split to use (e.g., "train", "val", or "test"). Defaults to ``"train"``.
+            mode: Annotation mode ("fine" or "coarse"). Defaults to ``"fine"``.
+            target_type: One or more target types to load ("instance", "semantic", etc.). Defaults to ``"instance"``.
+            transform: Transformation applied to the input image. Defaults to ``None``.
+            target_transform: Transformation applied to the target. Defaults to ``None``.
+            transforms: Combined transformation for image and target. Defaults to ``None``.
 
         """
         super().__init__(
@@ -89,13 +83,17 @@ class Cityscapes(TVCityscapes):
 
     @classmethod
     def encode_target(cls, target: Image.Image) -> Image.Image:
-        """Encode target image to tensor.
+        """Encode a Cityscapes target PIL image into a train-ID image.
+
+        The input is a color-coded PIL image (train-ID or label colors). The
+        method converts it to a single-channel image where each pixel value
+        is the corresponding train ID.
 
         Args:
-            target (Image.Image): Target PIL image.
+            target: A PIL image containing the ground-truth target map.
 
         Returns:
-            torch.Tensor: Encoded target.
+            A PIL image where pixel values correspond to Cityscapes train IDs.
         """
         colored_target = F.pil_to_tensor(target)
         colored_target = rearrange(colored_target, "c h w -> h w c")
@@ -111,27 +109,32 @@ class Cityscapes(TVCityscapes):
         return F.to_pil_image(rearrange(target, "h w c -> c h w"))
 
     def decode_target(self, target: torch.Tensor) -> torch.Tensor:
-        """Decode target tensor to RGB tensor.
+        """Decode a train-ID tensor into an RGB tensor using the palette.
+
+        Pixels with value ``255`` are treated as void and mapped to the
+        last palette entry (black). The returned tensor contains RGB color
+        values for each pixel according to the dataset palette.
 
         Args:
-            target (torch.Tensor): Target RGB tensor.
+            target: Integer tensor of train IDs.
 
         Returns:
-            Image.Image: Decoded target.
+            A tensor of RGB colors with shape ``(H, W, 3)`` mapped from train IDs.
         """
         target[target == 255] = -1
         return self.train_id_to_color[target]
 
     def __getitem__(self, index: int) -> tuple[Any, Any]:
-        """Get the sample at the given index.
+        """Return the sample at the given index.
 
         Args:
-            index (int): Index
+            index: Integer index of the sample to retrieve.
 
         Returns:
-            tuple: (image, target) where target is a tuple of all target types if ``target_type``
-                is a list with more than one item. Otherwise, target is a json object if
-                ``target_type="polygon"``, else the image segmentation.
+            ``(image, target)`` tuple: If ``target_type`` contains multiple
+            types, ``target`` is a tuple with each corresponding target. If
+            ``target_type=="polygon"``, the target is a JSON object; for
+            semantic targets the returned object is a mask or ``tv_tensors.Mask``.
         """
         image = tv_tensors.Image(Image.open(self.images[index]).convert("RGB"))
 
@@ -154,13 +157,22 @@ class Cityscapes(TVCityscapes):
         return image, target
 
     def plot_sample(self, index: int, ax: _AX_TYPE | None = None) -> _PLOT_OUT_TYPE:
-        """Plot a sample from the dataset.
+        """Plot a dataset sample (image and decoded target) for inspection.
+
+        Intended behavior: load the sample at ``index``, decode the target
+        to RGB using :attr:`train_id_to_color`, and render the image and
+        overlay/target on the provided axis. If ``ax`` is ``None``, a new
+        matplotlib figure and axis should be created.
 
         Args:
-            index: The index of the sample to plot.
-            ax: Optional matplotlib axis to plot on.
+            index: Index of the sample to plot.
+            ax: Optional matplotlib axis to draw on. Defaults to ``None``.
 
         Returns:
-            The axis on which the sample was plotted.
+            A tuple ``(fig, ax)`` or the axis object used for plotting, depending on
+            the plotting utility in use.
+
+        Raises:
+            NotImplementedError: This plotting helper is not implemented yet.
         """
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError("plot_sample is not implemented yet.")

--- a/src/torch_uncertainty/datasets/utils.py
+++ b/src/torch_uncertainty/datasets/utils.py
@@ -13,9 +13,9 @@ def create_train_val_split(
     """Split a dataset for training and validation.
 
     Args:
-        dataset (Dataset): The dataset to be split.
-        val_split_rate (float): The amount of the original dataset to use as validation split.
-        val_transforms (Callable | None): The transformations to apply on the validation set.
+        dataset: The dataset to be split.
+        val_split_rate: The amount of the original dataset to use as validation split.
+        val_transforms: The transformations to apply on the validation set.
             Defaults to ``None``.
 
     Returns:
@@ -34,8 +34,8 @@ class TTADataset(Dataset):
         This is useful for test-time augmentation (TTA).
 
         Args:
-            dataset (Dataset): The dataset to be adapted for TTA.
-            num_augmentations (int): The number of augmentations to apply.
+            dataset: The dataset to be adapted for TTA.
+            num_augmentations: The number of augmentations to apply.
         """
         super().__init__()
         self.dataset = dataset

--- a/src/torch_uncertainty/layers/batch_ensemble.py
+++ b/src/torch_uncertainty/layers/batch_ensemble.py
@@ -28,23 +28,19 @@ class BatchLinear(nn.Module):
     ) -> None:
         r"""BatchEnsemble-style Linear layer.
 
-        Apply a linear transformation using BatchEnsemble method to the incoming
-        data.
+        Apply a linear transformation using the BatchEnsemble method to the
+        incoming data.
 
         .. math::
             y=(x\circ \widehat{r_{group}})W^{T}\circ \widehat{s_{group}} + \widehat{b}
 
         Args:
-            in_features (int): Number of input features.
-            out_features (int): Number of output features.
-            num_estimators (int): Number of estimators in the ensemble, referred as
-                :math:`M`.
-            bias (bool): If ``True``, adds a learnable bias to the
-                output. Defaults to ``True``.
-            device (Any): Device to use for the parameters and
-                buffers of this module. Defaults to ``None``.
-            dtype (Any): Data type to use for the parameters and
-                buffers of this module. Defaults to ``None``.
+            in_features: Number of input features.
+            out_features: Number of output features.
+            num_estimators: Number of estimators in the ensemble (``M``).
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            device: Device to use for parameters and buffers. Defaults to ``None``.
+            dtype: Data type to use for parameters and buffers. Defaults to ``None``.
 
         Reference:
             Introduced by the paper `BatchEnsemble: An Alternative Approach to
@@ -60,14 +56,12 @@ class BatchLinear(nn.Module):
                 :math:`(H_{out}, H_{in})` shared between the estimators. The values
                 are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`,
                 where :math:`k = \frac{1}{H_{in}}`.
-            r_group: The learnable matrice of shape :math:`(M, H_{in})` where each row
-                consist of the vector :math:`r_{i}` corresponding to the
-                :math:`i^{th}` ensemble member. The values are initialized from
-                :math:`\mathcal{N}(1.0, 0.5)`.
-            s_group: The learnable matrice of shape :math:`(M, H_{out})` where each row
-                consist of the vector :math:`s_{i}` corresponding to the
-                :math:`i^{th}` ensemble member. The values are initialized from
-                :math:`\mathcal{N}(1.0, 0.5)`.
+            r_group: Learnable matrix of shape :math:`(M, H_{in})` where each row
+                is the vector :math:`r_{i}` corresponding to the :math:`i^{th}`
+                ensemble member. Initialized from :math:`\mathcal{N}(1.0, 0.5)`.
+            s_group: Learnable matrix of shape :math:`(M, H_{out})` where each row
+                is the vector :math:`s_{i}` corresponding to the :math:`i^{th}`
+                ensemble member. Initialized from :math:`\mathcal{N}(1.0, 0.5)`.
             bias: The learnable bias (:math:`b`) of shape :math:`(M, H_{out})`
                 where each row corresponds to the bias of the :math:`i^{th}`
                 ensemble member. If :attr:`bias` is ``True``, the values are
@@ -124,8 +118,8 @@ class BatchLinear(nn.Module):
         r"""Create a BatchEnsemble-style Linear layer from an existing Linear layer.
 
         Args:
-            linear (nn.Linear): The Linear layer to convert.
-            num_estimators (int): Number of ensemble members.
+            linear: The Linear layer to convert.
+            num_estimators: Number of ensemble members.
 
         Returns:
             BatchLinear: The converted BatchEnsemble-style Linear layer.
@@ -219,7 +213,7 @@ class BatchConv1d(nn.Module):
     ) -> None:
         r"""BatchEnsemble-style Conv1d layer.
 
-        Applies a 1d convolution over an input signal composed of several input
+        Apply a 1d convolution over an input signal composed of several input
         planes using BatchEnsemble method to the incoming data.
 
         In the simplest case, the output value of the layer with input size
@@ -244,24 +238,19 @@ class BatchConv1d(nn.Module):
             <https://www.tensorflow.org>`_.
 
         Args:
-            in_channels (int): Number of channels in the input images.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int): Size of the convolving kernel.
-            num_estimators (int): Number of estimators in the ensemble referred as
-                :math:`M` here.
-            stride (int): Stride of the convolution. Defaults to
-                ``1``.
-            padding (int or str): Padding added to all four sides
-                of the input. Defaults to ``0``.
-            dilation (int): Spacing between kernel elements.
-                Defaults to ``1``.
-            groups (int): Number of blocked connections from input
+            in_channels: Number of channels in the input images.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            num_estimators: Number of estimators in the ensemble referred as :math:`M` here.
+            stride: Stride of the convolution. Defaults to ``1``.
+            padding: Padding added to all four sides of the input. Defaults to ``0``.
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connections from input
                 channels to output channels. Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the
-                output. Defaults to ``True``.
-            device (Any): Device to use for the parameters and
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            device: Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any): Data type to use for the parameters and
+            dtype: Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
 
         Attributes:
@@ -348,8 +337,8 @@ class BatchConv1d(nn.Module):
         r"""Create a BatchEnsemble-style Conv1d layer from an existing Conv1d layer.
 
         Args:
-            conv1d (nn.Conv1d): The Conv1d layer to convert.
-            num_estimators (int): Number of ensemble members.
+            conv1d: The Conv1d layer to convert.
+            num_estimators: Number of ensemble members.
 
         Returns:
             BatchConv1d: The converted BatchEnsemble-style Conv1d layer.
@@ -451,7 +440,7 @@ class BatchConv2d(nn.Module):
     ) -> None:
         r"""BatchEnsemble-style Conv2d layer.
 
-        Applies a 2d convolution over an input signal composed of several input
+        Apply a 2d convolution over an input signal composed of several input
         planes using BatchEnsemble method to the incoming data.
 
         In the simplest case, the output value of the layer with input size
@@ -476,24 +465,24 @@ class BatchConv2d(nn.Module):
             <https://www.tensorflow.org>`_.
 
         Args:
-            in_channels (int): Number of channels in the input images.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            num_estimators (int): Number of estimators in the ensemble referred as
+            in_channels: Number of channels in the input images.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            num_estimators: Number of estimators in the ensemble referred as
                 :math:`M` here.
-            stride (int or tuple): Stride of the convolution. Defaults to
+            stride: Stride of the convolution. Defaults to
                 ``1``.
             padding (int, tuple or str): Padding added to all four sides
                 of the input. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements.
+            dilation: Spacing between kernel elements.
                 Defaults to ``1``.
-            groups (int): Number of blocked connections from input
+            groups: Number of blocked connections from input
                 channels to output channels. Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the
+            bias: If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            device (Any): Device to use for the parameters and
+            device: Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any): Data type to use for the parameters and
+            dtype: Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
 
         Attributes:
@@ -585,8 +574,8 @@ class BatchConv2d(nn.Module):
         r"""Create a BatchEnsemble-style Conv2d layer from an existing Conv2d layer.
 
         Args:
-            conv2d (nn.Conv2d): The Conv2d layer to convert.
-            num_estimators (int): Number of ensemble members.
+            conv2d: The Conv2d layer to convert.
+            num_estimators: Number of ensemble members.
 
         Returns:
             BatchConv2d: The converted BatchEnsemble-style Conv2d layer.
@@ -668,26 +657,25 @@ class BatchConvTranspose2d(nn.Module):
         r"""BatchEnsemble-style ConvTranspose2d layer.
 
         Args:
-            in_channels (int): Number of channels in the input images.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (_size_2_t): Size of the convolving kernel.
-            num_estimators (int): Number of estimators in the ensemble referred as
+            in_channels: Number of channels in the input images.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            num_estimators: Number of estimators in the ensemble referred as
                 :math:`M` here.
-            stride (_size_2_t): Stride of the convolution. Defaults to ``1``.
-            padding (_size_2_t): ``dilation * (kernel_size - 1) - padding`` zero-padding
+            stride: Stride of the convolution. Defaults to ``1``.
+            padding: ``dilation * (kernel_size - 1) - padding`` zero-padding
                 will be added to both sides of each dimension in the input. Defaults to ``0``.
-            output_padding (_size_2_t): Additional size added to one side
+            output_padding: Additional size added to one side
                 of each dimension in the output shape. Defaults to ``0``.
-            groups (int): Number of blocked connections from input channels to output
-                channels. Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to
-                ``True``.
-            dilation (_size_2_t): Spacing between kernel elements. Defaults to ``1``.
-            padding_mode (str): Padding mode for the convolution. Defaults to ``"zeros"``.
-            device (Any): Device to use for the parameters and
-                buffers of this module. Defaults to ``None``.
-            dtype (Any): Data type to use for the parameters and
-                buffers of this module. Defaults to ``None``.
+            groups: Number of blocked connections from input channels to output channels.
+                Defaults to ``1``.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            padding_mode: Padding mode for the convolution. Defaults to ``"zeros"``.
+            device: Device to use for the parameters and buffers of this module.
+                Defaults to ``None``.
+            dtype: Data type to use for the parameters and buffers of this module.
+                Defaults to ``None``.
         """
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -730,8 +718,8 @@ class BatchConvTranspose2d(nn.Module):
         r"""Create a BatchEnsemble-style ConvTranspose2d layer from an existing ConvTranspose2d layer.
 
         Args:
-            conv_transpose2d (nn.ConvTranspose2d): The ConvTranspose2d layer to convert.
-            num_estimators (int): Number of ensemble members.
+            conv_transpose2d: The ConvTranspose2d layer to convert.
+            num_estimators: Number of ensemble members.
 
         Returns:
             BatchConvTranspose2d: The converted BatchEnsemble-style ConvTranspose2d layer.

--- a/src/torch_uncertainty/layers/bayesian/bayes_conv.py
+++ b/src/torch_uncertainty/layers/bayesian/bayes_conv.py
@@ -19,6 +19,7 @@ __all__ = ["BayesConv1d", "BayesConv2d", "BayesConv3d"]
 
 
 class _BayesConvNd(Module):
+    # TODO: make abstract
     __constants__ = [
         "stride",
         "padding",
@@ -35,7 +36,8 @@ class _BayesConvNd(Module):
     def _conv_forward(
         self, inputs: Tensor, weight: Tensor, bias: Tensor | None
     ) -> Tensor:  # coverage: ignore
-        ...
+        """Run the convolution forward pass for a concrete Bayesian layer implementation."""
+        raise NotImplementedError
 
     in_channels: int
     _reversed_padding_repeated_twice: list[int]

--- a/src/torch_uncertainty/layers/bayesian/bayes_linear.py
+++ b/src/torch_uncertainty/layers/bayesian/bayes_linear.py
@@ -31,17 +31,17 @@ class BayesLinear(nn.Module):
         """Bayesian Linear Layer with Mixture of Normals prior and Normal posterior.
 
         Args:
-            in_features (int): Number of input features
-            out_features (int): Number of output features
-            prior_sigma_1 (float): Standard deviation of the first prior distribution. Defaults to ``0.1``.
-            prior_sigma_2 (float): Standard deviation of the second prior distribution. Defaults to ``0.4``.
-            prior_pi (float): Mixture control variable. Defaults to ``1``.
-            mu_init (float): Initial mean of the posterior distribution. Defaults to ``0.0``.
-            sigma_init (float): Initial standard deviation of the posterior distribution. Defaults to ``-7.0``.
-            frozen (bool): Whether to freeze the posterior distribution. Defaults to ``False``.
-            bias (bool): Whether to use a bias term. Defaults to ``True.``
-            device (optional): Device to use. Defaults to ``None``.
-            dtype (optional): Data type to use. Defaults to ``None``.
+            in_features: Number of input features
+            out_features: Number of output features
+            prior_sigma_1: Standard deviation of the first prior distribution. Defaults to ``0.1``.
+            prior_sigma_2: Standard deviation of the second prior distribution. Defaults to ``0.4``.
+            prior_pi: Mixture control variable. Defaults to ``1``.
+            mu_init: Initial mean of the posterior distribution. Defaults to ``0.0``.
+            sigma_init: Initial standard deviation of the posterior distribution. Defaults to ``-7.0``.
+            frozen: Whether to freeze the posterior distribution. Defaults to ``False``.
+            bias: Whether to use a bias term. Defaults to ``True.``
+            device: Device to use. Defaults to ``None``.
+            dtype: Data type to use. Defaults to ``None``.
 
         References:
             [1] `Blundell, Charles, et al. "Weight uncertainty in neural networks", in ICML 2015

--- a/src/torch_uncertainty/layers/bayesian/lpbnn.py
+++ b/src/torch_uncertainty/layers/bayesian/lpbnn.py
@@ -51,14 +51,14 @@ class LPBNNLinear(nn.Module):
         """LPBNN-style linear layer.
 
         Args:
-            in_features (int): Number of input features.
-            out_features (int): Number of output features.
-            num_estimators (int): Number of models to sample from.
-            hidden_size (int): Size of the hidden layer. Defaults to ``32``.
-            std_factor (float): Factor to multiply the standard deviation of the latent noise. Defaults to ``1e-2``.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            device (torch.device): Device on which the layer is stored. Defaults to ``None``.
-            dtype (torch.dtype): Data type of the layer. Defaults to ``None``.
+            in_features: Number of input features.
+            out_features: Number of output features.
+            num_estimators: Number of models to sample from.
+            hidden_size: Size of the hidden layer. Defaults to ``32``.
+            std_factor: Factor to multiply the standard deviation of the latent noise. Defaults to ``1e-2``.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            device: Device on which the layer is stored. Defaults to ``None``.
+            dtype: Data type of the layer. Defaults to ``None``.
 
         References:
             [1] `Encoding the latent posterior of Bayesian Neural Networks for uncertainty quantification
@@ -167,20 +167,20 @@ class LPBNNConv2d(nn.Module):
         """LPBNN-style 2D convolutional layer.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            num_estimators (int): Number of models to sample from.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            stride (int or tuple): Stride of the convolution. Default: ``1``.
-            padding (int or tuple): Zero-padding added to both sides of the input. Default: ``0``.
-            groups (int): Number of blocked connections from input channels to output channels. Default: ``1``.
-            hidden_size (int): Size of the hidden layer. Defaults to ``32``.
-            std_factor (float): Factor to multiply the standard deviation of the latent noise. Defaults to ``1e-2``.
-            gamma (bool): If ``True``, adds a learnable gamma to the output. Defaults to ``True``.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str): 'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'.
-            device (torch.device): Device on which the layer is stored. Defaults to ``None``.
-            dtype (torch.dtype): Data type of the layer. Defaults to ``None``.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            num_estimators: Number of models to sample from.
+            kernel_size: Size of the convolving kernel.
+            stride: Stride of the convolution. Default: ``1``.
+            padding: Zero-padding added to both sides of the input. Default: ``0``.
+            groups: Number of blocked connections from input channels to output channels. Default: ``1``.
+            hidden_size: Size of the hidden layer. Defaults to ``32``.
+            std_factor: Factor to multiply the standard deviation of the latent noise. Defaults to ``1e-2``.
+            gamma: If ``True``, adds a learnable gamma to the output. Defaults to ``True``.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode: 'zeros', 'reflect', 'replicate' or 'circular'. Default: 'zeros'.
+            device: Device on which the layer is stored. Defaults to ``None``.
+            dtype: Data type of the layer. Defaults to ``None``.
 
         References:
             [1] `Encoding the latent posterior of Bayesian Neural Networks for uncertainty quantification

--- a/src/torch_uncertainty/layers/bayesian/sampler.py
+++ b/src/torch_uncertainty/layers/bayesian/sampler.py
@@ -53,9 +53,9 @@ class CenteredGaussianMixture(nn.Module):
         """Create a mixture of two centered Gaussian distributions.
 
         Args:
-            sigma_1 (float): Standard deviation of the first Gaussian.
-            sigma_2 (float): Standard deviation of the second Gaussian.
-            pi (float): Mixing coefficient.
+            sigma_1: Standard deviation of the first Gaussian.
+            sigma_2: Standard deviation of the second Gaussian.
+            pi: Mixing coefficient.
         """
         super().__init__()
         self.register_buffer("pi", torch.tensor([pi, 1 - pi]))

--- a/src/torch_uncertainty/layers/channel_layer_norm.py
+++ b/src/torch_uncertainty/layers/channel_layer_norm.py
@@ -15,7 +15,17 @@ class ChannelLayerNorm(LayerNorm):
         device: torch.device | str | None = None,
         dtype: torch.dtype | str | None = None,
     ) -> None:
-        """Channel-wise layer-norm."""
+        """Channel-wise Layer Normalization.
+
+        Args:
+            normalized_shape: Input shape from an expected input of size
+                ``(N, C, ...)``. Defaults to provided value.
+            eps: A value added to the denominator for numerical stability. Defaults to ``1e-5``.
+            elementwise_affine: If ``True``, this module has learnable per-channel affine parameters. Defaults to ``True``.
+            bias: Included for API consistency; LayerNorm controls affine via ``elementwise_affine``. Defaults to ``True``.
+            device: Device for parameters. Defaults to ``None``.
+            dtype: Data type for parameters. Defaults to ``None``.
+        """
         super().__init__(normalized_shape, eps, elementwise_affine, bias, device, dtype)
         self.cback = ChannelBack()
         self.cfront = ChannelFront()

--- a/src/torch_uncertainty/layers/distributions.py
+++ b/src/torch_uncertainty/layers/distributions.py
@@ -43,19 +43,18 @@ def get_dist_conv_layer(dist_family: str) -> type[nn.Module]:
 
 
 class _ExpandOutputLinear(nn.Module, ABC):
-    """Abstract class for expanding the output of any nn.Module using an `out_features` argument.
-
-    Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        num_params (int): The number of parameters to output. For instance, the normal distribution
-            has 2 parameters (loc and scale).
-        **layer_args: Additional arguments for the base layer.
-    """
-
     def __init__(
         self, base_layer: type[nn.Module], event_dim: int, num_params: int, **layer_args
     ) -> None:
+        """Abstract class for expanding the output of any nn.Module using an `out_features` argument.
+
+        Args:
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            num_params: The number of parameters to output. For instance, the normal distribution
+                has 2 parameters (loc and scale).
+            **layer_args: Additional arguments for the base layer.
+        """
         if "out_features" not in inspect.getfullargspec(base_layer.__init__).args:
             raise ValueError(f"{base_layer.__name__} does not have an `out_features` argument.")
 
@@ -68,23 +67,22 @@ class _ExpandOutputLinear(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, x: Tensor) -> dict[str, Tensor]:
-        pass
+        """Expand the base layer output into distribution parameters."""
 
 
 class _ExpandOutputConvNd(nn.Module, ABC):
-    """Abstract class for expanding the output of any nn.Module using an `out_channels` argument.
-
-    Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        num_params (int): The number of parameters to output. For instance, the normal distribution
-            has 2 parameters (loc and scale).
-        **layer_args: Additional arguments for the base layer.
-    """
-
     def __init__(
         self, base_layer: type[nn.Module], event_dim: int, num_params: int, **layer_args
     ) -> None:
+        """Abstract class for expanding the output of any nn.Module using an `out_channels` argument.
+
+        Args:
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            num_params: The number of parameters to output. For instance, the normal distribution
+                has 2 parameters (loc and scale).
+            **layer_args: Additional arguments for the base layer.
+        """
         if "out_channels" not in inspect.getfullargspec(base_layer.__init__).args:
             raise ValueError(f"{base_layer.__name__} does not have an `out_channels` argument.")
 
@@ -97,19 +95,10 @@ class _ExpandOutputConvNd(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, x: Tensor) -> dict[str, Tensor]:
-        pass
+        """Expand the base layer output into distribution parameters."""
 
 
 class _LocScaleLinear(_ExpandOutputLinear):
-    """Base Linear layer for any distribution with loc and scale parameters.
-
-    Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
-        **layer_args: Additional arguments for the base layer.
-    """
-
     def __init__(
         self,
         base_layer: type[nn.Module],
@@ -117,6 +106,14 @@ class _LocScaleLinear(_ExpandOutputLinear):
         min_scale: float = 1e-6,
         **layer_args,
     ) -> None:
+        """Base Linear layer for any distribution with loc and scale parameters.
+
+        Args:
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_scale: The minimal value of the scale parameter.
+            **layer_args: Additional arguments for the base layer.
+        """
         super().__init__(
             base_layer=base_layer,
             event_dim=event_dim,
@@ -135,15 +132,6 @@ class _LocScaleLinear(_ExpandOutputLinear):
 
 
 class _LocScaleConvNd(_ExpandOutputConvNd):
-    """Base Convolutional layer for any distribution with loc and scale parameters.
-
-    Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
-        **layer_args: Additional arguments for the base layer.
-    """
-
     def __init__(
         self,
         base_layer: type[nn.Module],
@@ -151,6 +139,14 @@ class _LocScaleConvNd(_ExpandOutputConvNd):
         min_scale: float = 1e-6,
         **layer_args,
     ) -> None:
+        """Base Convolutional layer for any distribution with loc and scale parameters.
+
+        Args:
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_scale: The minimal value of the scale parameter.
+            **layer_args: Additional arguments for the base layer.
+        """
         super().__init__(
             base_layer=base_layer,
             event_dim=event_dim,
@@ -172,9 +168,9 @@ class NormalLinear(_LocScaleLinear):
     r"""Normal Distribution Linear Density Layer.
 
     Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
+        base_layer: The base layer class.
+        event_dim: The number of event dimensions.
+        min_scale: The minimal value of the scale parameter.
         **layer_args: Additional arguments for the base layer.
 
     Shape:
@@ -194,16 +190,16 @@ class NormalConvNd(_LocScaleConvNd):
     r"""Normal Distribution Convolutional Density Layer.
 
     Args:
-        in_channels (int): The number of input channels.
-        out_channels (int): The number of event channels.
-        kernel_size (int | tuple[int]): The size of the convolutional kernel.
-        stride (int | tuple[int]): The stride of the convolution.
-        padding (int | tuple[int]): The padding of the convolution.
-        dilation (int | tuple[int]): The dilation of the convolution.
-        groups (int): The number of groups in the convolution.
-        min_scale (float): The minimal value of the scale parameter.
-        device (torch.device): The device where the layer is stored.
-        dtype (torch.dtype): The datatype of the layer.
+        in_channels: The number of input channels.
+        out_channels: The number of event channels.
+        kernel_size: The size of the convolutional kernel.
+        stride: The stride of the convolution.
+        padding: The padding of the convolution.
+        dilation: The dilation of the convolution.
+        groups: The number of groups in the convolution.
+        min_scale: The minimal value of the scale parameter.
+        device: The device where the layer is stored.
+        dtype: The datatype of the layer.
 
     Shape:
         - Input: :math:`(N, C_{in}, \ast)` where :math:`\ast` means any number of dimensions and
@@ -221,9 +217,9 @@ class LaplaceLinear(_LocScaleLinear):
     r"""Laplace Distribution Linear Density Layer.
 
     Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
+        base_layer: The base layer class.
+        event_dim: The number of event dimensions.
+        min_scale: The minimal value of the scale parameter.
         **layer_args: Additional arguments for the base layer.
 
     Shape:
@@ -243,16 +239,16 @@ class LaplaceConvNd(_LocScaleConvNd):
     r"""Laplace Distribution Convolutional Density Layer.
 
     Args:
-        in_channels (int): The number of input channels.
-        out_channels (int): The number of event channels.
-        kernel_size (int | tuple[int]): The size of the convolutional kernel.
-        stride (int | tuple[int]): The stride of the convolution.
-        padding (int | tuple[int]): The padding of the convolution.
-        dilation (int | tuple[int]): The dilation of the convolution.
-        groups (int): The number of groups in the convolution.
-        min_scale (float): The minimal value of the scale parameter.
-        device (torch.device): The device where the layer is stored.
-        dtype (torch.dtype): The datatype of the layer.
+        in_channels: The number of input channels.
+        out_channels: The number of event channels.
+        kernel_size: The size of the convolutional kernel.
+        stride: The stride of the convolution.
+        padding: The padding of the convolution.
+        dilation: The dilation of the convolution.
+        groups: The number of groups in the convolution.
+        min_scale: The minimal value of the scale parameter.
+        device: The device where the layer is stored.
+        dtype: The datatype of the layer.
 
     Shape:
         - Input: :math:`(N, C_{in}, \ast)` where :math:`\ast` means any number of dimensions and
@@ -270,9 +266,9 @@ class CauchyLinear(_LocScaleLinear):
     r"""Cauchy Distribution Linear Density Layer.
 
     Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
+        base_layer: The base layer class.
+        event_dim: The number of event dimensions.
+        min_scale: The minimal value of the scale parameter.
         **layer_args: Additional arguments for the base layer.
 
     Shape:
@@ -292,16 +288,16 @@ class CauchyConvNd(_LocScaleConvNd):
     r"""Cauchy Distribution Convolutional Density Layer.
 
     Args:
-        in_channels (int): The number of input channels.
-        out_channels (int): The number of event channels.
-        kernel_size (int | tuple[int]): The size of the convolutional kernel.
-        stride (int | tuple[int]): The stride of the convolution.
-        padding (int | tuple[int]): The padding of the convolution.
-        dilation (int | tuple[int]): The dilation of the convolution.
-        groups (int): The number of groups in the convolution.
-        min_scale (float): The minimal value of the scale parameter.
-        device (torch.device): The device where the layer is stored.
-        dtype (torch.dtype): The datatype of the layer.
+        in_channels: The number of input channels.
+        out_channels: The number of event channels.
+        kernel_size: The size of the convolutional kernel.
+        stride: The stride of the convolution.
+        padding: The padding of the convolution.
+        dilation: The dilation of the convolution.
+        groups: The number of groups in the convolution.
+        min_scale: The minimal value of the scale parameter.
+        device: The device where the layer is stored.
+        dtype: The datatype of the layer.
 
     Shape:
         - Input: :math:`(N, C_{in}, \ast)` where :math:`\ast` means any number of dimensions and
@@ -319,9 +315,9 @@ class GammaLinear(_ExpandOutputLinear):
     """Gamma distribution Linear Density Layer.
 
     Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
+        base_layer: The base layer class.
+        event_dim: The number of event dimensions.
+        min_scale: The minimal value of the scale parameter.
         **layer_args: Additional arguments for the base layer.
 
     Note:
@@ -360,9 +356,9 @@ class GammaConvNd(_ExpandOutputConvNd):
     """Gamma distribution Convolutional Density Layer.
 
     Args:
-        base_layer (type[nn.Module]): The base layer class.
-        event_dim (int): The number of event dimensions.
-        min_scale (float): The minimal value of the scale parameter.
+        base_layer: The base layer class.
+        event_dim: The number of event dimensions.
+        min_scale: The minimal value of the scale parameter.
         **layer_args: Additional arguments for the base layer.
 
     Note:
@@ -406,11 +402,11 @@ class StudentTLinear(_ExpandOutputLinear):
         r"""Student's T-Distribution Linear Density Layer.
 
         Args:
-            base_layer (type[nn.Module]): The base layer class.
-            event_dim (int): The number of event dimensions.
-            min_scale (float): The minimal value of the scale parameter.
-            min_df (float): The minimal value of the degrees of freedom parameter.
-            fixed_df (float): If not None, the degrees of freedom parameter is fixed to this value.
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_scale: The minimal value of the scale parameter.
+            min_df: The minimal value of the degrees of freedom parameter.
+            fixed_df: If not None, the degrees of freedom parameter is fixed to this value.
                 Otherwise, it is learned.
             **layer_args: Additional arguments for the base layer.
 
@@ -465,11 +461,11 @@ class StudentTConvNd(_ExpandOutputConvNd):
         r"""Student's T-Distribution Convolutional Density Layer.
 
         Args:
-            base_layer (type[nn.Module]): The base layer class.
-            event_dim (int): The number of event dimensions.
-            min_scale (float): The minimal value of the scale parameter.
-            min_df (float): The minimal value of the degrees of freedom parameter.
-            fixed_df (float): If not None, the degrees of freedom parameter is fixed to this value.
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_scale: The minimal value of the scale parameter.
+            min_df: The minimal value of the degrees of freedom parameter.
+            fixed_df: If not None, the degrees of freedom parameter is fixed to this value.
                 Otherwise, it is learned.
             **layer_args: Additional arguments for the base layer.
 
@@ -523,11 +519,11 @@ class NormalInverseGammaLinear(_ExpandOutputLinear):
         r"""Normal-Inverse-Gamma Distribution Linear Density Layer.
 
         Args:
-            base_layer (type[nn.Module]): The base layer class.
-            event_dim (int): The number of event dimensions.
-            min_lmbda (float): The minimal value of the :math:`\lambda` parameter.
-            min_alpha (float): The minimal value of the :math:`\alpha` parameter.
-            min_beta (float): The minimal value of the :math:`\beta` parameter.
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_lmbda: The minimal value of the :math:`\lambda` parameter.
+            min_alpha: The minimal value of the :math:`\alpha` parameter.
+            min_beta: The minimal value of the :math:`\beta` parameter.
             **layer_args: Additional arguments for the base layer.
 
         Shape:
@@ -591,11 +587,11 @@ class NormalInverseGammaConvNd(_ExpandOutputConvNd):
         r"""Normal-Inverse-Gamma Distribution Convolutional Density Layer.
 
         Args:
-            base_layer (type[nn.Module]): The base layer class.
-            event_dim (int): The number of event dimensions.
-            min_lmbda (float): The minimal value of the :math:`\lambda` parameter.
-            min_alpha (float): The minimal value of the :math:`\alpha` parameter.
-            min_beta (float): The minimal value of the :math:`\beta` parameter.
+            base_layer: The base layer class.
+            event_dim: The number of event dimensions.
+            min_lmbda: The minimal value of the :math:`\lambda` parameter.
+            min_alpha: The minimal value of the :math:`\alpha` parameter.
+            min_beta: The minimal value of the :math:`\beta` parameter.
             **layer_args: Additional arguments for the base layer.
 
         Shape:

--- a/src/torch_uncertainty/layers/filter_response_norm.py
+++ b/src/torch_uncertainty/layers/filter_response_norm.py
@@ -14,11 +14,11 @@ class _FilterResponseNormNd(nn.Module):
         """N-dimensional Filter Response Normalization layer.
 
         Args:
-            dimension (int): Dimension of the input tensor.
-            num_channels (int): Number of channels.
-            eps (float): Epsilon. Defaults to 1e-6.
-            device (optional): Device. Defaults to None.
-            dtype (optional): Data type. Defaults to None.
+            dimension: Dimension of the input tensor.
+            num_channels: Number of channels.
+            eps: Epsilon. Defaults to ``1e-6``.
+            device: Device. Defaults to ``None``.
+            dtype: Data type. Defaults to ``None``.
         """
         super().__init__()
         if dimension < 1 or not isinstance(dimension, int):
@@ -50,10 +50,10 @@ class FilterResponseNorm1d(_FilterResponseNormNd):
         """1-dimensional Filter Response Normalization layer.
 
         Args:
-            num_channels (int): Number of channels.
-            eps (float): Epsilon. Defaults to 1e-6.
-            device (optional): Device. Defaults to None.
-            dtype (optional): Data type. Defaults to None.
+            num_channels: Number of channels.
+            eps: Epsilon. Defaults to ``1e-6``.
+            device: Device. Defaults to ``None``.
+            dtype: Data type. Defaults to ``None``.
         """
         super().__init__(
             dimension=1,
@@ -69,10 +69,10 @@ class FilterResponseNorm2d(_FilterResponseNormNd):
         """2-dimensional Filter Response Normalization layer.
 
         Args:
-            num_channels (int): Number of channels.
-            eps (float): Epsilon. Defaults to 1e-6.
-            device (optional): Device. Defaults to None.
-            dtype (optional): Data type. Defaults to None.
+            num_channels: Number of channels.
+            eps: Epsilon. Defaults to ``1e-6``.
+            device: Device. Defaults to ``None``.
+            dtype: Data type. Defaults to ``None``.
         """
         super().__init__(
             dimension=2,
@@ -88,10 +88,10 @@ class FilterResponseNorm3d(_FilterResponseNormNd):
         """3-dimensional Filter Response Normalization layer.
 
         Args:
-            num_channels (int): Number of channels.
-            eps (float): Epsilon. Defaults to 1e-6.
-            device (optional): Device. Defaults to None.
-            dtype (optional): Data type. Defaults to None.
+            num_channels: Number of channels.
+            eps: Epsilon. Defaults to ``1e-6``.
+            device: Device. Defaults to ``None``.
+            dtype: Data type. Defaults to ``None``.
         """
         super().__init__(
             dimension=3,

--- a/src/torch_uncertainty/layers/functional/packed.py
+++ b/src/torch_uncertainty/layers/functional/packed.py
@@ -25,8 +25,8 @@ def packed_linear(
             - "sparse": uses a sparse weight tensor directly to apply the linear transformation.
             - "einsum": uses `torch.einsum` to apply the packed linear transformation.
             - "conv1d": uses `torch.nn.functional.conv1d` to apply the packed linear transformation.
-        rearrange (bool): _description_. Defaults to ``True``.
-        bias (Tensor | None): _description_. Defaults to ``None``.
+        rearrange: Whether to rearrange the inputs for the ``"conv1d"`` implementation. Defaults to ``True``.
+        bias: The projection bias. Defaults to ``None``.
 
     Returns:
         Tensor: Output tensor after applying the packed linear transform.

--- a/src/torch_uncertainty/layers/functional/packed.py
+++ b/src/torch_uncertainty/layers/functional/packed.py
@@ -17,19 +17,19 @@ def packed_linear(
         inputs (Tensor): :math:`(\star, \text{in\_features})` where :math:`\star` is any number of
             additional dimensions including none.
         weight (Tensor): :math:(\text{num\_groups}, \frac{\text{out\_features}}{\text{num\_groups}}, \frac{\text{in\_features}}{\text{num\_groups}})`.
-        num_groups (int): number of groups to split the input.
-        implementation (str): the implementation of the packed linear operation. Three
+        num_groups: number of groups to split the input.
+        implementation: the implementation of the packed linear operation. Three
             implementations are currently supported:
             - "full": creates a block diagonal matrix from the weight tensor and applies the linear
                 transformation using `torch.nn.functional.linear`.
             - "sparse": uses a sparse weight tensor directly to apply the linear transformation.
             - "einsum": uses `torch.einsum` to apply the packed linear transformation.
             - "conv1d": uses `torch.nn.functional.conv1d` to apply the packed linear transformation.
-        rearrange (bool): _description_. Defaults to True.
-        bias (Tensor | None): _description_. Defaults to None.
+        rearrange (bool): _description_. Defaults to ``True``.
+        bias (Tensor | None): _description_. Defaults to ``None``.
 
     Returns:
-        Tensor:
+        Tensor: Output tensor after applying the packed linear transform.
     """
     if implementation == "full":
         block_diag = torch.block_diag(*weight)
@@ -206,7 +206,7 @@ def packed_multi_head_attention_forward(  # noqa: D417
                        value sequences at dim=1.
         dropout_p: probability of an element to be zeroed.
         out_proj_weight, out_proj_bias: the output projection weight and bias.
-        implementation (str): the implementation of the packed linear operation. Three
+        implementation: the implementation of the packed linear operation. Three
             implementations are currently supported:
             - ``"full"``: creates a block diagonal matrix from the weight tensor and applies the
                 linear transformation using `torch.nn.functional.linear`.

--- a/src/torch_uncertainty/layers/masksembles.py
+++ b/src/torch_uncertainty/layers/masksembles.py
@@ -10,15 +10,14 @@ from torch.nn.common_types import _size_2_t
 
 def _generate_masks(m: int, n: int, s: float) -> np.ndarray:
     """Generates set of binary masks with properties defined by n, m, s params.
-    Results of this function are stochastic, that is, calls with the same sets
-    of arguments might generate outputs of different shapes. Check
-    generate_masks and generation_wrapper function for more deterministic
-    behaviour.
+    Results of this function are stochastic: repeated calls with the same
+    arguments may produce different outputs. Use :func:`generate_masks` and
+    :func:`generation_wrapper` for more deterministic behaviour.
 
     Args:
-        m (int): Number of ones in each mask.
-        n (int): Number of masks in the set.
-        s (float): Scale param controls overlap of generated masks.
+        m: Number of ones in each mask.
+        n: Number of masks in the set.
+        s: Scale parameter controlling overlap of generated masks.
 
     Returns:
         np.ndarray: Matrix of binary vectors.
@@ -39,18 +38,19 @@ def _generate_masks(m: int, n: int, s: float) -> np.ndarray:
 
 
 def generate_masks(m: int, n: int, s: float) -> np.ndarray:
-    """Generates set of binary masks with properties defined by n, m, s params
-    Resulting masks are required to have fixed features size.
-    Since process of masks generation is stochastic therefore function
-    evaluates _generate_masks multiple times till expected size is acquired.
+    """Generate a set of binary masks with properties defined by ``m``, ``n``, ``s``.
+
+    The function repeatedly calls :func:`_generate_masks` until the resulting
+    masks match the expected feature size. The process is stochastic, so
+    repetition ensures a correct-sized output.
 
     Args:
-        m (int): number of ones in each mask
-        n (int): number of masks in the set
-        s (float): scale param controls overlap of generated masks
+        m: Number of ones in each mask.
+        n: Number of masks in the set.
+        s: Scale parameter controlling overlap of generated masks.
 
     Returns:
-        np.ndarray: matrix of binary vectors
+        np.ndarray: Matrix of binary vectors.
     """
     masks = _generate_masks(m, n, s)
     # hardcoded formula for expected size, check reference
@@ -61,37 +61,35 @@ def generate_masks(m: int, n: int, s: float) -> np.ndarray:
 
 
 def generation_wrapper(c: int, n: int, scale: float) -> np.ndarray:
-    """Generates set of binary masks with properties defined by c, n, scale
-    params. Allows to generate masks sets with predefined features number c.
-    Particularly convenient to use in torch-like layers where one need to
-    define shapes inputs tensors beforehand.
+    """Generate binary masks with a target number of channel features.
+
+    This wrapper produces masks with an expected number of active features
+    equal to ``c``. It is convenient for torch-like layers where tensor
+    shapes must be known in advance.
 
     Args:
-        c (int): number of channels in generated masks.
-        n (int): number of masks in the set.
-        scale (float): scale param controls overlap of generated masks.
+        c: Number of channels in generated masks.
+        n: Number of masks in the set.
+        scale: Scale parameter controlling overlap of generated masks.
 
     Raises:
-        ValueError: If :attr:`c` < 10.
-        ValueError: If :attr:`s` > 0.6.
+        ValueError: If ``c < 10``.
+        ValueError: If ``scale > 6.0``.
 
     Returns:
         np.ndarray: matrix of binary vectors
     """
     if c < 10:
         raise ValueError(
-            "Masksembles approach couldn't be used in such setups where "
-            "number of channels is less then 10. Current value is "
-            f"(channels={c})."
-            "Please increase number of features in your layer or remove this "
-            "particular instance of Masksembles from your architecture."
+            "Masksembles cannot be used when the number of channels is less than 10. "
+            f"Current value is (channels={c}). Increase the number of features "
+            "or remove this Masksembles instance from your architecture."
         )
 
     if scale > 6.0:
         raise ValueError(
-            "Masksembles approach couldn't be used in such setups where "
-            "scale parameter is larger then 6. Current value is  "
-            f"(scale={scale})."
+            "Masksembles cannot be used when the scale parameter is larger than 6. "
+            f"Current value is (scale={scale})."
         )
 
     # inverse formula for number of active features in masks
@@ -173,14 +171,14 @@ class MaskedLinear(nn.Module):
         estimators (:attr:`num_estimators`) with a given :attr:`scale`.
 
         Args:
-            in_features (int): Number of input features of the linear layer.
-            out_features (int): Number of channels produced by the linear layer.
-            num_estimators (int): The number of estimators grouped in the layer.
-            scale (float): The scale parameter for the masks.
-            bias (bool): It ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            groups (int): Number of blocked connections from input channels to output channels. Defaults to ``1``.
-            device (Any): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
+            in_features: Number of input features of the linear layer.
+            out_features: Number of channels produced by the linear layer.
+            num_estimators: The number of estimators grouped in the layer.
+            scale: The scale parameter for the masks.
+            bias: It ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            groups: Number of blocked connections from input channels to output channels. Defaults to ``1``.
+            device: The desired device of returned tensor. Defaults to ``None``.
+            dtype: The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training
@@ -230,18 +228,18 @@ class MaskedConv2d(nn.Module):
         r"""Masksembles-style Conv2d layer.
 
         Args:
-            in_channels (int): Number of channels in the input image.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            num_estimators (int): Number of estimators in the ensemble.
-            scale (float): The scale parameter for the masks.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            num_estimators: Number of estimators in the ensemble.
+            scale: The scale parameter for the masks.
+            stride: Stride of the convolution. Defaults to ``1``.
             padding (int, tuple or str): Padding added to all four sides of the input. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            groups (int): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            device (Any): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            device: The desired device of returned tensor. Defaults to ``None``.
+            dtype: The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training
@@ -300,20 +298,20 @@ class MaskedConvTranspose2d(nn.Module):
         r"""Masksembles-style ConvTranspose2d layer.
 
         Args:
-            in_channels (int): Number of channels in the input image.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            num_estimators (int): Number of estimators in the ensemble.
-            scale (float): The scale parameter for the masks.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
-            padding (int or tuple): Padding added to all four sides of the input. Defaults to ``0``.
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            num_estimators: Number of estimators in the ensemble.
+            scale: The scale parameter for the masks.
+            stride: Stride of the convolution. Defaults to ``1``.
+            padding: Padding added to all four sides of the input. Defaults to ``0``.
             output_padding (int, tuple or str): Additional size added to one side of each dimension in the output shape. Defaults to ``0``.
-            groups (int): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            padding_mode (str): _description_. Defaults to ``'zeros'``.
-            device (Any): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
+            groups: Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            padding_mode: _description_. Defaults to ``'zeros'``.
+            device: The desired device of returned tensor. Defaults to ``None``.
+            dtype: The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training

--- a/src/torch_uncertainty/layers/mc_batch_norm.py
+++ b/src/torch_uncertainty/layers/mc_batch_norm.py
@@ -18,13 +18,12 @@ class _MCBatchNorm(_BatchNorm):
         """Base class for Monte-Carlo Batch Normalization layers.
 
         Args:
-            num_features (int): number of input features.
-            num_estimators (int): number of stochastic estimators.
-            eps (float): eps arg. for the core batch normalization. Defaults to ``0.00001``.
-            affine (bool): affine arg. for the core batch normalization. Defaults to `True`.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
-            device (Literal["cpu", "cuda"] | torch.device | None): device.
-                Defaults to ``None``
+            num_features: Number of input features.
+            num_estimators: Number of stochastic estimators.
+            eps: Epsilon argument for the core batch normalization. Defaults to ``0.00001``.
+            affine: Whether to include an affine transformation. Defaults to ``True``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
+            device: Device to use for the layer's parameters. Defaults to ``None``.
 
         Warning:
             The update of the batch statistics slightly differs from the method as worded in the
@@ -73,7 +72,7 @@ class _MCBatchNorm(_BatchNorm):
             predictions.
 
         Args:
-            input (Tensor): Input tensor.
+            input: Input tensor.
         """
         if not self.training:
             if self.accumulate:
@@ -89,7 +88,7 @@ class _MCBatchNorm(_BatchNorm):
         """Set the counter.
 
         Args:
-            counter (int): new value for the counter.
+            counter: New value for the counter.
         """
         self.counter = counter % self.num_estimators
 
@@ -105,12 +104,12 @@ class MCBatchNorm1d(_MCBatchNorm):
     """Monte Carlo Batch Normalization over a 2D or 3D (batched) input.
 
     Args:
-        num_features (int): Number of features.
-        num_estimators (int): Number of estimators.
-        eps (float): Epsilon. Defaults to ``0.00001``.
-        affine (bool): Affine. Defaults to ``True``.
-        device (optional): Device. Defaults to ``None``.
-        dtype (optional): Data type. Defaults to ``None``.
+        num_features: Number of features.
+        num_estimators: Number of estimators.
+        eps: Epsilon. Defaults to ``0.00001``.
+        affine: Whether to use a bias. Defaults to ``True``.
+        device: Device. Defaults to ``None``.
+        dtype: Data type. Defaults to ``None``.
 
     Warning:
         This layer should not be used out of the corresponding wrapper.
@@ -132,12 +131,12 @@ class MCBatchNorm2d(_MCBatchNorm):
     """Monte Carlo Batch Normalization over a 3D or 4D (batched) input.
 
     Args:
-        num_features (int): Number of features.
-        num_estimators (int): Number of estimators.
-        eps (float): Epsilon. Defaults to ``0.00001``.
-        affine (bool): Affine. Defaults to ``True``.
-        device (optional): Device. Defaults to ``None``.
-        dtype (optional): Data type. Defaults to ``None``.
+        num_features: Number of features.
+        num_estimators: Number of estimators.
+        eps: Epsilon. Defaults to ``0.00001``.
+        affine: Whether to use a bias. Defaults to ``True``.
+        device: Device. Defaults to ``None``.
+        dtype: Data type. Defaults to ``None``.
 
     Warning:
         This layer should not be used out of the corresponding wrapper.
@@ -159,12 +158,12 @@ class MCBatchNorm3d(_MCBatchNorm):
     """Monte Carlo Batch Normalization over a 4D or 5D (batched) input.
 
     Args:
-        num_features (int): Number of features.
-        num_estimators (int): Number of estimators.
-        eps (float): Epsilon. Defaults to ``0.00001``.
-        affine (bool): Affine. Defaults to ``True``.
-        device (optional): Device. Defaults to ``None``.
-        dtype (optional): Data type. Defaults to ``None``.
+        num_features: Number of features.
+        num_estimators: Number of estimators.
+        eps: Epsilon. Defaults to ``0.00001``.
+        affine: Whether to use a bias. Defaults to ``True``.
+        device: Device. Defaults to ``None``.
+        dtype: Data type. Defaults to ``None``.
 
     Warning:
         This layer should not be used out of the corresponding wrapper.

--- a/src/torch_uncertainty/layers/modules.py
+++ b/src/torch_uncertainty/layers/modules.py
@@ -5,6 +5,11 @@ from torch import nn
 
 class Identity(nn.Module):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """A trivial identity module that returns its inputs unchanged.
+
+        Useful as a placeholder in model construction where a module is
+        expected but no operation is required.
+        """
         super().__init__()
 
     def forward(self, *args) -> Any:

--- a/src/torch_uncertainty/layers/packed.py
+++ b/src/torch_uncertainty/layers/packed.py
@@ -15,9 +15,9 @@ def check_packed_parameters_consistency(alpha: float, gamma: int, num_estimators
     """Check the consistency of the parameters of the Packed-Ensembles layers.
 
     Args:
-        alpha (float): The width multiplier of the layer.
-        gamma (int): The number of groups in the ensemble.
-        num_estimators (int): The number of estimators in the ensemble.
+        alpha: The width multiplier of the layer.
+        gamma: The number of groups in the ensemble.
+        num_estimators: The number of estimators in the ensemble.
     """
     if alpha is None:
         raise ValueError("You must specify the value of the arg. `alpha`")
@@ -59,26 +59,26 @@ class PackedLinear(nn.Module):
         estimators (:attr:`num_estimators`).
 
         Args:
-            in_features (int): Number of input features of the linear layer.
-            out_features (int): Number of channels produced by the linear layer.
-            alpha (float): The width multiplier of the linear layer.
-            num_estimators (int): The number of estimators grouped in the layer.
-            gamma (int): Defaults to ``1``.
-            bias (bool): If ``True``, adds a learnable bias to the
+            in_features: Number of input features of the linear layer.
+            out_features: Number of channels produced by the linear layer.
+            alpha: The width multiplier of the linear layer.
+            num_estimators: The number of estimators grouped in the layer.
+            gamma: Defaults to ``1``.
+            bias: If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            first (bool): Whether this is the first layer of the
+            first: Whether this is the first layer of the
                 network. Defaults to ``False``.
-            last (bool): Whether this is the last layer of the network.
+            last: Whether this is the last layer of the network.
                 Defaults to ``False``.
-            implementation (str): The implementation to use. Available implementations:
+            implementation: The implementation to use. Available implementations:
 
                 - ``"conv1d"``: The conv1d implementation of the linear layer.
                 - ``"sparse"``: The sparse implementation of the linear layer.
                 - ``"full"``: The full implementation of the linear layer.
                 - ``"einsum"`` (default): The einsum implementation of the linear layer.
-            device (torch.device): The device to use for the layer's
+            device: The device to use for the layer's
                 parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's
+            dtype: The dtype to use for the layer's
                 parameters. Defaults to ``None``.
 
         Shape:
@@ -215,25 +215,25 @@ class PackedConv1d(nn.Module):
         r"""Packed-Ensembles-style Conv1d layer.
 
         Args:
-            in_channels (int): Number of channels in the input image.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            alpha (int): The channel multiplier of the convolutional layer.
-            num_estimators (int): Number of estimators in the ensemble.
-            gamma (int): Defaults to ``1``.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            alpha: The channel multiplier of the convolutional layer.
+            num_estimators: Number of estimators in the ensemble.
+            gamma: Defaults to ``1``.
+            stride: Stride of the convolution. Defaults to ``1``.
             padding (int, tuple or str): Padding added to both sides of the input. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            groups (int): Number of blocked connexions from input
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connexions from input
             channels to output channels for each estimator. Defaults to ``1``.
-            minimum_channels_per_group (int): Smallest possible number of channels per group.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
-            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device): The device to use for the layer's
+            minimum_channels_per_group: Smallest possible number of channels per group.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode: ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
+            first: Whether this is the first layer of the network. Defaults to ``False``.
+            last: Whether this is the last layer of the network. Defaults to ``False``.
+            device: The device to use for the layer's
             parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's
+            dtype: The dtype to use for the layer's
             parameters. Defaults to ``None``.
 
         Shape:
@@ -353,25 +353,25 @@ class PackedConv2d(nn.Module):
         r"""Packed-Ensembles-style Conv2d layer.
 
         Args:
-            in_channels (int): Number of channels in the input image.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            alpha (int): The channel multiplier of the convolutional layer.
-            num_estimators (int): Number of estimators in the ensemble.
-            gamma (int): Defaults to ``1``.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            alpha: The channel multiplier of the convolutional layer.
+            num_estimators: Number of estimators in the ensemble.
+            gamma: Defaults to ``1``.
+            stride: Stride of the convolution. Defaults to ``1``.
             padding (int, tuple or str): Padding added to all four sides of the input. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            groups (int): Number of blocked connexions from input channels to output channels for each
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connexions from input channels to output channels for each
                 estimator. Defaults to ``1``.
-            minimum_channels_per_group (int): Smallest possible number of channels per group.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults
+            minimum_channels_per_group: Smallest possible number of channels per group.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode: ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults
                 to ``'zeros'``.
-            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
+            first: Whether this is the first layer of the network. Defaults to ``False``.
+            last: Whether this is the last layer of the network. Defaults to ``False``.
+            device: The device to use for the layer's parameters. Defaults to ``None``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input:
@@ -491,24 +491,24 @@ class PackedConv3d(nn.Module):
         r"""Packed-Ensembles-style Conv3d layer.
 
         Args:
-            in_channels (int): Number of channels in the input image.
-            out_channels (int): Number of channels produced by the convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            alpha (int): The channel multiplier of the convolutional layer.
-            num_estimators (int): Number of estimators in the ensemble.
-            gamma (int): Defaults to ``1``.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            kernel_size: Size of the convolving kernel.
+            alpha: The channel multiplier of the convolutional layer.
+            num_estimators: Number of estimators in the ensemble.
+            gamma: Defaults to ``1``.
+            stride: Stride of the convolution. Defaults to ``1``.
             padding (int, tuple or str): Padding added to all six sides of the input. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            groups (int): Number of blocked connexions from input
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connexions from input
             channels to output channels for each estimator. Defaults to ``1``.
-            minimum_channels_per_group (int): Smallest possible number of channels per group.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
-            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
+            minimum_channels_per_group: Smallest possible number of channels per group.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode: ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
+            first: Whether this is the first layer of the network. Defaults to ``False``.
+            last: Whether this is the last layer of the network. Defaults to ``False``.
+            device: The device to use for the layer's parameters. Defaults to ``None``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input:
@@ -629,23 +629,23 @@ class PackedConvTranspose2d(nn.Module):
         r"""Packed-Ensembles-style ConvTranspose2d layer with debug flags.
 
         Args:
-            in_channels (int): Number of channels in the input.
-            out_channels (int): Number of channels produced by the transposed convolution.
-            kernel_size (int or tuple): Size of the convolving kernel.
-            alpha (int): The channel multiplier for the layer.
-            num_estimators (int): Number of estimators in the ensemble.
-            gamma (int): Defaults to ``1``.
-            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
-            padding (int or tuple): Zero-padding added to both sides of the input. Defaults to ``0``.
-            output_padding (int or tuple): Additional size added to one side of the output shape. Defaults to ``0``.
-            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
-            groups (int): Number of blocked connections from input channels to output channels. Defaults to ``1``.
-            minimum_channels_per_group (int): Smallest possible number of channels per group.
-            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
+            in_channels: Number of channels in the input.
+            out_channels: Number of channels produced by the transposed convolution.
+            kernel_size: Size of the convolving kernel.
+            alpha: The channel multiplier for the layer.
+            num_estimators: Number of estimators in the ensemble.
+            gamma: Defaults to ``1``.
+            stride: Stride of the convolution. Defaults to ``1``.
+            padding: Zero-padding added to both sides of the input. Defaults to ``0``.
+            output_padding: Additional size added to one side of the output shape. Defaults to ``0``.
+            dilation: Spacing between kernel elements. Defaults to ``1``.
+            groups: Number of blocked connections from input channels to output channels. Defaults to ``1``.
+            minimum_channels_per_group: Smallest possible number of channels per group.
+            bias: If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            first: Whether this is the first layer of the network. Defaults to ``False``.
+            last: Whether this is the last layer of the network. Defaults to ``False``.
+            device: The device to use for the layer's parameters. Defaults to ``None``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
         """
         check_packed_parameters_consistency(alpha, gamma, num_estimators)
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -732,15 +732,15 @@ class PackedLayerNorm(nn.GroupNorm):
         r"""Packed-Ensembles-style LayerNorm layer.
 
         Args:
-            embed_dim (int): the number of features in the input tensor.
-            num_estimators (int): the number of estimators in the ensemble.
-            alpha (float): the width multiplier of the layer.
-            eps (float): a value added to the denominator for numerical stability. Defaults to 1e-5.
-            affine (bool): a boolean value that when set to ``True``, this module has learnable per_channel affine parameters initialized to ones (for weights) and zeros (for biases). Defaults to ``True``.
-            first (bool): Whether this layer processes the raw inputs of the model. Defaults to ``False``.
-            last (bool): Whether this layer processes the final outputs of the model. Defaults to ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
+            embed_dim: the number of features in the input tensor.
+            num_estimators: the number of estimators in the ensemble.
+            alpha: the width multiplier of the layer.
+            eps: a value added to the denominator for numerical stability. Defaults to 1e-5.
+            affine: a boolean value that when set to ``True``, this module has learnable per_channel affine parameters initialized to ones (for weights) and zeros (for biases). Defaults to ``True``.
+            first: Whether this layer processes the raw inputs of the model. Defaults to ``False``.
+            last: Whether this layer processes the final outputs of the model. Defaults to ``False``.
+            device: The device to use for the layer's parameters. Defaults to ``None``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input: :math:`(N, *)` where :math:`*` means any number of additional dimensions.
@@ -803,33 +803,25 @@ class PackedMultiheadAttention(nn.Module):
         r"""Packed-Ensembles-style MultiheadAttention layer.
 
         Args:
-            embed_dim (int): Size of the embedding dimension.
-            num_heads (int): Number of parallel attention heads.
-            alpha (float): The width multiplier of the embedding dimension.
-            num_estimators (int): The number of estimators packed in the layer.
-            gamma (int): Defaults to ``1``.
-            dropout (float): Dropout probability on ``attn_output_weights``. Defaults to ``0.0``
-                (no dropout).
-            bias (bool): If specified, adds bias to input / output projection layers.
-                Defaults to ``True``.
-            add_bias_kv (bool): If specified, adds bias to the key and value sequences at
+            embed_dim: Size of the embedding dimension.
+            num_heads: Number of parallel attention heads.
+            alpha: The width multiplier of the embedding dimension.
+            num_estimators: The number of estimators packed in the layer.
+            gamma: Defaults to ``1``.
+            dropout: Dropout probability on ``attn_output_weights``. Defaults to ``0.0``(no dropout).
+            bias: If specified, adds bias to input / output projection layers. Defaults to ``True``.
+            add_bias_kv: If specified, adds bias to the key and value sequences at
                 ``dim=0``. Defaults to ``False``.
-            add_zero_attn (bool): If specified, adds a new batch of zeros to the key and
+            add_zero_attn: If specified, adds a new batch of zeros to the key and
                 value sequences at ``dim=1``. Defaults to ``False``.
-            kdim (int | None): Total number of features for keys. Defaults to ``None``
-                (uses ``kdim=embed_dim``).
-            vdim (int | None): Total number of features for values. Defaults to ``None``
-                (uses ``vdim=embed_dim``).
-            batch_first (bool): If ``True``, then the input and output tensors are provided
+            kdim: Total number of features for keys. Defaults to ``None`` (uses ``kdim=embed_dim``).
+            vdim: Total number of features for values. Defaults to ``None`` (uses ``vdim=embed_dim``).
+            batch_first: If ``True``, then the input and output tensors are provided
                 as (batch, seq, feature). Defaults to ``False`` (seq, batch, feature).
-            first (bool): Whether this is the first layer of the network. Defaults to
-                ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to
-                ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults
-                to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
-                ``None``.
+            first: Whether this is the first layer of the network. Defaults to ``False``.
+            last: Whether this is the last layer of the network. Defaults to ``False``.
+            device: The device to use for the layer's parameters. Defaults to ``None``.
+            dtype: The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Reference:
             - `Attention Is All You Need <https://arxiv.org/abs/1706.03762>`_: Original Multihead Attention formulation.
@@ -976,30 +968,30 @@ class PackedMultiheadAttention(nn.Module):
         r"""Computes attention outputs given query, key, and value tensors.
 
         Args:
-            query (Tensor): Query embeddings of shape :math:`(L, E_q)` for unbatched input,
+            query: Query embeddings of shape :math:`(L, E_q)` for unbatched input,
                 :math:`(L, B, E_q)` when ``batch_first=False`` or :math:`(B, L, E_q)` when
                 ``batch_first=True``, where :math:`L` is the target sequence length, :math:`B` is
                 the batch size, and :math:`E_q` is the query embedding dimension ``embed_dim``.
-            key (Tensor): Key embeddings of shape :math:`(S, E_k)` for unbatched input,
+            key: Key embeddings of shape :math:`(S, E_k)` for unbatched input,
                 :math:`(S, B, E_k)` when ``batch_first=False`` or :math:`(B, S, E_k)` when
                 ``batch_first=True``, where :math:`S` is the source sequence length, :math:`B` is
                 the batch size and :math:`E_k` is the key embedding dimension ``kdim``.
-            value (Tensor): Value embeddings of shape :math:`(S, E_v)` for unbatched input,
+            value: Value embeddings of shape :math:`(S, E_v)` for unbatched input,
                 :math:`(S, B, E_v)` when ``batch_first=False`` or :math:`(B, S, E_v)` when
                 ``batch_first=True``, where :math:`S` is the source sequence length, :math:`B` is
                 the batch size and :math:`E_v` is the value embedding dimension ``vdim``.
-            key_padding_mask (Tensor | None): If specified, a mask of shape
+            key_padding_mask: If specified, a mask of shape
                 :math:`(B, S)` indicating which elements within ``key`` to ignore for the purpose
                 of attention (i.e. treat as "padding"). For unbatched `query`, shape should be
                 :math:`(S)`. Binary and float masks are supported. For a binary mask, a ``True``
                 value indicates that the corresponding ``key`` value will be ignored for the
                 purpose of attention. For a float mask, it will be directly added to the
                 corresponding ``key`` value. Defaults to ``None``.
-            need_weights (bool): If specified, returns ``attn_output_weights`` in
+            need_weights: If specified, returns ``attn_output_weights`` in
                 addition to ``attn_outputs``. Set ``need_weights=False`` to use the optimized
                 ``scale_dot_product_attention`` and achieve the best performance for MHA.
                 Defaults to ``False``.
-            attn_mask (Tensor | None): If specified, a 2D or 3D mask preventing attention
+            attn_mask: If specified, a 2D or 3D mask preventing attention
                 to certain positions. Must be of shape :math:`(L,S)` or
                 :math:`(B \times \text{num_heads}, L, S)`, where :math:`B` is the batch size, :math:`L`
                 is the target sequence length, and :math:`S` is the source sequence length. A 2D mask
@@ -1009,11 +1001,11 @@ class PackedMultiheadAttention(nn.Module):
                 For a float mask, the mask values will be added to the attention weight. If both
                 ``attn_mask`` and ``key_padding_mask`` are provided, their types should match.
                 Defaults to ``None``.
-            average_attn_weights (bool): If ``True``, indicates that the returned
+            average_attn_weights: If ``True``, indicates that the returned
                 ``attn_weights`` should be averaged across heads. Otherwise, ``attn_weights`` are
                 provided separately per head. Note that this flag only has an effect when
                 ``need_weights=True``. Defaults to ``True``.
-            is_causal (bool): If specified, applies a causal mask as ``attn_mask``.
+            is_causal: If specified, applies a causal mask as ``attn_mask``.
                 Defaults to ``False``.
 
         Warning:
@@ -1022,7 +1014,7 @@ class PackedMultiheadAttention(nn.Module):
 
         Returns:
             tuple[Tensor, None]:
-                - *attn_output* (Tensor): The output tensor of shape :math:`(L, E_q)`, :math:`(L, B, E_q)`
+                - *attn_output*: The output tensor of shape :math:`(L, E_q)`, :math:`(L, B, E_q)`
                   or :math:`(B, L, E_q)` where :math:`L` is the target sequence length, :math:`B` is
                   the batch size, and :math:`E_q` is the embedding dimension ``embed_dim``.
                 - *attn_output_weights* (None): Always ``None`` as we do not support
@@ -1149,33 +1141,33 @@ class PackedTransformerEncoderLayer(nn.Module):
         feedforward network).
 
         Args:
-            d_model (int): the number of expected features in the input.
-            nhead (int): the number of heads in the multiheadattention models.
-            alpha (float): the width multiplier of the layer.
-            num_estimators (int): the number of estimators packed in the layer.
-            gamma (int): Defaults to ``1``.
-            dim_feedforward (int): the dimension of the feedforward network model. Defaults
+            d_model: the number of expected features in the input.
+            nhead: the number of heads in the multiheadattention models.
+            alpha: the width multiplier of the layer.
+            num_estimators: the number of estimators packed in the layer.
+            gamma: Defaults to ``1``.
+            dim_feedforward: the dimension of the feedforward network model. Defaults
                 to ``2048``.
-            dropout (float): the dropout value. Defaults to ``0.1``.
+            dropout: the dropout value. Defaults to ``0.1``.
             activation (Callable[[Tensor], Tensor]): the activation function of the
                 intermediate layer, that is a unary callable. Defaults to ``F.relu``.
-            layer_norm_eps (float): the eps value in layer normalization components. Defaults
+            layer_norm_eps: the eps value in layer normalization components. Defaults
                 to ``1e-5``.
-            bias (bool): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
+            bias: If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
                 additive bias. Defaults to ``True``.
-            batch_first (bool): If ``True``, then the input and output tensors are provided
+            batch_first: If ``True``, then the input and output tensors are provided
                 as :math:`(\text{batch}, \text{seq}, \text{d_model})`. Defaults to ``False``
                 :math:`(\text{seq}, \text{batch}, \text{d_model})`.
-            norm_first (bool): If ``True``, the layer norm is done prior to attention and
+            norm_first: If ``True``, the layer norm is done prior to attention and
                 feedforward operations, respectively. Otherwise, it is done after. Defaults to
                 ``False``.
-            first (bool): Whether this is the first layer of the network. Defaults to
+            first: Whether this is the first layer of the network. Defaults to
                 ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to
+            last: Whether this is the last layer of the network. Defaults to
                 ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults
+            device: The device to use for the layer's parameters. Defaults
                 to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
+            dtype: The dtype to use for the layer's parameters. Defaults to
                 ``None``.
 
         Reference:
@@ -1263,12 +1255,12 @@ class PackedTransformerEncoderLayer(nn.Module):
         r"""Pass the input through the encoder layer.
 
         Args:
-            src (Tensor): The sequence to the encoder layer. Shape: :math:`(B, L, E)` or
+            src: The sequence to the encoder layer. Shape: :math:`(B, L, E)` or
                 :math:`(L, B, E)`.
-            src_mask (Tensor | None): The mask for the ``src`` sequence. Defaults to ``None``.
-            src_key_padding_mask (Tensor | None): The mask for the ``src`` keys per
+            src_mask: The mask for the ``src`` sequence. Defaults to ``None``.
+            src_key_padding_mask: The mask for the ``src`` keys per
                 batch. Defaults to ``None``.
-            is_causal (bool): If specified, applies a causal mask as ``src_mask``.
+            is_causal: If specified, applies a causal mask as ``src_mask``.
                 Defaults to ``False``. Warning: ``is_causal`` provides a hint the ``src_mask`` is
                 a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.
@@ -1360,33 +1352,33 @@ class PackedTransformerDecoderLayer(nn.Module):
         attention, and feedforward network).
 
         Args:
-            d_model (int): the number of expected features in the input.
-            nhead (int): the number of heads in the multiheadattention models.
-            alpha (float): the width multiplier of the layer.
-            num_estimators (int): the number of estimators packed in the layer.
-            gamma (int): Defaults to ``1``.
-            dim_feedforward (int): the dimension of the feedforward network model. Defaults
+            d_model: the number of expected features in the input.
+            nhead: the number of heads in the multiheadattention models.
+            alpha: the width multiplier of the layer.
+            num_estimators: the number of estimators packed in the layer.
+            gamma: Defaults to ``1``.
+            dim_feedforward: the dimension of the feedforward network model. Defaults
                 to ``2048``.
-            dropout (float): the dropout value. Defaults to ``0.1``.
+            dropout: the dropout value. Defaults to ``0.1``.
             activation (Callable[[Tensor], Tensor]): the activation function of the
                 intermediate layer, that is a unary callable. Defaults to ``F.relu``.
-            layer_norm_eps (float): the eps value in layer normalization components. Defaults
+            layer_norm_eps: the eps value in layer normalization components. Defaults
                 to ``1e-5``.
-            bias (bool): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
+            bias: If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
                 additive bias. Defaults to ``True``.
-            batch_first (bool): If ``True``, then the input and output tensors are provided
+            batch_first: If ``True``, then the input and output tensors are provided
                 as :math:`(\text{batch}, \text{seq}, \text{d_model})`. Defaults to ``False``
                 :math:`(\text{seq}, \text{batch}, \text{d_model})`.
-            norm_first (bool): If ``True``, the layer norm is done prior to attention and
+            norm_first: If ``True``, the layer norm is done prior to attention and
                 feedforward operations, respectively. Otherwise, it is done after. Defaults to
                 ``False``.
-            first (bool): Whether this is the first layer of the network. Defaults to
+            first: Whether this is the first layer of the network. Defaults to
                 ``False``.
-            last (bool): Whether this is the last layer of the network. Defaults to
+            last: Whether this is the last layer of the network. Defaults to
                 ``False``.
-            device (torch.device): The device to use for the layer's parameters. Defaults
+            device: The device to use for the layer's parameters. Defaults
                 to ``None``.
-            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
+            dtype: The dtype to use for the layer's parameters. Defaults to
                 ``None``.
 
         Reference:
@@ -1499,23 +1491,18 @@ class PackedTransformerDecoderLayer(nn.Module):
         r"""Pass the input (and mask) through the decoder layer.
 
         Args:
-            tgt (Tensor): The sequence to the decoder layer. Shape: :math:`(B, L, E)` or
-                :math:`(L, B, E)`.
-            memory (Tensor): The sequence from the last layer of the encoder. Shape:
+            tgt: The sequence to the decoder layer. Shape: :math:`(B, L, E)` or :math:`(L, B, E)`.
+            memory: The sequence from the last layer of the encoder. Shape:
                 :math:`(B, S, E)` or :math:`(S, B, E)`.
-            tgt_mask (Tensor | None): The mask for the ``tgt`` sequence. Defaults to
-                ``None``.
-            memory_mask (Tensor | None): The mask for the ``memory`` sequence. Defaults
-                to ``None``.
-            tgt_key_padding_mask (Tensor | None): The mask for the ``tgt`` keys per
-                batch. Defaults to ``None``.
-            memory_key_padding_mask (Tensor | None): The mask for the ``memory`` keys per
-                batch. Defaults to ``None``.
-            tgt_is_causal (bool): If specified, applies a causal mask as ``tgt_mask``.
+            tgt_mask: The mask for the ``tgt`` sequence. Defaults to ``None``.
+            memory_mask: The mask for the ``memory`` sequence. Defaults to ``None``.
+            tgt_key_padding_mask: The mask for the ``tgt`` keys per batch. Defaults to ``None``.
+            memory_key_padding_mask: The mask for the ``memory`` keys per batch. Defaults to ``None``.
+            tgt_is_causal: If specified, applies a causal mask as ``tgt_mask``.
                 Defaults to ``False``. Warning: ``tgt_is_causal`` provides a hint the ``tgt_mask``
                 is a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.
-            memory_is_causal (bool): If specified, applies a causal mask as ``memory_mask``.
+            memory_is_causal: If specified, applies a causal mask as ``memory_mask``.
                 Defaults to ``False``. Warning: ``memory_is_causal`` provides a hint the ``memory_mask``
                 is a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.

--- a/src/torch_uncertainty/losses/bayesian.py
+++ b/src/torch_uncertainty/losses/bayesian.py
@@ -12,7 +12,7 @@ class KLDiv(nn.Module):
         modules computed in the forward passes.
 
         Args:
-            model (nn.Module): Bayesian Neural Network
+            model: Bayesian Neural Network
         """
         super().__init__()
         self.model = model
@@ -49,11 +49,11 @@ class ELBOLoss(nn.Module):
         objective that you seek to minimize as :attr:`inner_loss`.
 
         Args:
-            model (nn.Module): The Bayesian Neural Network to compute the loss for
-            inner_loss (nn.Module): The loss function to use during training
-            kl_weight (float): The weight of the KL divergence term
-            num_samples (int): The number of samples to use for the ELBO loss
-            dist_family (str): The distribution family to use for the output of the
+            model: The Bayesian Neural Network to compute the loss for
+            inner_loss: The loss function to use during training
+            kl_weight: The weight of the KL divergence term
+            num_samples: The number of samples to use for the ELBO loss
+            dist_family: The distribution family to use for the output of the
                 model. ``None`` means point-wise prediction. Defaults to ``None``.
 
         Note:
@@ -75,8 +75,8 @@ class ELBOLoss(nn.Module):
         the ELBO loss for a given network.
 
         Args:
-            inputs (Tensor): The inputs of the Bayesian Neural Network
-            targets (Tensor): The target values
+            inputs: The inputs of the Bayesian Neural Network
+            targets: The target values
 
         Returns:
             Tensor: The aggregated ELBO loss

--- a/src/torch_uncertainty/losses/classification.py
+++ b/src/torch_uncertainty/losses/classification.py
@@ -14,13 +14,12 @@ class DECLoss(nn.Module):
         """The Deep Evidential Classification loss.
 
         Args:
-            annealing_step (int | None): Annealing step for the weight of the
-                regularization term. Defaults to None.
-            reg_weight (float | None): Fixed weight of the regularization term.
-                Defaults to None.
-            loss_type (str): Specifies the loss type to apply to the
+            annealing_step: Annealing step for the weight of the
+                regularization term. Defaults to ``None``.
+            reg_weight: Fixed weight of the regularization term. Defaults to ``None``.
+            loss_type: Specifies the loss type to apply to the
                 Dirichlet parameters: ``'mse'`` | ``'log'`` | ``'digamma'``.
-            reduction (str): Specifies the reduction to apply to the
+            reduction: Specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:
@@ -175,10 +174,10 @@ class ConfidencePenaltyLoss(nn.Module):
         """The Confidence Penalty Loss.
 
         Args:
-            reg_weight (float): The weight of the regularization term.
-            reduction (str): specifies the reduction to apply to the
+            reg_weight: The weight of the regularization term.
+            reduction: specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``. Defaults to "mean".
-            eps (float): A small value to avoid numerical instability.
+            eps: A small value to avoid numerical instability.
                 Defaults to ``1e-6.``
 
         References:
@@ -206,8 +205,8 @@ class ConfidencePenaltyLoss(nn.Module):
         """Compute the Confidence Penalty loss.
 
         Args:
-            logits (Tensor): The inputs of the Bayesian Neural Network
-            targets (Tensor): The target values
+            logits: The inputs of the Bayesian Neural Network
+            targets: The target values
 
         Returns:
             Tensor: The Confidence Penalty loss
@@ -233,8 +232,8 @@ class ConflictualLoss(nn.Module):
         r"""The Conflictual Loss.
 
         Args:
-            reg_weight (float): The weight of the regularization term.
-            reduction (str): specifies the reduction to apply to the
+            reg_weight: The weight of the regularization term.
+            reduction: specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:
@@ -258,8 +257,8 @@ class ConflictualLoss(nn.Module):
         """Compute the conflictual loss.
 
         Args:
-            logits (Tensor): The outputs of the model.
-            targets (Tensor): The target values.
+            logits: The outputs of the model.
+            targets: The target values.
 
         Returns:
             Tensor: The conflictual loss.
@@ -286,9 +285,9 @@ class FocalLoss(nn.Module):
         """Focal-Loss for classification tasks.
 
         Args:
-            gamma (float): A constant, as described in the paper.
-            alpha (Tensor): Weights for each class. Defaults to ``None``.
-            reduction (str): ``'mean'``, ``'sum'`` or ``'none'``. Defaults to ``'mean'``.
+            gamma: A constant, as described in the paper.
+            alpha: Weights for each class. Defaults to ``None``.
+            reduction: ``'mean'``, ``'sum'`` or ``'none'``. Defaults to ``'mean'``.
 
         References:
             [1] `Lin, T.-Y., Goyal, P., Girshick, R., He, K., & Dollár, P. (2017). Focal Loss for Dense Object Detection.
@@ -344,15 +343,15 @@ class BCEWithLogitsLSLoss(nn.BCEWithLogitsLoss):
         the BCEWithLogitsLoss.
 
         Args:
-            weight (Tensor): A manual rescaling weight given to the
+            weight: A manual rescaling weight given to the
                 loss of each batch element. If given, has to be a Tensor of size
                 "nbatch". Defaults to ``None``.
-            reduction (str): Specifies the reduction to apply to the
+            reduction: Specifies the reduction to apply to the
                 output: ``'none'`` | ``'mean'`` | ``'sum``'. ``'none'``: no reduction will be applied,
                 ``'mean'``: the sum of the output will be divided by the number of
                 elements in the output, ``'sum'``: the output will be summed. Defaults
                 to ``'mean'``.
-            label_smoothing (float): The label smoothing factor. Defaults
+            label_smoothing: The label smoothing factor. Defaults
                 to ``0.0``.
         """
         super().__init__(weight=weight, reduction=reduction)
@@ -449,13 +448,13 @@ class MixupMPLoss(nn.CrossEntropyLoss):
         ratio r.
 
         Args:
-            mixup_ratio (float): Ratio of number of mixup samples vs normal samples
+            mixup_ratio: Ratio of number of mixup samples vs normal samples
                 output by the MixupMP transform. This should match the transform's
                 :attr:`mixup_ratio` hyperparameter. Defaults to ``1.0`` (equal weighting).
-            weight (Tensor | None): a manual rescaling weight given to each class.
-            ignore_index (int): Specifies a target value that is ignored
+            weight: a manual rescaling weight given to each class.
+            ignore_index: Specifies a target value that is ignored
                 and does not contribute to the input gradient. Defaults to ``-100``.
-            reduction (str): Specifies the reduction to apply to the output: 'none'|'mean'|'sum'.
+            reduction: Specifies the reduction to apply to the output: 'none'|'mean'|'sum'.
 
         See Also:
             torch_uncertainty/transforms/mixup.py — MixupMP transform implementation.
@@ -477,8 +476,8 @@ class MixupMPLoss(nn.CrossEntropyLoss):
         that case by manually using F.kl_div if needed.
 
         Args:
-            input (Tensor): model logits shape (N_total, num_classes)
-            target (Tensor): target labels (one-hot or class indices) shape (N_total, ...)
+            input: model logits shape (N_total, num_classes)
+            target: target labels (one-hot or class indices) shape (N_total, ...)
         """
         # determine how many samples correspond to mixup vs normal
         mixup_count = round((self.mixup_ratio / (self.mixup_ratio + 1)) * input.size(0))

--- a/src/torch_uncertainty/losses/regression.py
+++ b/src/torch_uncertainty/losses/regression.py
@@ -12,8 +12,8 @@ class DistributionNLLLoss(nn.Module):
         """Negative Log-Likelihood loss using given distributions as inputs.
 
         Args:
-            reduction (str): specifies the reduction to apply to the
-                output:``'none'`` | ``'mean'`` | ``'sum'``. Defaults to "mean".
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``. Defaults to ``"mean"``.
         """
         super().__init__()
         self.reduction = reduction
@@ -27,10 +27,10 @@ class DistributionNLLLoss(nn.Module):
         """Compute the NLL of the targets given predicted distributions.
 
         Args:
-            dist (Distribution): The predicted distributions
-            targets (Tensor): The target values
-            padding_mask (Tensor): The padding mask. Defaults to ``None.``
-                Sets the loss to ``0`` for padded values.
+            dist: The predicted distributions.
+            targets: The target values.
+            padding_mask: The padding mask. Sets the loss to ``0`` for padded values.
+                Defaults to ``None``.
         """
         loss = -dist.log_prob(targets)
         if padding_mask is not None:
@@ -51,9 +51,9 @@ class DERLoss(DistributionNLLLoss):
         inverse gamma distribution and a weighted regularization term.
 
         Args:
-            reg_weight (float): The weight of the regularization term.
-            reduction (str): specifies the reduction to apply to the
-                output:``'none'`` | ``'mean'`` | ``'sum'``.
+            reg_weight: The weight of the regularization term.
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``.
 
         References:
             [1] `Amini, A., Schwarting, W., Soleimany, A., & Rus, D. (2019). Deep evidential regression
@@ -106,11 +106,10 @@ class BetaNLL(nn.Module):
         """The Beta Negative Log-likelihood loss.
 
         Args:
-            beta (float): Parameter from range [0, 1] controlling relative
-                weighting between data points, where `0` corresponds to
-                high weight on low error points and `1` to an equal weighting.
-            reduction (str): specifies the reduction to apply to the
-                output:``'none'`` | ``'mean'`` | ``'sum'``.
+            beta: Parameter from range [0, 1] controlling relative weighting between data points,
+                where ``0`` corresponds to high weight on low error points and ``1`` to an equal weighting.
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``.
 
         References:
             [1] `Seitzer, M., Tavakoli, A., Antic, D., & Martius, G. (2022). On the pitfalls of heteroscedastic uncertainty estimation with probabilistic neural networks

--- a/src/torch_uncertainty/methods/batch_ensemble.py
+++ b/src/torch_uncertainty/methods/batch_ensemble.py
@@ -23,14 +23,14 @@ class BatchEnsemble(nn.Module):
         ensuring that each estimator receives the correct data format.
 
         Args:
-            core_model (nn.Module): The BatchEnsemble model.
-            num_estimators (int): Number of ensemble members.
-            repeat_training_inputs (optional, bool): Whether to repeat the input batch during training.
+            core_model: The BatchEnsemble model.
+            num_estimators: Number of ensemble members.
+            repeat_training_inputs: Whether to repeat the input batch during training.
                 If ``True``, the input batch is repeated during both training and evaluation. If ``False``,
-                the input batch is repeated only during evaluation. Default is ``False``.
-            convert_layers (optional, bool): Whether to convert the model's layers to BatchEnsemble layers.
+                the input batch is repeated only during evaluation. Defaults to ``False``.
+            convert_layers: Whether to convert the model's layers to BatchEnsemble layers.
                 If ``True``, the wrapper will convert all ``nn.Linear`` and ``nn.Conv2d`` layers to their
-                BatchEnsemble counterparts. Default is ``False``.
+                BatchEnsemble counterparts. Defaults to ``False``.
 
         Raises:
             ValueError: If neither ``BatchLinear`` nor ``BatchConv2d`` layers are found in the core_model at the
@@ -131,14 +131,14 @@ def batch_ensemble(
     """BatchEnsemble wrapper for a model.
 
     Args:
-        core_model (nn.Module): model to wrap
-        num_estimators (int): number of ensemble members
-        repeat_training_inputs (bool): whether to repeat the input batch during training.
+        core_model: Model to wrap.
+        num_estimators: Number of ensemble members.
+        repeat_training_inputs: Whether to repeat the input batch during training.
             If ``True``, the input batch is repeated during both training and evaluation. If ``False``,
-            the input batch is repeated only during evaluation. Default is ``False``.
-        convert_layers (bool): whether to convert the model's layers to BatchEnsemble layers.
+            the input batch is repeated only during evaluation. Defaults to ``False``.
+        convert_layers: Whether to convert the model's layers to BatchEnsemble layers.
             If ``True``, the wrapper will convert all ``nn.Linear`` and ``nn.Conv2d`` layers to their
-            BatchEnsemble counterparts. Default is ``False``.
+            BatchEnsemble counterparts. Defaults to ``False``.
 
     Returns:
         BatchEnsemble: BatchEnsemble wrapper for the :attr:`core_model`

--- a/src/torch_uncertainty/methods/checkpoint_collector.py
+++ b/src/torch_uncertainty/methods/checkpoint_collector.py
@@ -21,12 +21,12 @@ class CheckpointCollector(nn.Module):
         as implemented in TorchUncertainty.
 
         Args:
-            core_model (nn.Module): The model to train and ensemble.
-            cycle_start (int): Epoch to start ensembling. Defaults to ``None``.
-            cycle_length (int): Number of epochs between model collections. Defaults to ``None``.
-            save_schedule (list[int] | None): The epochs at which to save the model. Defaults to ``None``.
-            use_final_model (bool): Whether to use the final model as a checkpoint. Defaults to ``True``.
-            store_on_cpu (bool): Whether to put the models on the CPU when unused. Defaults to ``False``.
+            core_model: The model to train and ensemble.
+            cycle_start: Epoch to start ensembling. Defaults to ``None``.
+            cycle_length: Number of epochs between model collections. Defaults to ``None``.
+            save_schedule: The epochs at which to save the model. Defaults to ``None``.
+            use_final_model: Whether to use the final model as a checkpoint. Defaults to ``True``.
+            store_on_cpu: Whether to put the models on the CPU when unused. Defaults to ``False``.
 
         Note:
             The models are saved at the end of the specified epochs.
@@ -83,7 +83,7 @@ class CheckpointCollector(nn.Module):
         """Save the model at the end of the epoch, if included in the schedule.
 
         Args:
-            epoch (int): The current epoch.
+            epoch: The current epoch.
         """
         match self.mode:
             case "schedule":
@@ -105,7 +105,7 @@ class CheckpointCollector(nn.Module):
         This method will return the ensemble prediction if models have already been collected.
 
         Args:
-            x (Tensor): The input tensor.
+            x: The input tensor.
 
         Returns:
             Tensor: The ensemble output.
@@ -137,7 +137,7 @@ class CheckpointCollector(nn.Module):
         current model.
 
         Args:
-            x (Tensor): The input tensor.
+            x: The input tensor.
 
         Returns:
             Tensor: The model or ensemble output.

--- a/src/torch_uncertainty/methods/deep_ensembles.py
+++ b/src/torch_uncertainty/methods/deep_ensembles.py
@@ -12,7 +12,7 @@ class _DeepEnsembles(nn.Module):
         core_models: list[nn.Module],
         store_on_cpu: bool = False,
     ) -> None:
-        """Create a classification deep ensembles from a list of models."""
+        """Create a classification deep ensemble from a list of models."""
         super().__init__()
         self.core_models = nn.ModuleList(core_models)
         self.num_estimators = len(core_models)
@@ -25,7 +25,7 @@ class _DeepEnsembles(nn.Module):
             dict.
 
         Args:
-            x (Tensor): The input of the model.
+            x: The input of the model.
 
         Returns:
             Tensor: The output of the model with shape :math:`(N \times B, C)`,
@@ -67,7 +67,7 @@ class _RegDeepEnsembles(_DeepEnsembles):
         r"""Return the logits of the ensemble.
 
         Args:
-            x (Tensor): The input of the model.
+            x: The input of the model.
 
         Returns:
             Tensor | dict[str, Tensor]: The output of the model with shape :math:`(N \times B, *)`
@@ -105,20 +105,20 @@ def deep_ensembles(
     """Build a Deep Ensembles out of the original models.
 
     Args:
-        core_models (list[nn.Module] | nn.Module): The model to be ensembled.
-        num_estimators (int | None): The number of estimators in the ensemble.
-        task (Literal[``"classification"``, ``"regression"``, ``"segmentation"``, ``"pixel_regression"``]): The model task. Defaults to ``"classification"``.
-        probabilistic (bool): Whether the regression model is probabilistic.
-        reset_model_parameters (bool): Whether to reset the model parameters
-            when :attr:core_models is a module or a list of length 1. Defaults to ``True``.
-        store_on_cpu (bool): Whether to store the models on CPU. Defaults to ``False``.
-            This is useful for large models that do not fit in GPU memory. Only one
-            model will be stored on GPU at a time during forward. The rest will be stored on CPU.
+        core_models: The model to be ensembled.
+        num_estimators: The number of estimators in the ensemble.
+        task: The model task. Defaults to ``"classification"``.
+        probabilistic: Whether the regression model is probabilistic.
+        reset_model_parameters: Whether to reset the model parameters when :attr:`core_models` is a module or
+            a list of length 1. Defaults to ``True``.
+        store_on_cpu: Whether to store the models on CPU. Defaults to ``False``.
+        This is useful for large models that do not fit in GPU memory. Only one
+        model will be stored on GPU at a time during forward. The rest will be stored on CPU.
         ckpt_paths (list[str | Path] | None): The paths to the checkpoints of the models.
             If provided, the models will be loaded from the checkpoints. The number of
             models and the number of checkpoint paths must be the same. If not provided,
             the models will be used as is. Defaults to ``None``.
-        use_tu_ckpt_format (bool): Whether the checkpoint is from torch-uncertainty. If ``True``,
+        use_tu_ckpt_format: Whether the checkpoint is from torch-uncertainty. If ``True``,
             the checkpoint will be loaded using the torch-uncertainty loading function. If
             ``False``, the checkpoint will be loaded using the default PyTorch loading function.
             Note that this option is only used if :attr:ckpt_paths is provided. Defaults to
@@ -136,8 +136,7 @@ def deep_ensembles(
             a (non-singleton) list.
 
     Warning:
-        The :attr:`store_on_cpu` option is not supported for training. It is
-        only supported for inference.
+        The :attr:`store_on_cpu` option is not supported for training. It is only supported for evaluation.
 
     References:
             [1] `Simple and scalable predictive uncertainty estimation using deep ensembles. In NeurIPS, 2017

--- a/src/torch_uncertainty/methods/ema.py
+++ b/src/torch_uncertainty/methods/ema.py
@@ -11,12 +11,12 @@ class EMA(nn.Module):
     ) -> None:
         """Exponential Moving Average (EMA).
 
-        The :attr:`model` given as argument is used to compute the gradient during the training.
+        The core model given as argument is used to compute the gradient during training.
         The EMA model is regularly updated with the inner-model and used at evaluation time.
 
         Args:
-            core_model (nn.Module): The model to train and ensemble.
-            momentum (float): The momentum of the moving average. The larger the momentum,
+            core_model: The model to train and ensemble.
+            momentum: The momentum of the moving average. The larger the momentum,
                 the more stable the model.
 
         Note:
@@ -30,13 +30,14 @@ class EMA(nn.Module):
 
     @property
     def remainder(self):
+        """Complement of the EMA momentum."""
         return 1 - self.momentum
 
     def update_wrapper(self, epoch: int | None = None) -> None:
         """Update the EMA model.
 
         Args:
-            epoch (int): The current epoch. For API consistency.
+            epoch: The current epoch. Present for API consistency. Defaults to ``None``.
         """
         for ema_param, param in zip(
             self.ema_model.parameters(),
@@ -46,6 +47,7 @@ class EMA(nn.Module):
             ema_param.data = ema_param.data * self.momentum + param.data * self.remainder
 
     def eval_forward(self, x: Tensor) -> Tensor:
+        """Run the EMA model in evaluation mode."""
         return self.ema_model.forward(x)
 
     def forward(self, x: Tensor) -> Tensor:

--- a/src/torch_uncertainty/methods/mc_dropout.py
+++ b/src/torch_uncertainty/methods/mc_dropout.py
@@ -17,10 +17,10 @@ class _MCDropout(nn.Module):
         """MC Dropout wrapper for a model containing nn.Dropout modules.
 
         Args:
-            core_model (nn.Module): model to wrap
-            num_estimators (int): number of estimators to use during the evaluation
-            last_layer (bool): whether to apply dropout to the last layer only.
-            on_batch (bool): Perform the MC-Dropout on the batch-size. Otherwise in a for loop. Useful when constrained in memory.
+            core_model: Model to wrap.
+            num_estimators: Number of estimators to use during evaluation.
+            last_layer: Whether to apply dropout to the last layer only.
+            on_batch: Perform MC-Dropout on the batch dimension instead of in a Python loop.
 
         Warning:
             This module will work only if you apply dropout through modules
@@ -54,8 +54,7 @@ class _MCDropout(nn.Module):
         selected dropout modules.
 
         Args:
-            mode (bool): whether to set the module to training
-                mode. Defaults to True.
+            mode: Whether to set the module to training mode. Defaults to ``True``.
         """
         if not isinstance(mode, bool):
             raise TypeError("Training mode is expected to be boolean")
@@ -78,10 +77,10 @@ class _MCDropout(nn.Module):
         :attr:`last_layer`.
 
         Args:
-            x (Tensor): input tensor of shape (B, ...)
+            x: Input tensor of shape (B, ...).
 
         Returns:
-            Tensor: output tensor of shape (:attr:`num_estimators` * B, ...)
+            Tensor | dict[str, Tensor]: Output tensor of shape (:attr:`num_estimators` * B, ...).
         """
         if self.training:
             return self.core_model(x)
@@ -121,10 +120,10 @@ class _RegMCDropout(_MCDropout):
         :attr:`last_layer`.
 
         Args:
-            x (Tensor): input tensor of shape (B, ...)
+            x: Input tensor of shape (B, ...).
 
         Returns:
-            Tensor: output tensor of shape (:attr:`num_estimators` * B, ...)
+            Tensor | dict[str, Tensor]: Output tensor of shape (:attr:`num_estimators` * B, ...).
         """
         if self.training:
             return self.core_model(x)
@@ -157,12 +156,13 @@ def mc_dropout(
     """MC Dropout wrapper for a model.
 
     Args:
-        core_model (nn.Module): model to wrap
-        num_estimators (int): number of estimators to use last_layer (bool): whether to apply dropout to the last layer only. Defaults to ``False``.
-        on_batch (bool): Increase the batch_size to perform MC-Dropout. Otherwise in a for loop to reduce memory footprint. Defaults to ``True``.
-        last_layer (bool): whether to apply dropout to the last layer only. Defaults to ``False``.
-        task (Literal[``"classification"``, ``"regression"``, ``"segmentation"``, ``"pixel_regression"``]): The model task. Defaults to ``"classification"``.
-        probabilistic (bool): Whether the regression model is probabilistic.
+        core_model: Model to wrap.
+        num_estimators: Number of estimators to use during evaluation.
+        last_layer: Whether to apply dropout to the last layer only. Defaults to ``False``.
+        on_batch: Increase the batch size to perform MC-Dropout instead of using a Python loop.
+            Increases memory footprint. Defaults to ``True``.
+        task: The model task. Defaults to ``"classification"``.
+        probabilistic: Whether the regression model is probabilistic. Defaults to ``None``
 
     Warning:
         Beware that :attr:`on_batch==True` can raise weird errors if not enough memory is available.
@@ -193,6 +193,7 @@ def mc_dropout(
 
 
 def _dropout_checks(filtered_modules: list[_DropoutNd], num_estimators: int) -> None:
+    """Validate the dropout configuration used for MC Dropout."""
     if not filtered_modules:
         raise ValueError(
             "No dropout module found in the model. "

--- a/src/torch_uncertainty/methods/stochastic.py
+++ b/src/torch_uncertainty/methods/stochastic.py
@@ -32,7 +32,7 @@ class StochasticModel(nn.Module):
         """Check that the module has a sampling method, then sample it.
 
         Args:
-            module (nn.Module): The module to sample.
+            module: The module to sample.
 
         Raises:
             TypeError: Triggered when the module doesn't implement sample.
@@ -51,6 +51,14 @@ class StochasticModel(nn.Module):
         return weight_bias
 
     def sample(self, num_samples: int = 1) -> list[dict[str, Tensor]]:
+        """Sample the wrapped model multiple times.
+
+        Args:
+            num_samples: Number of samples to generate. Defaults to ``1``.
+
+        Returns:
+            list[dict[str, Tensor]]: Sampled model states.
+        """
         sampled_models = [{}] * num_samples
         for module_name in self.core_model._modules:
             module = self.core_model._modules[module_name]
@@ -74,6 +82,7 @@ class StochasticModel(nn.Module):
         return sampled_models
 
     def freeze(self) -> None:
+        """Freeze all Bayesian submodules in the wrapped model."""
         for module in self.core_model.modules():
             if isinstance(module, bayesian_modules):
                 freeze_fn = getattr(module, "freeze", None)
@@ -81,6 +90,7 @@ class StochasticModel(nn.Module):
                     freeze_fn()
 
     def unfreeze(self) -> None:
+        """Unfreeze all Bayesian submodules in the wrapped model."""
         for module in self.core_model.modules():
             if isinstance(module, bayesian_modules):
                 unfreeze_fn = getattr(module, "unfreeze", None)

--- a/src/torch_uncertainty/methods/swa.py
+++ b/src/torch_uncertainty/methods/swa.py
@@ -21,9 +21,9 @@ class SWA(nn.Module):
         uses the base model for training.
 
         Args:
-            core_model (nn.Module): PyTorch model to be trained.
-            cycle_start (int): Epoch to start SWA.
-            cycle_length (int): Number of epochs between SWA updates.
+            core_model: PyTorch model to be trained.
+            cycle_start: Epoch to start SWA.
+            cycle_length: Number of epochs between SWA updates.
 
         References:
             [1] `Averaging Weights Leads to Wider Optima and Better Generalization.. In UAI 2018

--- a/src/torch_uncertainty/methods/swag.py
+++ b/src/torch_uncertainty/methods/swag.py
@@ -36,14 +36,15 @@ class SWAG(SWA):
         the batchnorm statistics of the current SWAG samples.
 
         Args:
-            core_model (nn.Module): PyTorch model to be trained.
-            cycle_start (int): Begininning of the first SWAG averaging cycle.
-            cycle_length (int): Number of epochs between SWAG updates. The first update occurs at :attr:`cycle_start` + :attr:`cycle_length`.
-            scale (float): Scale of the Gaussian. Defaults to ``1.0``.
-            diag_covariance (bool): Whether to use a diagonal covariance. Defaults to ``False``.
-            max_num_models (int): Maximum number of models to store. Defaults to ``0``.
-            var_clamp (float): Minimum variance. Defaults to ``1e-30``.
-            num_estimators (int): Number of posterior estimates to use. Defaults to ``16``.
+            core_model: PyTorch model to be trained.
+            cycle_start: Beginning of the first SWAG averaging cycle.
+            cycle_length: Number of epochs between SWAG updates. The first update occurs at
+                :attr:`cycle_start` + :attr:`cycle_length`.
+            scale: Scale of the Gaussian. Defaults to ``1.0``.
+            diag_covariance: Whether to use a diagonal covariance. Defaults to ``False``.
+            max_num_models: Maximum number of models to store. Defaults to ``0``.
+            var_clamp: Minimum variance. Defaults to ``1e-30``.
+            num_estimators: Number of posterior estimates to use. Defaults to ``16``.
 
         References:
             [1] `A simple baseline for bayesian uncertainty in deep learning. In NeurIPS 2019
@@ -101,7 +102,7 @@ class SWAG(SWA):
         of the cycle length.
 
         Args:
-            epoch (int): Current epoch.
+            epoch : Current epoch.
         """
         if not (epoch > self.cycle_start and (epoch - self.cycle_start) % self.cycle_length == 0):
             return
@@ -138,11 +139,11 @@ class SWAG(SWA):
         self.fit = True
 
     def bn_update(self, loader: DataLoader, device: torch.device | str | int | None) -> None:
-        """Update the bachnorm statistics of the current SWAG samples.
+        """Update the batchnorm statistics of the current SWAG samples.
 
         Args:
-            loader (DataLoader): DataLoader to update the batchnorm statistics.
-            device (torch.device): Device to perform the update.
+            loader: DataLoader to update the batchnorm statistics.
+            device: Device to perform the update.
         """
         if self.need_bn_update:
             for mod in self.samples:
@@ -159,12 +160,10 @@ class SWAG(SWA):
         """Sample a model from the SWAG posterior.
 
         Args:
-            scale (float): Rescale coefficient of the Gaussian.
-            diag_covariance (bool): Whether to use a diagonal
-                covariance. Defaults to None.
-            block (bool): Whether to sample a block diagonal
-                covariance. Defaults to False.
-            seed (int): Random seed. Defaults to None.
+            scale: Rescale coefficient of the Gaussian.
+            diag_covariance: Whether to use a diagonal covariance. Defaults to ``None``.
+            block: Whether to sample a block diagonal covariance. Defaults to ``False``.
+            seed: Random seed. Defaults to ``None``.
 
         Returns:
             nn.Module: Sampled model.

--- a/src/torch_uncertainty/methods/zero.py
+++ b/src/torch_uncertainty/methods/zero.py
@@ -16,11 +16,11 @@ class Zero(nn.Module):
         passed as argument (:attr:`model`).
 
         Args:
-            core_model (nn.Module): The inner model to train.
-            num_tta (int): The number of views at evaluation time.
-            filter_views (float): Filter out 1-:attr:`filter_views` of the predictions of the augmented views.
+            core_model: The inner model to train.
+            num_tta: The number of views at evaluation time.
+            filter_views: Filter out 1-:attr:`filter_views` of the predictions of the augmented views.
                 Defaults to ``0.1``.
-            eps (float): for computational stability. Defaults to ``1e-8``;
+            eps: For computational stability. Defaults to ``1e-8``.
         """
         super().__init__()
         _zero_checks(num_tta, filter_views, eps)

--- a/src/torch_uncertainty/metrics/classification/brier_score.py
+++ b/src/torch_uncertainty/metrics/classification/brier_score.py
@@ -30,10 +30,10 @@ class BrierScore(Metric):
         better calibration and prediction quality.
 
         Args:
-            num_classes (int): Number of classes.
-            top_class (bool): If True, computes the Brier score for the
-                top predicted class only. Defaults to ``False``.
-            reduction (str): Determines how to reduce the score across the
+            num_classes: Number of classes.
+            top_class: If True, computes the Brier score for the top predicted class only.
+                Defaults to ``False``.
+            reduction: Determines how to reduce the score across the
                 batch dimension:
 
                 - ``'mean'`` [default]: Averages the score across samples.
@@ -114,10 +114,10 @@ class BrierScore(Metric):
         """Update the current Brier score with a new tensor of probabilities.
 
         Args:
-            probs (Tensor): A probability tensor of shape
+            probs: A probability tensor of shape
                 (batch, num_estimators, num_classes) or
                 (batch, num_classes)
-            target (Tensor): A tensor of ground truth labels of shape
+            target: A tensor of ground truth labels of shape
                 (batch, num_classes) or (batch)
         """
         if target.ndim == 1 and self.num_classes > 1:

--- a/src/torch_uncertainty/metrics/classification/calibration/adaptive_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/adaptive_calibration_error.py
@@ -18,11 +18,9 @@ def _equal_binning_bucketize(
     """Compute bins for the adaptive calibration error.
 
     Args:
-        confidences: The confidence (i.e. predicted prob) of the top1
-            prediction.
+        confidences: The confidence (i.e. predicted prob) of the top-1 prediction.
         accuracies: 1.0 if the top-1 prediction was correct, 0.0 otherwise.
-        num_bins: Number of bins to use when computing adaptive calibration
-            error.
+        num_bins: Number of bins to use when computing adaptive calibration error.
 
     Returns:
         tuple with binned accuracy, binned confidence and binned probabilities
@@ -52,19 +50,15 @@ def _ace_compute(
     norm: Literal["l1", "l2", "max"] = "l1",
     debias: bool = False,
 ) -> Tensor:
-    """Compute the adaptive calibration error given the provided number of bins
-        and norm.
+    """Compute the adaptive calibration error given the provided number of bins and norm.
 
     Args:
-        confidences: The confidence (i.e. predicted prob) of the top1
-            prediction.
+        confidences: The confidence (i.e. predicted prob) of the top-1 prediction.
         accuracies: 1.0 if the top-1 prediction was correct, 0.0 otherwise.
-        num_bins: Number of bins to use when computing adaptive calibration
-            error.
-        norm: Norm function to use when computing calibration error. Defaults
-            to "l1".
-        debias: Apply debiasing to L2 norm computation as in
-            `Verified Uncertainty Calibration`. Defaults to False.
+        num_bins: Number of bins to use when computing adaptive calibration error.
+        norm: Norm function to use when computing calibration error. Defaults to ``"l1"``.
+        debias: Apply debiasing to L2 norm computation as in `Verified Uncertainty Calibration`.
+            Defaults to ``False``.
 
     Returns:
         Tensor: Adaptive Calibration error scalar.
@@ -105,7 +99,15 @@ class BinaryAdaptiveCalibrationError(Metric):
         validate_args: bool = True,
         **kwargs: Any,
     ) -> None:
-        r"""Adaptive Top-label Calibration Error for binary tasks."""
+        r"""Adaptive Top-label Calibration Error for binary tasks.
+
+        Args:
+            n_bins: Number of bins to use when computing the calibration error. Defaults to ``10``.
+            norm: Norm function to use when computing calibration error. Defaults to ``"l1"``.
+            ignore_index: Index to ignore during calculations. Defaults to ``None``.
+            validate_args: Whether to validate input arguments. Defaults to ``True``.
+            kwargs: Additional keyword arguments passed to the parent metric.
+        """
         super().__init__(**kwargs)
         if ignore_index is not None:  # coverage: ignore
             raise ValueError("ignore_index is not supported for multiclass tasks.")
@@ -149,7 +151,16 @@ class MulticlassAdaptiveCalibrationError(Metric):
         validate_args: bool = True,
         **kwargs: Any,
     ) -> None:
-        r"""Adaptive Top-label Calibration Error for multiclass tasks."""
+        r"""Adaptive Top-label Calibration Error for multiclass tasks.
+
+        Args:
+            num_classes: Number of classes.
+            n_bins: Number of bins to use when computing the calibration error. Defaults to ``10``.
+            norm: Norm function to use when computing calibration error. Defaults to ``"l1"``.
+            ignore_index: Index to ignore during calculations. Defaults to ``None``.
+            validate_args: Whether to validate input arguments. Defaults to ``True``.
+            kwargs: Additional keyword arguments passed to the parent metric.
+        """
         super().__init__(**kwargs)
         if ignore_index is not None:  # coverage: ignore
             raise ValueError("ignore_index is not supported for multiclass tasks.")
@@ -198,13 +209,14 @@ class AdaptiveCalibrationError:
         concentrated in certain regions of the probability space.
 
         Args:
-            task (str): Specifies the task type, either ``"binary"`` or ``"multiclass"``.
-            num_bins (int): Number of bins to divide the probability space. Defaults to ``10``.
-            norm (str): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``. Defaults to ``"l1"``.
-            num_classes (int): Number of classes for ``"multiclass"`` tasks. Required when task is ``"multiclass"``.
-            ignore_index (int): Index to ignore during calculations. Defaults to ``None``.
-            validate_args (bool): Whether to validate input arguments. Defaults to ``True``.
-            **kwargs (Any): Additional keyword arguments passed to the metric.
+            task: Specifies the task type, either ``"binary"`` or ``"multiclass"``.
+            num_bins: Number of bins to divide the probability space. Defaults to ``10``.
+            norm: Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
+                Defaults to ``"l1"``.
+            num_classes: Number of classes for ``"multiclass"`` tasks. Required when task is ``"multiclass"``.
+            ignore_index: Index to ignore during calculations. Defaults to ``None``.
+            validate_args: Whether to validate input arguments. Defaults to ``True``.
+            kwargs: Additional keyword arguments passed to the metric.
 
         Example:
 
@@ -218,7 +230,7 @@ class AdaptiveCalibrationError:
                 predicted_probs = torch.tensor([0.95, 0.85, 0.15, 0.05])
                 true_labels = torch.tensor([1, 1, 0, 0])
 
-                metric = CalibrationError(
+                metric = AdaptiveCalibrationError(
                     task="binary",
                     num_bins=5,
                     norm="l1",

--- a/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
@@ -147,8 +147,9 @@ def reliability_chart(
     figsize: tuple[float, float] = (6.0, 6.0),
     dpi: int = 150,
 ) -> tuple[object, object]:
-    """Builds Reliability Diagram
-    `Source <https://github.com/hollance/reliability-diagrams>`_.
+    """Build a reliability diagram.
+
+    Source: `reliability-diagrams <https://github.com/hollance/reliability-diagrams>`_.
     """
     figsize = (figsize[0], figsize[0] * 1.4)
 
@@ -192,6 +193,7 @@ def custom_plot(
     ch_xlabel: str = "Top-class Confidence (%)",
     ch_ylabel: str = "Density (%)",
 ) -> tuple[object, object]:
+    """Plot a reliability chart from stored confidence and accuracy states."""
     confidences = dim_zero_cat(self.confidences)
     accuracies = dim_zero_cat(self.accuracies)
 
@@ -295,19 +297,19 @@ class CalibrationError:
             - :math:`c_i` is the mean predicted confidence in bin :math:`i`.
             - :math:`b_i` is the fraction of total samples falling into bin :math:`i`.
 
-        Bins are constructed either uniformly in the range :math:`[0, 1]` or adaptively
-        (if `adaptive=True`).
+        Bins are constructed either uniformly in the range :math:`[0, 1]` or
+        adaptively (if ``adaptive=True``).
 
         Args:
-            task (str): Specifies the task type, either ``"binary"`` or ``"multiclass"``.
-            adaptive (bool): Whether to use adaptive binning. Defaults to ``False``.
-            num_bins (int): Number of bins to divide the probability space. Defaults to ``10``.
-            norm (str): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
+            task: Specifies the task type, either ``"binary"`` or ``"multiclass"``.
+            adaptive: Whether to use adaptive binning. Defaults to ``False``.
+            num_bins : Number of bins to divide the probability space. Defaults to ``10``.
+            norm: Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
                 Defaults to ``"l1"``.
-            num_classes (int): Number of classes for ``"multiclass"`` tasks. Required when task
-                is ``"multiclass"``.
-            ignore_index (int): Index to ignore during calculations. Defaults to ``None``.
-            validate_args (bool): Whether to validate input arguments. Defaults to ``True``.
+            num_classes: Number of classes for ``"multiclass"`` tasks.
+                Required when task is ``"multiclass"``. Defaults to ``None``.
+            ignore_index: Index to ignore during calculations. Defaults to ``None``.
+            validate_args: Whether to validate input arguments. Defaults to ``True``.
             **kwargs: Additional keyword arguments for the metric.
 
         Example:
@@ -334,12 +336,12 @@ class CalibrationError:
             # Output: Calibration Error: 0.199
 
         Note:
-            Bins are either uniformly distributed in :math:`[0, 1]` or adaptively sized
-            (if `adaptive=True`).
+            Bins are either uniformly distributed in :math:`[0, 1]` or
+            adaptively sized (if ``adaptive=True``).
 
         Warning:
-            If `task="multiclass"`, `num_classes` must be an integer; otherwise, a :class:`TypeError`
-            is raised.
+            If ``task="multiclass"``, ``num_classes`` must be an integer;
+            otherwise, a :class:`TypeError` is raised.
 
         References:
             [1] `Naeini et al. Obtaining well calibrated probabilities using Bayesian binning. In AAAI, 2015
@@ -347,7 +349,8 @@ class CalibrationError:
 
         .. seealso::
             See `CalibrationError <https://torchmetrics.readthedocs.io/en/stable/classification/calibration_error.html>`_
-            for details. Our version of the metric is a wrapper around the original metric providing an improved plotting functionality.
+            for details. This implementation wraps the original metric and
+            provides improved plotting functionality.
         """
         if kwargs.get("n_bins") is not None:
             raise ValueError("`n_bins` does not exist in TorchUncertainty, use `num_bins`.")

--- a/src/torch_uncertainty/metrics/classification/calibration/classwise_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/classwise_calibration_error.py
@@ -33,11 +33,11 @@ class ClasswiseCalibrationError(Metric):
         lower score indicates better calibration quality.
 
         Args:
-            num_classes (int): Number of classes.
-            num_bins (int): Number of calibration bins. Defaults to ``15``.
-            norm (Literal["l1", "l2", "max"]): Norm used to compute the ECE (e.g., ``'l1'``,
-                ``'l2'``, ``'max'``). Defaults to ``'l1'``.
-            reduction (Literal["mean", "sum", "none"] | None): Determines how to reduce the score across the
+            num_classes: Number of classes.
+            num_bins: Number of calibration bins. Defaults to ``15``.
+            norm: Norm used to compute the ECE (e.g., ``'l1'``, ``'l2'``, ``'max'``).
+                Defaults to ``'l1'``.
+            reduction: Determines how to reduce the score across the
                 classes:
 
                 - ``'mean'`` [default]: Averages the ECE across classes.
@@ -110,8 +110,8 @@ class ClasswiseCalibrationError(Metric):
         """Update the state with a new tensor of probabilities.
 
         Args:
-            probs (Tensor): A probability tensor of shape (batch, num_classes).
-            target (Tensor): A tensor of ground truth labels of shape
+            probs: A probability tensor of shape (batch, num_classes).
+            target: A tensor of ground truth labels of shape
                 (batch, num_classes) or (batch).
         """
         if target.ndim == 1 and self.num_classes > 1:

--- a/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_error.py
@@ -27,7 +27,7 @@ class SmoothCalibrationError(Metric):
         refine_steps: int = 10,
         **kwargs,
     ):
-        """Smooth Expected Calibration Error (SmECE).
+        r"""Smooth Expected Calibration Error (SmECE).
 
         This metric implements the Kernel Density Estimation based ECE as
         proposed by Błasiok & Nakkiran (2023). It addresses the limitations of
@@ -36,29 +36,30 @@ class SmoothCalibrationError(Metric):
         bandwidth selection strategy. Computed on the top label.
 
         Args:
-            kernel_type (str): The kernel to use. Choose between:
+            kernel_type: The kernel to use. Choose between:
                 - ``'logit'``: Applies a Gaussian kernel in log-odds space. This
                     effectively uses an adaptive bandwidth that is narrower near 1.0,
                     making it ideal for modern overconfident models. (Default)
                 - ``'reflected'``: Applies a Gaussian kernel in probability space
                     with reflections at 0 and 1 to prevent boundary bias.
-                Note that relplot's original implementation has ``'reflected'`` as default.
-            bandwidth (Literal[auto] | float): The kernel bandwidth $h$. If set to
+                Note that relplot's original implementation uses ``'reflected'`` by default.
+            bandwidth: The kernel bandwidth :math:`h`. If set to
                 ``'auto'``, it uses a fixed-point binary search to find a bandwidth
                 consistent with the error level. Defaults to ``'auto'``.
-            eps (float): The tolerance for the binary search when
+            eps: The tolerance for the binary search when
                 bandwidth is ``'auto'``. Defaults to ``0.001``.
-            mesh_pts (int): The base number of points for the grid
+            mesh_pts: The base number of points for the grid
                 discretization. The actual number may be higher depending on the
                 bandwidth. Defaults to ``200``.
-            refine_steps (int): Number of binary search iterations for
+            refine_steps: Number of binary search iterations for
                 the ``'auto'`` bandwidth. Defaults to ``10``.
             **kwargs: Additional arguments for the :class:`torchmetrics.Metric` base.
 
         Note:
             In the multiclass case, this metric evaluates the calibration of the
             maximum probability (top-label calibration). In the binary case, it
-            evaluates the calibration of the predicted class (i.e., using $max(p, 1-p)$).
+            evaluates the calibration of the predicted class (i.e., using
+            :math:`\max(p, 1-p)`).
 
         Note:
             This implementation has been tested on a use case and provided the same values
@@ -87,10 +88,10 @@ class SmoothCalibrationError(Metric):
         """Update the state with predictions and targets.
 
         Args:
-            preds (Tensor): Predictions from the model.
+            preds: Predictions from the model.
                 - Multiclass: Shape ``(N, C)`` (logits or probabilities).
                 - Binary: Shape ``(N,)`` or ``(N, 1)`` (logits or probabilities).
-            target (Tensor): Ground truth labels.
+            target: Ground truth labels.
                 - Multiclass: Shape ``(N,)`` containing class indices.
                 - Binary: Shape ``(N,)`` containing 0 or 1.
         """

--- a/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_kernels.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_kernels.py
@@ -12,7 +12,7 @@ def smooth_round_to_grid(f: Tensor, y: Tensor, num_eval_points: int) -> Tensor:
 
     Args:
         f: A 1D Tensor of positions, expected to be normalized in the range [0, 1].
-        y: A 1D Tensor of weights or values associated with each position in `f`.
+        y: A 1D Tensor of weights or values associated with each position in ``f``.
         num_eval_points: The number of bins in the output grid.
 
     Returns:
@@ -39,7 +39,7 @@ def interpolate(t: Tensor, y: Tensor) -> Tensor:
         y: A 1D Tensor representing the discrete grid of values.
 
     Returns:
-        The interpolated values at positions `t`.
+        The interpolated values at positions ``t``.
     """
     num_buckets = y.size(0)
     bucket_size = 1.0 / (num_buckets - 1)
@@ -58,7 +58,7 @@ class GaussianKernel:
         $$K(d) = \\frac{1}{\\sigma\\sqrt{2\\pi}} \\exp\\left(-\\frac{d^2}{2\\sigma^2}\\right)$$
 
         Args:
-            sigma (float): The standard deviation (bandwidth) of the Gaussian kernel.
+            sigma: The standard deviation (bandwidth) of the Gaussian kernel.
         """
         self.sigma = sigma
 
@@ -98,10 +98,10 @@ class GaussianKernel:
         """Performs kernel smoothing.
 
         Args:
-            f (Tensor): Input positions [0, 1].
-            y (Tensor): Input values.
-            eval_coordinates (Tensor): Point coordinates at which to evaluate the smoothed function.
-            eps (float): A small constant to prevent division by zero in low-density regions.
+            f: Input positions [0, 1].
+            y: Input values.
+            eval_coordinates: Point coordinates at which to evaluate the smoothed function.
+            eps: A small constant to prevent division by zero in low-density regions.
                 Defaults to ``1e-4``.
 
         Returns:
@@ -141,7 +141,7 @@ class LogitGaussianKernel:
         smoothing in the unconstrained space, and maps back.
 
         Args:
-            sigma (float): Bandwidth applied in the logit-transformed space.
+            sigma: Bandwidth applied in the logit-transformed space.
         """
         self.sigma = sigma
 

--- a/src/torch_uncertainty/metrics/classification/categorical_nll.py
+++ b/src/torch_uncertainty/metrics/classification/categorical_nll.py
@@ -34,7 +34,7 @@ class CategoricalNLL(Metric):
         of sample :math:`i`.
 
         Args:
-            reduction (str): Determines how to reduce the computed loss over
+            reduction: Determines how to reduce the computed loss over
                 the batch dimension:
 
                 - ``'mean'`` [default]: Averages the loss across samples in the batch.
@@ -101,8 +101,8 @@ class CategoricalNLL(Metric):
         r"""Update state with prediction probabilities and targets.
 
         Args:
-            probs (Tensor): Probabilities from the model.
-            target (Tensor): Ground truth labels.
+            probs: Probabilities from the model.
+            target: Ground truth labels.
 
         For each sample :math:`i`, the negative log likelihood is computed as:
 

--- a/src/torch_uncertainty/metrics/classification/coverage_rate.py
+++ b/src/torch_uncertainty/metrics/classification/coverage_rate.py
@@ -23,18 +23,17 @@ class CoverageRate(Metric):
         """Empirical coverage rate metric.
 
         Args:
-            num_classes (int | None): Number of classes. Defaults to ``None``.
-            average (str): Defines the reduction that is applied over labels. Should be
-                one of the following:
+            num_classes: Number of classes. Defaults to ``None``.
+            average: Defines the reduction that is applied over labels.  Defaults to ``"macro"``.
+                Should be one of the following:
 
-                - ``'macro'`` (default): Compute the metric for each class separately and find their
+                - ``'macro'``: Compute the metric for each class separately and find their
                   unweighted mean. This does not take label imbalance into account.
                 - ``'micro'``: Sum statistics across over all labels.
 
-            validate_args (bool): Whether to validate the arguments. Defaults to ``True``.
+            validate_args: Whether to validate the arguments. Defaults to ``True``.
             kwargs: Additional keyword arguments, see `Advanced metric settings
                 <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
-
 
         Raises:
             ValueError: If `num_classes` is `None` and `average` is not `micro`.
@@ -68,9 +67,9 @@ class CoverageRate(Metric):
         """Update the metric state with predictions and targets.
 
         Args:
-            preds (torch.Tensor): predicted sets tensor of shape (B, C), where B is the batch size
+            preds: Predicted sets tensor of shape (B, C), where B is the batch size
                 and C is the number of classes.
-            target (torch.Tensor): target sets tensor of shape (B,).
+            target: Target labels tensor of shape (B,).
         """
         batch_size = preds.size(0)
         target = target.long()

--- a/src/torch_uncertainty/metrics/classification/disagreement.py
+++ b/src/torch_uncertainty/metrics/classification/disagreement.py
@@ -26,7 +26,7 @@ class Disagreement(Metric):
         estimators.
 
         Args:
-            reduction (str): Determines how to reduce over the :math:`B`/batch dimension:
+            reduction: Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples
@@ -101,7 +101,7 @@ class Disagreement(Metric):
         """Update state with prediction probabilities and targets.
 
         Args:
-            probs (torch.Tensor): Probabilities from the model.
+            probs: Probabilities from the model.
         """
         preds = probs.argmax(dim=-1)
         if self.reduction is None or self.reduction == "none":

--- a/src/torch_uncertainty/metrics/classification/entropy.py
+++ b/src/torch_uncertainty/metrics/classification/entropy.py
@@ -23,8 +23,7 @@ class Entropy(Metric):
         or the mean confidence across estimators.
 
         Args:
-            reduction (str): Determines how to reduce over the
-                :math:`B`/batch dimension:
+            reduction: Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples
@@ -99,7 +98,7 @@ class Entropy(Metric):
         """Update the current entropy with a new tensor of probabilities.
 
         Args:
-            probs (torch.Tensor): Probabilities from the model.
+            probs: Probabilities from the model.
         """
         batch_size = probs.size(0)
         entropy = torch.special.entr(probs).sum(dim=-1)
@@ -114,9 +113,7 @@ class Entropy(Metric):
             self.total += batch_size
 
     def compute(self) -> torch.Tensor:
-        """Computes Entropy based on inputs passed in to ``update``
-        previously.
-        """
+        """Compute entropy based on inputs passed to ``update``."""
         values = dim_zero_cat(self.values)
         if self.reduction == "sum":
             return values.sum(dim=-1)

--- a/src/torch_uncertainty/metrics/classification/fpr.py
+++ b/src/torch_uncertainty/metrics/classification/fpr.py
@@ -16,15 +16,20 @@ class FPRx(Metric):
     def __init__(self, recall_level: float, pos_label: int, **kwargs) -> None:
         r"""Compute the False Positive Rate at x% Recall.
 
-        The False Positive Rate at x% Recall (FPR@x) is a metric used in tasks like anomaly detection, out-of-distribution (OOD) detection, and binary classification. It measures the proportion of false positives (normal samples misclassified as anomalies) when the model achieves a specified recall level for the positive class (e.g., anomalies or OOD samples).
+        The False Positive Rate at x% Recall (FPR@x) is used in anomaly
+        detection, out-of-distribution (OOD) detection, and binary
+        classification. It measures the proportion of false positives
+        (normal samples misclassified as anomalies) when the model reaches
+        a specified recall level for the positive class.
 
         Args:
-            recall_level (float): The recall level at which to compute the FPR.
-            pos_label (int): The positive label.
-            kwargs: Additional arguments to pass to the metric class.
+            recall_level: The recall level at which to compute the FPR.
+            pos_label: The positive label.
+            kwargs: Additional keyword arguments for the metric class.
 
         Reference:
-            Improved from https://github.com/hendrycks/anomaly-seg and translated to torch.
+            Improved from `anomaly-seg <https://github.com/hendrycks/anomaly-seg>`_
+            and translated to torch.
 
         Example:
             .. code-block:: python
@@ -44,7 +49,7 @@ class FPRx(Metric):
                 # Compute FPR at 95% recall
                 result = metric.compute()
                 print(f"FPR at 95% Recall: {result.item()}")
-                # output : FPR at 95% Recall: 0.75
+                # output: FPR at 95% Recall: 0.75
         """
         super().__init__(**kwargs)
 
@@ -65,8 +70,8 @@ class FPRx(Metric):
         """Update the metric state.
 
         Args:
-            confidences (Tensor): The confidence scores.
-            target (Tensor): The target labels, 0 if ID, 1 if OOD.
+            confidences: The confidence scores.
+            target: The target labels, 0 if ID, 1 if OOD.
         """
         self.confidences.append(confidences)
         self.targets.append(target)
@@ -134,10 +139,10 @@ class FPR95(FPRx):
         This is a specific case of the more general FPRx metric, where the recall level is fixed at 95%.
 
         Args:
-            pos_label (int): The positive label (e.g., 1 for OOD samples).
-            kwargs: Additional arguments to pass to the FPRx metric class.
+            pos_label: The positive label (e.g., 1 for OOD samples).
+            kwargs: Additional keyword arguments for :class:`FPRx`.
 
         .. seealso::
-            - :class:`FPRx` - The base metric that allows customization of the recall level.
+            - :class:`FPRx`: Base metric that allows customization of the recall level.
         """
         super().__init__(recall_level=0.95, pos_label=pos_label, **kwargs)

--- a/src/torch_uncertainty/metrics/classification/grouping_loss.py
+++ b/src/torch_uncertainty/metrics/classification/grouping_loss.py
@@ -87,12 +87,12 @@ class GroupingLoss(Metric):
         """Accumulate the tensors for the estimation of the Grouping Loss.
 
         Args:
-            probs (Tensor): A probability tensor of shape (batch, num_classes),
+            probs: A probability tensor of shape (batch, num_classes),
                 (batch, num_estimators, num_classes), or (batch) if binary
                 classification
-            target (Tensor): A tensor of ground truth labels of shape
+            target: A tensor of ground truth labels of shape
                 (batch, num_classes) or (batch)
-            features (Tensor): A tensor of features of shape
+            features: A tensor of features of shape
                 (batch, num_estimators, num_features) or (batch, num_features)
         """
         if target.ndim == 2:

--- a/src/torch_uncertainty/metrics/classification/mutual_information.py
+++ b/src/torch_uncertainty/metrics/classification/mutual_information.py
@@ -25,7 +25,7 @@ class MutualInformation(Metric):
         ensemble of estimators.
 
         Args:
-            reduction (str): Determines how to reduce over the :math:`B`/batch dimension:
+            reduction: Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples
@@ -79,7 +79,7 @@ class MutualInformation(Metric):
         probabilities.
 
         Args:
-            probs (torch.Tensor): Likelihoods from the ensemble of shape
+            probs: Likelihoods from the ensemble of shape
                 :math:`(B, N, C)`, where :math:`B` is the batch size,
                 :math:`N` is the number of estimators and :math:`C` is the
                 number of classes.
@@ -99,9 +99,7 @@ class MutualInformation(Metric):
             self.total += batch_size
 
     def compute(self) -> torch.Tensor:
-        r"""Computes Mutual Information based on inputs passed in to ``update``
-        previously.
-        """
+        r"""Compute mutual information based on inputs passed to ``update``."""
         values = torch.clamp(dim_zero_cat(self.values), min=0)
         if self.reduction == "sum":
             return values.sum(dim=-1)

--- a/src/torch_uncertainty/metrics/classification/risk_coverage.py
+++ b/src/torch_uncertainty/metrics/classification/risk_coverage.py
@@ -55,8 +55,7 @@ class AURC(Metric):
             tensor(0.0833)  # Example output
 
         References:
-            [1] `Geifman & El-Yaniv.`Selective classification for deep neural networks. In NeurIPS, 2017
-            <https://papers.nips.cc/paper_files/paper/2017/file/4a8423d5e91fda00bb7e46540e2b0cf1-Paper.pdf>`_.
+            [1] `Geifman & El-Yaniv. Selective classification for deep neural networks. In NeurIPS, 2017 <https://papers.nips.cc/paper_files/paper/2017/file/4a8423d5e91fda00bb7e46540e2b0cf1-Paper.pdf>`_.
         """
         super().__init__(**kwargs)
         self.add_state("scores", default=[], dist_reduce_fx="cat")
@@ -66,8 +65,8 @@ class AURC(Metric):
         """Store the scores and their associated errors for later computation.
 
         Args:
-            probs (Tensor): The predicted probabilities of shape :math:`(N, C)`.
-            targets (Tensor): The ground truth labels of shape :math:`(N,)`.
+            probs: The predicted probabilities of shape :math:`(N, C)`.
+            targets: The ground truth labels of shape :math:`(N,)`.
         """
         if probs.ndim == 1:
             probs = torch.stack([1 - probs, probs], dim=-1)
@@ -113,14 +112,12 @@ class AURC(Metric):
         ``update``.
 
         Args:
-            ax (Axes | None): An matplotlib axis object. If provided
-                will add plot to this axis. Defaults to None.
-            plot_value (bool): Whether to print the AURC value on the
-                plot. Defaults to True.
-            name (str | None): Name of the model. Defaults to None.
+            ax: A matplotlib axis object. If provided, the plot is added to this axis. Defaults to ``None``.
+            plot_value: Whether to print the AURC value on the plot. Defaults to ``True``.
+            name: Name of the model. Defaults to ``None``.
 
         Returns:
-            tuple[[Figure | None], Axes]: Figure object and Axes object
+            tuple[Figure | None, Axes]: Figure object and axes object.
         """
         fig, ax = plt.subplots(figsize=(6, 6)) if ax is None else (None, ax)
         ax = cast("plt.Axes", ax)
@@ -172,8 +169,8 @@ def _aurc_rejection_rate_compute(
     """Compute the cumulative error rates for a given set of scores and errors.
 
     Args:
-        scores (Tensor): uncertainty scores of shape :math:`(B,)`
-        errors (Tensor): binary errors of shape :math:`(B,)`
+        scores: uncertainty scores of shape :math:`(B,)`
+        errors: binary errors of shape :math:`(B,)`
     """
     errors = errors[scores.argsort(descending=True)]
     return errors.cumsum(dim=-1) / torch.arange(
@@ -185,8 +182,8 @@ class AUGRC(AURC):
     def __init__(self, **kwargs) -> None:
         r"""Calculate The Area Under the Generalized Risk-Coverage curve (AUGRC).
 
-        The Area Under the Generalized Risk-Coverage curve (AUGRC) for Selective Classification (SC) performance assessment. It avoids putting too much
-        weight on the most confident samples.
+        The Area Under the Generalized Risk-Coverage curve (AUGRC) for selective classification
+        performance assessment. It avoids putting too much weight on the most confident samples.
 
         As input to ``forward`` and ``update`` the metric accepts the following input:
 
@@ -205,8 +202,7 @@ class AUGRC(AURC):
             kwargs: Additional keyword arguments.
 
         References:
-            [1] `Traub et al. Overcoming Common Flaws in the Evaluation of Selective Classification Systems
-            <https://arxiv.org/pdf/2407.01032>`_.
+            [1] `Traub et al. Overcoming Common Flaws in the Evaluation of Selective Classification Systems <https://arxiv.org/pdf/2407.01032>`_.
 
         .. seealso::
             - :class:`~torch_uncertainty.metrics.classification.AURC` : Parent class, the AURC metric
@@ -237,14 +233,12 @@ class AUGRC(AURC):
         ``update``.
 
         Args:
-            ax (Axes | None): An matplotlib axis object. If provided
-                will add plot to this axis. Defaults to None.
-            plot_value (bool): Whether to print the AURC value on the
-                plot. Defaults to True.
-            name (str | None): Name of the model. Defaults to None.
+            ax: A matplotlib axis object. If provided, the plot is added to this axis. Defaults to ``None``.
+            plot_value: Whether to print the AURC value on the plot. Defaults to ``True``.
+            name: Name of the model. Defaults to ``None``.
 
         Returns:
-            tuple[[Figure | None], Axes]: Figure object and Axes object
+            tuple[Figure | None, Axes]: Figure object and axes object.
         """
         fig, ax = plt.subplots(figsize=(6, 6)) if ax is None else (None, ax)
         ax = cast("plt.Axes", ax)
@@ -303,11 +297,10 @@ class CovAtxRisk(Metric):
         If there are multiple coverage values corresponding to the given risk,
         i.e., the risk(coverage) is not monotonic, the coverage at x risk is
         the maximum coverage value corresponding to the given risk. If no
-        there is no coverage value corresponding to the given risk, return
-        float("nan").
+        there is no coverage value corresponding to the given risk, this metric returns ``float("nan")``.
 
         Args:
-            risk_threshold (float): The risk threshold at which to compute the coverage.
+            risk_threshold: The risk threshold at which to compute the coverage.
             kwargs: Additional arguments to pass to the metric class.
 
         Example:
@@ -347,8 +340,8 @@ class CovAtxRisk(Metric):
         """Store the scores and their associated errors for later computation.
 
         Args:
-            probs (Tensor): The predicted probabilities of shape :math:`(N, C)`.
-            targets (Tensor): The ground truth labels of shape :math:`(N,)`.
+            probs: The predicted probabilities of shape :math:`(N, C)`.
+            targets: The ground truth labels of shape :math:`(N,)`.
         """
         if probs.ndim == 1:
             probs = torch.stack([1 - probs, probs], dim=-1)
@@ -383,10 +376,10 @@ class CovAt5Risk(CovAtxRisk):
 
         If there are multiple coverage values corresponding to 5% risk, the
         coverage at 5% risk is the maximum coverage value corresponding to 5%
-        risk. If no there is no coverage value corresponding to the given risk,
-        this metric returns float("nan").
+        risk. If there is no coverage value corresponding to the given risk,
+        this metric returns ``float("nan")``.
 
-        This is a specific case of the more general CovAtxRisk metric, where the risk level is fixed at 5%.
+        This is a specific case of the more general :class:`CovAtxRisk` metric, where the risk level is fixed at 5%.
 
         .. seealso::
             - :class:`CovAtxRisk` : Parent class, the CovAtxRisk metric
@@ -411,7 +404,7 @@ class RiskAtxCov(Metric):
         trade-off between coverage and risk in predictive models.
 
         Args:
-            cov_threshold (float): The coverage threshold at which to compute the risk.
+            cov_threshold: The coverage threshold at which to compute the risk.
             kwargs: Additional arguments to pass to the metric class.
 
         Example:
@@ -461,8 +454,8 @@ class RiskAtxCov(Metric):
         """Store the scores and their associated errors for later computation.
 
         Args:
-            probs (Tensor): The predicted probabilities of shape :math:`(N, C)`.
-            targets (Tensor): The ground truth labels of shape :math:`(N,)`.
+            probs: The predicted probabilities of shape :math:`(N, C)`.
+            targets: The ground truth labels of shape :math:`(N,)`.
         """
         if probs.ndim == 1:
             probs = torch.stack([1 - probs, probs], dim=-1)
@@ -485,7 +478,7 @@ class RiskAt80Cov(RiskAtxCov):
     def __init__(self, **kwargs) -> None:
         r"""Compute the risk at 80% coverage.
 
-        This is a specific case of the more general RiskAtxCov metric, where the risk level is fixed at 80%.
+        This is a specific case of the more general :class:`RiskAtxCov` metric, where the coverage level is fixed at 80%.
 
         .. seealso::
             - :class:`RiskAtxCov` : Parent class, the RiskAtxCov metric

--- a/src/torch_uncertainty/metrics/classification/set_size.py
+++ b/src/torch_uncertainty/metrics/classification/set_size.py
@@ -23,8 +23,7 @@ class SetSize(Metric):
         """Set size to compute the efficiency of conformal prediction methods.
 
         Args:
-            reduction (str): Determines how to reduce over the
-                :math:`B`/batch dimension:
+            reduction: Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples
@@ -54,9 +53,9 @@ class SetSize(Metric):
         """Update the metric state with predictions and targets.
 
         Args:
-            preds (torch.Tensor): predicted sets tensor of shape (B, C), where B is the batch size
-                and C is the number of classes.
-            targets (torch.Tensor): For API consistency
+            preds: Predicted sets tensor of shape ``(B, C)``, where ``B`` is the
+                batch size and ``C`` is the number of classes.
+            targets: Unused. Kept for API consistency. Defaults to ``None``.
         """
         batch_size = preds.size(0)
         pred_sizes = preds.bool().sum(-1)
@@ -69,10 +68,10 @@ class SetSize(Metric):
             self.total += batch_size
 
     def compute(self) -> Tensor:
-        """Compute the mean set size.
+        """Compute the set size.
 
         Returns:
-            Tensor: The coverage rate.
+            Tensor: The set size according to the selected reduction.
         """
         values = dim_zero_cat(self.sizes)
         if self.reduction == "sum":

--- a/src/torch_uncertainty/metrics/classification/variation_ratio.py
+++ b/src/torch_uncertainty/metrics/classification/variation_ratio.py
@@ -27,8 +27,8 @@ class VariationRatio(Metric):
         predicted class labels that are not the chosen (most frequent) class.
 
         Args:
-            probabilistic (bool): Whether to use probabilistic predictions. Defaults to True.
-            reduction (Literal["mean", "sum", "none", None]): Determines how to reduce over the batch dimension:
+            probabilistic: Whether to use probabilistic predictions. Defaults to ``True``.
+            reduction: Determines how to reduce over the batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples

--- a/src/torch_uncertainty/metrics/regression/inverse.py
+++ b/src/torch_uncertainty/metrics/regression/inverse.py
@@ -50,9 +50,10 @@ class MeanSquaredErrorInverse(MeanSquaredError):
           squared error
 
         Args:
-            squared: If True returns MSE value, if False returns RMSE value.
+            squared: If ``True``, returns MSE. If ``False``, returns RMSE.
             num_outputs: Number of outputs in multioutput setting.
-            unit: Unit for the computation of the metric. Must be one of 'mm', 'm', 'km'. Defauts to 'km'.
+            unit: Unit for the computation of the metric. Must be one of
+                ``"mm"``, ``"m"``, ``"km"``. Defaults to ``"km"``.
             kwargs: Additional keyword arguments.
         """
         super().__init__(squared, num_outputs, **kwargs)
@@ -87,7 +88,8 @@ class MeanAbsoluteErrorInverse(MeanAbsoluteError):
           mean absolute error over the state
 
         Args:
-            unit: Unit for the computation of the metric. Must be one of 'mm', 'm', 'km'. Defauts to 'km'.
+            unit: Unit for the computation of the metric. Must be one of
+                ``"mm"``, ``"m"``, ``"km"``. Defaults to ``"km"``.
             kwargs: Additional keyword arguments.
         """
         super().__init__(**kwargs)

--- a/src/torch_uncertainty/metrics/regression/log10.py
+++ b/src/torch_uncertainty/metrics/regression/log10.py
@@ -5,7 +5,7 @@ from torchmetrics import MeanAbsoluteError
 
 class Log10(MeanAbsoluteError):
     def __init__(self, **kwargs) -> None:
-        r"""Computes the LOG10 metric.
+        r"""Compute the LOG10 metric.
 
         The Log10 metric computes the mean absolute error in the base-10 logarithmic space.
 
@@ -16,12 +16,13 @@ class Log10(MeanAbsoluteError):
         - :math:`y_i` represents the true target values.
         - :math:`\hat{y_i}` represents the predicted values.
 
-        This metric is useful for scenarios where the data spans multiple orders of magnitude, and evaluating
-        error in log-space provides a more meaningful comparison.
+        This metric is useful when data spans multiple orders of magnitude,
+        where evaluating error in log-space provides a more meaningful
+        comparison.
 
         Inputs:
-        - :attr:`preds`: :math:`(N)`
-        - :attr:`target`: :math:`(N)`
+            - :attr:`preds`: :math:`(N)`
+            - :attr:`target`: :math:`(N)`
 
         Args:
             kwargs: Additional keyword arguments, see `Advanced metric settings <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.

--- a/src/torch_uncertainty/metrics/regression/mse_log.py
+++ b/src/torch_uncertainty/metrics/regression/mse_log.py
@@ -4,7 +4,7 @@ from torchmetrics import MeanSquaredError
 
 class MeanSquaredLogError(MeanSquaredError):
     def __init__(self, squared: bool = True, **kwargs) -> None:
-        r"""Computes the Mean Squared Logarithmic Error (MSLE) regression metric.
+        r"""Compute the Mean Squared Logarithmic Error (MSLE).
 
         This metric is commonly used in regression problems where the relative
         difference between predictions and targets is of greater importance than
@@ -26,11 +26,11 @@ class MeanSquaredLogError(MeanSquaredError):
         As output of ``forward`` and ``compute`` the metric returns the
         following output:
 
-        - **mse_log** (:class:`~torch.Tensor`): A tensor with the
-          relative mean absolute error over the state
+            - **mse_log** (:class:`~torch.Tensor`): A tensor with the
+                mean squared logarithmic error over the state
 
         Args:
-            squared: If True returns MSELog value, if False returns EMSELog value.
+            squared: If ``True``, returns MSLE. If ``False``, returns RMSLE.
             kwargs: Additional keyword arguments, see `Advanced metric settings <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
 
         Reference:

--- a/src/torch_uncertainty/metrics/regression/nll.py
+++ b/src/torch_uncertainty/metrics/regression/nll.py
@@ -14,10 +14,10 @@ class DistributionNLL(CategoricalNLL):
         """Update state with the predicted distributions and the targets.
 
         Args:
-            dist (torch.distributions.Distribution): Predicted distributions.
-            target (Tensor): Ground truth labels.
-            padding_mask (Tensor): The padding mask. Defaults to None.
-                Sets the loss to 0 for padded values.
+            dist: Predicted distributions.
+            target: Ground truth labels.
+            padding_mask: Optional padding mask. Sets the loss to 0 for padded values. Defaults to
+                ``None``.
         """
         nlog_prob = -dist.log_prob(target)
         if padding_mask is not None:
@@ -29,7 +29,7 @@ class DistributionNLL(CategoricalNLL):
             self.total += padding_mask.sum() if padding_mask is not None else target.numel()
 
     def compute(self) -> Tensor:
-        """Computes NLL based on inputs passed in to ``update`` previously."""
+        """Compute NLL based on inputs passed to ``update``."""
         values = dim_zero_cat(self.values)
 
         if self.reduction == "sum":

--- a/src/torch_uncertainty/metrics/regression/quantile_calibration.py
+++ b/src/torch_uncertainty/metrics/regression/quantile_calibration.py
@@ -27,17 +27,17 @@ class QuantileCalibrationError(BinaryCalibrationError):
         ignore_index=None,
         validate_args=True,
         **kwargs,
-    ):
+    ) -> None:
         """Quantile Calibration Error for regression tasks.
 
         This metric computes the calibration error of quantile predictions
         against the ground truth values.
 
         Args:
-            num_bins (int): Number of bins to use for calibration. Defaults to `15`.
-            norm (str): Norm to use for calibration error computation. Defaults to `"l1"`.
-            ignore_index (int): Index to ignore during calibration. Defaults to `None`.
-            validate_args (bool): Whether to validate the input arguments. Defaults to `True`.
+            num_bins: Number of bins to use for calibration. Defaults to ``15``.
+            norm: Norm to use for calibration error computation. Defaults to ``"l1"``.
+            ignore_index: Index to ignore during calibration. Defaults to ``None``.
+            validate_args: Whether to validate the input arguments. Defaults to ``True``.
             kwargs: Additional keyword arguments, see `Advanced metric settings
               <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
         """
@@ -53,9 +53,9 @@ class QuantileCalibrationError(BinaryCalibrationError):
         """Update the metric with new predictions and targets.
 
         Args:
-            dist (Distribution): The predicted distribution.
-            target (Tensor): The ground truth values.
-            padding_mask (Tensor | None): A mask to ignore certain values. Defaults to `None`.
+            dist: The predicted distribution.
+            target: The ground truth values.
+            padding_mask: A mask to ignore certain values. Defaults to ``None``.
         """
         reduce_event_dims = False
         if isinstance(dist, Independent):
@@ -106,7 +106,7 @@ class QuantileCalibrationError(BinaryCalibrationError):
             Tensor: The quantile calibration error.
 
         Warning:
-            If the distribution does not support the `icdf()` method, this will return `nan` values.
+            If the distribution does not support ``icdf()``, this returns ``nan`` values.
         """
         if self.not_implemented_error:
             return torch.tensor(float("nan"))
@@ -116,7 +116,7 @@ class QuantileCalibrationError(BinaryCalibrationError):
         """Plot the quantile calibration reliability diagram.
 
         Raises:
-            NotImplementedError: If the distribution does not support the `icdf()` method.
+            NotImplementedError: If the distribution does not support ``icdf()``.
         """
         if self.not_implemented_error:
             raise NotImplementedError(

--- a/src/torch_uncertainty/metrics/regression/relative_error.py
+++ b/src/torch_uncertainty/metrics/regression/relative_error.py
@@ -5,8 +5,7 @@ from torchmetrics import MeanAbsoluteError, MeanSquaredError
 
 class MeanGTRelativeAbsoluteError(MeanAbsoluteError):
     def __init__(self, **kwargs) -> None:
-        r"""Compute Mean Absolute Error relative to the Ground Truth (MAErel
-        or ARErel).
+        r"""Compute the Mean Absolute Error relative to the Ground Truth (MAErel or ARErel).
 
         This metric is commonly used in tasks where the relative deviation of
         predictions with respect to the ground truth is important.

--- a/src/torch_uncertainty/metrics/regression/silog.py
+++ b/src/torch_uncertainty/metrics/regression/silog.py
@@ -12,7 +12,7 @@ class SILog(Metric):
     total: Tensor
 
     def __init__(self, sqrt: bool = False, lmbda: float = 1.0, **kwargs: Any) -> None:
-        r"""Computes The Scale-Invariant Logarithmic Loss metric.
+        r"""Compute The Scale-Invariant Logarithmic Loss metric.
 
         The Scale-Invariant Logarithmic Loss (SILog), a metric designed for depth estimation tasks.
 
@@ -80,8 +80,8 @@ class SILog(Metric):
         """Update state with predictions and targets.
 
         Args:
-            preds (Tensor): A prediction tensor of shape (batch)
-            target (Tensor): A tensor of ground truth labels of shape (batch)
+            preds: A prediction tensor of shape (batch)
+            target: A tensor of ground truth labels of shape (batch)
         """
         self.log_dists += torch.sum(preds.log() - target.log())
         self.sq_log_dists += torch.sum((preds.log() - target.log()) ** 2)

--- a/src/torch_uncertainty/metrics/regression/threshold_accuracy.py
+++ b/src/torch_uncertainty/metrics/regression/threshold_accuracy.py
@@ -9,7 +9,7 @@ class ThresholdAccuracy(Metric):
     total: Tensor
 
     def __init__(self, power: int, lmbda: float = 1.25, **kwargs) -> None:
-        r"""Computes the Threshold Accuracy metric, also referred to as d1, d2, or d3.
+        r"""Compute the Threshold Accuracy metric, also referred to as d1, d2, or d3.
 
         This metric evaluates the percentage of predictions that fall within a
         specified threshold of their corresponding target values. The threshold

--- a/src/torch_uncertainty/metrics/segmentation/mean_iou.py
+++ b/src/torch_uncertainty/metrics/segmentation/mean_iou.py
@@ -19,13 +19,13 @@ class MeanIntersectionOverUnion(MulticlassStatScores):
         r"""Computes Mean Intersection over Union (IoU) score.
 
         Args:
-            num_classes (int): Integer specifying the number of classes.
-            top_k (int): Number of highest probability or logit score predictions
+            num_classes: Integer specifying the number of classes.
+            top_k: Number of highest probability or logit score predictions
                 considered to find the correct label. Only works when ``preds`` contain
                 probabilities/logits. Defaults to ``1``.
-            ignore_index (int | None): Specifies a target value that is ignored and does
+            ignore_index: Specifies a target value that is ignored and does
                 not contribute to the metric calculation. Defaults to ``None``.
-            validate_args (bool): Bool indicating if input arguments and tensors should
+            validate_args: Bool indicating if input arguments and tensors should
                 be validated for correctness. Set to ``False`` for faster computations. Defaults to
                 ``True``.
             **kwargs: kwargs: Additional keyword arguments, see

--- a/src/torch_uncertainty/metrics/segmentation/seg_fpr95.py
+++ b/src/torch_uncertainty/metrics/segmentation/seg_fpr95.py
@@ -19,7 +19,7 @@ class SegmentationFPR95(Metric):
         Compute the mean FPR95 per batch across all batches.
 
         Args:
-            pos_label (int): The positive label in the segmentation OOD detection task.
+            pos_label: The positive label in the segmentation OOD detection task.
             **kwargs: Additional keyword arguments for the FPR95 metric.
         """
         super().__init__(**kwargs)

--- a/src/torch_uncertainty/metrics/sparsification.py
+++ b/src/torch_uncertainty/metrics/sparsification.py
@@ -52,8 +52,8 @@ class AUSE(Metric):
         """Store the scores and their associated errors for later computation.
 
         Args:
-            scores (Tensor): uncertainty scores of shape :math:`(B,)`
-            errors (Tensor): errors of shape :math:`(B,)`
+            scores: uncertainty scores of shape :math:`(B,)`
+            errors: errors of shape :math:`(B,)`
         """
         self.scores.append(scores)
         self.errors.append(errors)
@@ -93,12 +93,10 @@ class AUSE(Metric):
         ``update``, and the oracle sparsification curve.
 
         Args:
-            ax (Axes | None): An matplotlib axis object. If provided
-                will add plot to this axis. Defaults to None.
-            plot_oracle (bool): Whether to plot the oracle
-                sparsification curve. Defaults to True.
-            plot_value (bool): Whether to plot the AUSE value.
-                Defaults to True.
+            ax: An matplotlib axis object. If provided will add plot to this axis.
+                Defaults to ``None``.
+            plot_oracle: Whether to plot the oracle sparsification curve. Defaults to ``True``.
+            plot_value: Whether to plot the AUSE value. Defaults to ``True``.
 
         Returns:
             tuple[[Figure | None], Axes]: Figure object and Axes object
@@ -155,8 +153,8 @@ def _ause_rejection_rate_compute(
     """Compute the cumulative error rates for a given set of scores and errors.
 
     Args:
-        scores (Tensor): uncertainty scores of shape :math:`(B,)`
-        errors (Tensor): errors of shape :math:`(B,)`
+        scores: uncertainty scores of shape :math:`(B,)`
+        errors: errors of shape :math:`(B,)`
     """
     num_samples = errors.size(0)
 

--- a/src/torch_uncertainty/models/classification/inception_time/batched.py
+++ b/src/torch_uncertainty/models/classification/inception_time/batched.py
@@ -117,7 +117,7 @@ class _BatchedInceptionTime(nn.Module):
         """Forward pass through the model.
 
         Args:
-            x (Tensor): Input tensor of shape (batch_size, in_channels, seq_len).
+            x: Input tensor of shape (batch_size, in_channels, seq_len).
 
         Returns:
             Tensor: Output tensor of shape (batch_size, num_classes).
@@ -151,14 +151,14 @@ def batched_inception_time(
     """BatchEnsemble of InceptionTime.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators for BatchEnsemble.
-        kernel_size (int): Size of the convolutional kernels. Default is ``40``.
-        embed_dim (int): Dimension of the embedding. Default is ``32``.
-        num_blocks (int): Number of inception blocks. Default is ``6``.
-        dropout (float): Dropout rate. Default is ``0.0``.
-        residual (bool): Whether to use residual connections. Default is ``True``.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators for BatchEnsemble.
+        kernel_size: Size of the convolutional kernels. Default is ``40``.
+        embed_dim: Dimension of the embedding. Default is ``32``.
+        num_blocks: Number of inception blocks. Default is ``6``.
+        dropout: Dropout rate. Default is ``0.0``.
+        residual: Whether to use residual connections. Default is ``True``.
         repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 

--- a/src/torch_uncertainty/models/classification/inception_time/bayesian.py
+++ b/src/torch_uncertainty/models/classification/inception_time/bayesian.py
@@ -102,7 +102,7 @@ class _BayesianInceptionTime(nn.Module):
         """Forward pass through the model.
 
         Args:
-            x (Tensor): Input tensor of shape (batch_size, in_channels, seq_len).
+            x: Input tensor of shape (batch_size, in_channels, seq_len).
 
         Returns:
             Tensor: Output tensor of shape (batch_size, num_classes).
@@ -133,14 +133,14 @@ def bayesian_inception_time(
     """Bayesian InceptionTime.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_samples (int): Number of samples for stochastic modeling. Default is ``16``.
-        kernel_size (int): Size of the convolutional kernels. Default is ``40``.
-        embed_dim (int): Dimension of the embedding. Default is ``32``.
-        num_blocks (int): Number of inception blocks. Default is ``6``.
-        dropout (float): Dropout rate. Default is ``0.0``.
-        residual (bool): Whether to use residual connections. Default is ``True``.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_samples: Number of samples for stochastic modeling. Defaults to ``16``.
+        kernel_size: Size of the convolutional kernels. Defaults to ``40``.
+        embed_dim: Dimension of the embedding. Defaults to ``32``.
+        num_blocks: Number of inception blocks. Defaults to ``6``.
+        dropout: Dropout rate. Defaults to ``0.0``.
+        residual: Whether to use residual connections. Defaults to ``True``.
 
     Returns:
         StochasticModel: A stochastic InceptionTime model.

--- a/src/torch_uncertainty/models/classification/inception_time/mimo.py
+++ b/src/torch_uncertainty/models/classification/inception_time/mimo.py
@@ -45,17 +45,17 @@ def mimo_inception_time(
     dropout: float = 0.0,
     residual: bool = True,
 ) -> _MIMOInceptionTime:
-    """MIMO of InceptionTime.
+    """MIMO InceptionTime.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators for MIMO.
-        kernel_size (int): Size of the convolutional kernel. Default is ``40``.
-        embed_dim (int): Dimension of the embedding. Default is ``32``.
-        num_blocks (int): Number of inception blocks. Default is ``6``.
-        dropout (float): Dropout rate. Default is ``0.0``.
-        residual (bool): Whether to use residual connections. Default is ``True``.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators for MIMO.
+        kernel_size: Size of the convolutional kernel. Defaults to ``40``.
+        embed_dim: Dimension of the embedding. Defaults to ``32``.
+        num_blocks: Number of inception blocks. Defaults to ``6``.
+        dropout: Dropout rate. Defaults to ``0.0``.
+        residual: Whether to use residual connections. Defaults to ``True``.
 
     Returns:
         _MIMOInceptionTime: The MIMO InceptionTime model.

--- a/src/torch_uncertainty/models/classification/inception_time/packed.py
+++ b/src/torch_uncertainty/models/classification/inception_time/packed.py
@@ -156,7 +156,7 @@ class _PackedInceptionTime(nn.Module):
         """Forward pass through the model.
 
         Args:
-            x (Tensor): Input tensor of shape (batch_size, in_channels, seq_len).
+            x: Input tensor of shape (batch_size, in_channels, seq_len).
 
         Returns:
             Tensor: Output tensor of shape (batch_size, num_classes).
@@ -189,16 +189,16 @@ def packed_inception_time(
     """Packed-Ensembles of InceptionTime.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators for Packed-Ensembles.
-        alpha (float): Alpha parameter for Packed-Ensembles.
-        gamma (int): Gamma parameter for Packed-Ensembles. Default is ``1``.
-        kernel_size (int): Size of the convolutional kernels. Default is ``40``.
-        embed_dim (int): Dimension of the embedding. Default is ``32``.
-        num_blocks (int): Number of inception blocks. Default is ``6``.
-        dropout (float): Dropout rate. Default is ``0.0``.
-        residual (bool): Whether to use residual connections. Default is ``True``.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators for Packed-Ensembles.
+        alpha: Alpha parameter for Packed-Ensembles.
+        gamma: Gamma parameter for Packed-Ensembles. Default is ``1``.
+        kernel_size: Size of the convolutional kernels. Default is ``40``.
+        embed_dim: Dimension of the embedding. Default is ``32``.
+        num_blocks: Number of inception blocks. Default is ``6``.
+        dropout: Dropout rate. Default is ``0.0``.
+        residual: Whether to use residual connections. Default is ``True``.
 
     Returns:
         _InceptionTime: An instance of the InceptionTime model.

--- a/src/torch_uncertainty/models/classification/inception_time/std.py
+++ b/src/torch_uncertainty/models/classification/inception_time/std.py
@@ -99,7 +99,7 @@ class _InceptionTime(nn.Module):
         """Forward pass through the model.
 
         Args:
-            x (Tensor): Input tensor of shape (batch_size, in_channels, seq_len).
+            x: Input tensor of shape (batch_size, in_channels, seq_len).
 
         Returns:
             Tensor: Output tensor of shape (batch_size, num_classes).
@@ -130,13 +130,13 @@ def inception_time(
     <https://arxiv.org/abs/1909.04939>`_.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        kernel_size (int): Size of the convolutional kernels. Default is ``40``.
-        embed_dim (int): Dimension of the embedding. Default is ``32``.
-        num_blocks (int): Number of inception blocks. Default is ``6``.
-        dropout (float): Dropout rate. Default is ``0.0``.
-        residual (bool): Whether to use residual connections. Default is ``True``.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        kernel_size: Size of the convolutional kernels. Default is ``40``.
+        embed_dim: Dimension of the embedding. Default is ``32``.
+        num_blocks: Number of inception blocks. Default is ``6``.
+        dropout: Dropout rate. Default is ``0.0``.
+        residual: Whether to use residual connections. Default is ``True``.
 
     Returns:
         _InceptionTime: An instance of the InceptionTime model.

--- a/src/torch_uncertainty/models/classification/lenet.py
+++ b/src/torch_uncertainty/models/classification/lenet.py
@@ -29,6 +29,7 @@ class _LeNet(nn.Module):
         first_layer_args: dict | None = None,
         last_layer_args: dict | None = None,
     ) -> None:
+        """Build a LeNet-style feature extractor and classifier head."""
         super().__init__()
         self.activation = activation
 
@@ -91,6 +92,7 @@ def _lenet(
     first_layer_args: dict | None = None,
     last_layer_args: dict | None = None,
 ) -> _LeNet | StochasticModel:
+    """Construct a LeNet variant, optionally wrapped for stochastic inference."""
     model = _LeNet(
         in_channels=in_channels,
         num_classes=num_classes,
@@ -117,6 +119,7 @@ def lenet(
     groups: int = 1,
     dropout_rate: float = 0.0,
 ) -> _LeNet:
+    """Build the standard deterministic LeNet variant."""
     return cast(
         "_LeNet",
         _lenet(
@@ -144,6 +147,7 @@ def batchensemble_lenet(
     dropout_rate: float = 0.0,
     repeat_training_inputs: bool = False,
 ) -> BatchEnsemble:
+    """Build a LeNet wrapped with BatchEnsemble layers."""
     model = lenet(
         in_channels=in_channels,
         num_classes=num_classes,
@@ -171,6 +175,7 @@ def packed_lenet(
     groups: int = 1,
     dropout_rate: float = 0.0,
 ) -> _LeNet:
+    """Build a LeNet variant using Packed-Ensembles layers."""
     layer_args = {
         "num_estimators": num_estimators,
         "alpha": alpha,
@@ -209,6 +214,7 @@ def bayesian_lenet(
     groups: int = 1,
     dropout_rate: float = 0.0,
 ) -> StochasticModel:
+    """Build a Bayesian LeNet wrapped in a stochastic model."""
     layers_args = {}
     if prior_sigma_1 is not None:
         layers_args["prior_sigma_1"] = prior_sigma_1

--- a/src/torch_uncertainty/models/classification/resnet/batched.py
+++ b/src/torch_uncertainty/models/classification/resnet/batched.py
@@ -321,18 +321,18 @@ def batched_resnet(
     """BatchEnsemble of ResNet.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        num_estimators (int): Number of estimators in the ensemble.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0``.
-        width_multiplier (float): Width multiplier. Defaults to ``1.0``.
-        groups (int): Number of groups within each estimator.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module): Normalization layer.
-        repeat_strategy (Literal["legacy", "paper"]): The repeatrepeat_strategy ("legacy"|"paper"): The repeat
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        num_estimators: Number of estimators in the ensemble.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0``.
+        width_multiplier: Width multiplier. Defaults to ``1.0``.
+        groups: Number of groups within each estimator.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        normalization_layer: Normalization layer. Defaults to ``nn.BatchNorm2d``.
+        repeat_strategy: The repeatrepeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training

--- a/src/torch_uncertainty/models/classification/resnet/lpbnn.py
+++ b/src/torch_uncertainty/models/classification/resnet/lpbnn.py
@@ -325,16 +325,16 @@ def lpbnn_resnet(
     """LPBNN version of ResNet.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        dropout_rate (float): Dropout rate. Defaults to ``0``.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to ``True``.
-        num_estimators (int): Number of estimators in the ensemble.
-        width_multiplier (float): Width multiplier. Defaults to ``1.0``.
-        groups (int): Number of ResNet groups. Defaults to ``1``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        dropout_rate: Dropout rate. Defaults to ``0``.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        num_estimators: Number of estimators in the ensemble.
+        width_multiplier: Width multiplier. Defaults to ``1.0``.
+        groups: Number of ResNet groups. Defaults to ``1``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
 
     Returns:
         _LPBNNResNet: An LPBNN ResNet.

--- a/src/torch_uncertainty/models/classification/resnet/masked.py
+++ b/src/torch_uncertainty/models/classification/resnet/masked.py
@@ -340,18 +340,18 @@ def masked_resnet(
     """Masksembles of ResNet.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        num_estimators (int): Number of estimators in the ensemble.
-        scale (float): The scale of the mask.
-        width_multiplier (float): Width multiplier. Defaults to 1.
-        groups (int): Number of groups within each estimator. Defaults to 1.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module): Normalization layer.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        num_estimators: Number of estimators in the ensemble.
+        scale: The scale of the mask.
+        width_multiplier: Width multiplier. Defaults to ``1``.
+        groups: Number of groups within each estimator. Defaults to ``1``.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        normalization_layer: Normalization layer. Defaults to ``nn.BatchNorm2d``.
         repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 

--- a/src/torch_uncertainty/models/classification/resnet/mimo.py
+++ b/src/torch_uncertainty/models/classification/resnet/mimo.py
@@ -65,18 +65,17 @@ def mimo_resnet(
     """MIMO ResNet.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        num_estimators (int): Number of estimators in the ensemble.
-        conv_bias (bool): Whether to use bias in convolutional layers. Defaults to ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
-        width_multiplier (float): Width multiplier. Defaults to ``1.0``.
-        groups (int): Number of groups for grouped convolution. Defaults to ``1``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        num_estimators: Number of estimators in the ensemble.
+        conv_bias: Whether to use bias in convolutional layers. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+        width_multiplier: Width multiplier. Defaults to ``1.0``.
+        groups: Number of groups for grouped convolution. Defaults to ``1``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:
         _MIMOResNet: A MIMO-style ResNet.

--- a/src/torch_uncertainty/models/classification/resnet/packed.py
+++ b/src/torch_uncertainty/models/classification/resnet/packed.py
@@ -399,23 +399,21 @@ def packed_resnet(
     """Packed-Ensembles of ResNet.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0``.
-        num_estimators (int): Number of estimators in the ensemble.
-        alpha (int): Expansion factor affecting the width of the estimators.
-        gamma (int): Number of groups within each estimator.
-        width_multiplier (float): Width multiplier. Defaults to ``1``.
-        groups (int): Number of groups within each estimator group.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module): Normalization layer. Defaults to ``nn.BatchNorm2d``.
-        pretrained (bool): Whether to load pretrained weights.
-            Defaults to ``False``.
-        linear_implementation (str): Implementation of the
-            packed linear layer. Defaults to ``"conv1d"``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0``.
+        num_estimators: Number of estimators in the ensemble.
+        alpha: Expansion factor affecting the width of the estimators.
+        gamma: Number of groups within each estimator.
+        width_multiplier: Width multiplier. Defaults to ``1``.
+        groups: Number of groups within each estimator group.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        normalization_layer: Normalization layer. Defaults to ``nn.BatchNorm2d``.
+        pretrained: Whether to load pretrained weights. Defaults to ``False``.
+        linear_implementation: Implementation of the packed linear layer. Defaults to ``"conv1d"``.
 
     Returns:
         _PackedResNet: A Packed-Ensembles ResNet.

--- a/src/torch_uncertainty/models/classification/resnet/std.py
+++ b/src/torch_uncertainty/models/classification/resnet/std.py
@@ -357,20 +357,17 @@ def resnet(
     """ResNet model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        arch (int): The architecture of the ResNet.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``False``.
-        dropout_rate (float): Dropout rate. Defaults to 0.0.
-        width_multiplier (float): Width multiplier. Defaults to 1.0.
-        groups (int): Number of groups in convolutions. Defaults to 1.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        arch: The architecture of the ResNet.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``False``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+        width_multiplier: Width multiplier. Defaults to ``1.0``.
+        groups: Number of groups in convolutions. Defaults to ``1``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:
         _ResNet: The ResNet model.

--- a/src/torch_uncertainty/models/classification/wideresnet/batched.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/batched.py
@@ -247,25 +247,22 @@ def batched_wideresnet28x10(
     """BatchEnsemble of Wide-ResNet-28x10.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_estimators (int): Number of estimators in the ensemble.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
-        num_classes (int): Number of classes to predict.
-        groups (int): Number of groups in the convolutions. Defaults to ``1``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
-        repeat_strategy ("legacy"|"paper"): The repeat
+        in_channels: Number of input channels.
+        num_estimators: Number of estimators in the ensemble.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.3``.
+        num_classes: Number of classes to predict.
+        groups: Number of groups in the convolutions. Defaults to ``1``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
+        repeat_strategy: The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training
               and evaluation.
-            - "paper"(default): Repeat inputs for each estimator only during
+            - "paper" (default): Repeat inputs for each estimator only during
               evaluation.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/wideresnet/masked.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/masked.py
@@ -253,27 +253,21 @@ def masked_wideresnet28x10(
     """Masksembles of Wide-ResNet-28x10.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        num_estimators (int): Number of estimators in the ensemble.
-        scale (float): Expansion factor affecting the width of the estimators.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
-        groups (int): Number of groups within each estimator. Defaults to
-            ``1``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
-        repeat_strategy ("legacy"|"paper"): The repeat
-            strategy to use during training:
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        num_estimators: Number of estimators in the ensemble.
+        scale: Expansion factor affecting the width of the estimators.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.3``.
+        groups: Number of groups within each estimator. Defaults to ``1``.
+        style: Whether to use the ImageNet or CIFAR structure. Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
+        repeat_strategy: The repeat strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both
               training and evaluation.
-            - "paper"(default): Repeat inputs for each estimator only during
+            - "paper" (default): Repeat inputs for each estimator only during
               evaluation.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/wideresnet/mimo.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/mimo.py
@@ -64,19 +64,16 @@ def mimo_wideresnet28x10(
     """MIMO of Wide-ResNet-28x10.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        num_estimators (int): Number of estimators in the ensemble.
-        groups (int): Number of subgroups in the convolutions.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        num_estimators: Number of estimators in the ensemble.
+        groups: Number of subgroups in the convolutions.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.3``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:
         _MIMOWideResNet: A MIMO Wide-ResNet-28x10.

--- a/src/torch_uncertainty/models/classification/wideresnet/packed.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/packed.py
@@ -267,21 +267,18 @@ def packed_wideresnet28x10(
     """Packed-Ensembles of Wide-ResNet-28x10.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        num_estimators (int): Number of estimators in the ensemble.
-        alpha (int): Expansion factor affecting the width of the estimators.
-        gamma (int): Number of groups within each estimator.
-        groups (int): Number of subgroups in the convolutions.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        num_estimators: Number of estimators in the ensemble.
+        alpha: Expansion factor affecting the width of the estimators.
+        gamma: Number of groups within each estimator.
+        groups: Number of subgroups in the convolutions.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.3``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:
         _PackedWideResNet: A Packed-Ensembles Wide-ResNet-28x10.

--- a/src/torch_uncertainty/models/classification/wideresnet/std.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/std.py
@@ -222,19 +222,15 @@ def wideresnet28x10(
     <https://arxiv.org/pdf/1605.07146.pdf>`_.
 
     Args:
-        in_channels (int): Number of input channels
-        num_classes (int): Number of classes to predict.
-        groups (int): Number of groups in convolutions. Defaults to
-            ``1``.
-        conv_bias (bool): Whether to use bias in convolutions. Defaults to
-            ``True``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
-        style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
-            structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable): Activation function. Defaults to
-            ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module): Normalization layer.
-            Defaults to ``torch.nn.BatchNorm2d``.
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        groups: Number of groups in convolutions. Defaults to ``1``.
+        conv_bias: Whether to use bias in convolutions. Defaults to ``True``.
+        dropout_rate: Dropout rate. Defaults to ``0.3``.
+        style: Whether to use the ImageNet or CIFAR structure.
+            Defaults to ``ResNetStyle.IMAGENET``.
+        activation_fn: Activation function. Defaults to ``torch.nn.functional.relu``.
+        normalization_layer: Normalization layer. Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:
         _WideResNet: A Wide-ResNet-28x10.

--- a/src/torch_uncertainty/models/depth/bts.py
+++ b/src/torch_uncertainty/models/depth/bts.py
@@ -51,14 +51,14 @@ class AtrousBlock2d(nn.Module):
         """Atrous block with 1x1 and 3x3 convolutions.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            dilation (int): Dilation rate for the 3x3 convolution.
-            norm_first (bool): Whether to apply normalization before the 1x1 convolution.
+            in_channels : Number of input channels.
+            out_channels : Number of output channels.
+            dilation : Dilation rate for the 3x3 convolution.
+            norm_first: Whether to apply normalization before the 1x1 convolution.
                 Defaults to ``True``.
-            norm_momentum (float): Momentum for the normalization layer. Defaults to ``0.1``.
-            device: torch device. Defaults to ``None``.
-            dtype: torch dtype. Defaults to ``None``.
+            norm_momentum: Momentum for the normalization layer. Defaults to ``0.1``.
+            device: Torch device. Defaults to ``None``.
+            dtype: Torch dtype. Defaults to ``None``.
         """
         super().__init__()
 
@@ -113,11 +113,11 @@ class UpConv2d(nn.Module):
         """Upsampling convolution.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            ratio (int): Upsampling ratio.
-            device: torch device. Defaults to ``None``.
-            dtype: torch dtype. Defaults to ``None``.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            ratio: Upsampling ratio.
+            device: Torch device. Defaults to ``None``.
+            dtype: Torch dtype. Defaults to ``None``.
         """
         super().__init__()
         self.conv = nn.Conv2d(
@@ -264,8 +264,8 @@ class BTSBackbone(Backbone):  # coverage: ignore
         """BTS backbone.
 
         Args:
-        backbone_name (str): Name of the backbone.
-        pretrained (bool): Use a pretrained backbone.
+            backbone_name: Name of the backbone.
+            pretrained: Whether to use pretrained weights.
         """
         feat_names: list[str] = []
         if isinstance(backbone_name, str):
@@ -319,11 +319,11 @@ class BTSDecoder(nn.Module):
         """BTS decoder.
 
         Args:
-            max_depth (float): The maximum predicted depth.
-            feat_out_channels (list[int]): The number of output channels from the backbone.
-            num_features (int): The number of features to use in the decoder.
-            dist_family (str | None): The distribution family name. ``None`` means point-wise
-            prediction. Defaults to ``None``.
+            max_depth: The maximum predicted depth.
+            feat_out_channels: The number of output channels from the backbone.
+            num_features: The number of features to use in the decoder.
+            dist_family: The distribution family name. ``None`` means point-wise
+                prediction. Defaults to ``None``.
         """
         super().__init__()
         self.max_depth = max_depth
@@ -522,7 +522,7 @@ class BTSDecoder(nn.Module):
 
         Note:
             Depending of the :attr:`dist_family` of the backbone, the output can
-            be a dictionnary of distribution parameters or a single tensor.
+            be a dictionary of distribution parameters or a single tensor.
         """
         # TODO: handle focal
         out = self.depth(self.feat_forward(features))
@@ -552,11 +552,11 @@ class _BTS(nn.Module):
         """BTS model.
 
         Args:
-            backbone_name (str): Name of the encoding backbone.
-            max_depth (float): Maximum predicted depth.
-            bts_size (int): BTS feature size. Defaults to 512.
-            dist_family (str): Distribution family name. Defaults to None.
-            pretrained_backbone (bool): Use a pretrained backbone. Defaults to True.
+            backbone_name: Name of the encoding backbone.
+            max_depth: Maximum predicted depth.
+            bts_size: BTS feature size. Defaults to ``512``.
+            dist_family: Distribution family name. Defaults to ``None``.
+            pretrained_backbone: Use a pretrained backbone. Defaults to ``True``.
 
         References:
             [1] `From Big to Small: Multi-Scale Local Planar Guidance for Monocular Depth Estimation
@@ -573,8 +573,8 @@ class _BTS(nn.Module):
         """Forward pass.
 
         Args:
-            x (Tensor): Input tensor.
-            focal (float): Focal length for API consistency.
+            x: Input tensor.
+            focal: Focal length for API consistency. Defaults to ``None``.
         """
         return self.decoder(self.backbone(x))
 
@@ -600,14 +600,14 @@ def bts_resnet(
     dist_family: str | None = None,
     pretrained_backbone: bool = True,
 ) -> _BTS:
-    """BTS model with ResNet-50 backbone.
+    """BTS model with a ResNet backbone.
 
     Args:
-        arch (int): The number of layers of the underlying ResNet model: 50 or 101.
-        max_depth (float): Maximum predicted depth.
-        bts_size (int): BTS feature size. Defaults to 512.
-        dist_family (str): Distribution family name. Defaults to None.
-        pretrained_backbone (bool): Use a pretrained backbone. Defaults to True.
+        arch: The number of layers of the underlying ResNet model: 50 or 101.
+        max_depth: Maximum predicted depth.
+        bts_size: BTS feature size. Defaults to ``512``.
+        dist_family: Distribution family name. Defaults to ``None``.
+        pretrained_backbone: Use a pretrained backbone. Defaults to ``True``.
     """
     return _bts(
         f"resnet{arch}",

--- a/src/torch_uncertainty/models/mlp.py
+++ b/src/torch_uncertainty/models/mlp.py
@@ -29,17 +29,16 @@ class _MLP(nn.Module):
         """Multi-layer perceptron class.
 
         Args:
-            in_features (int): Number of input features.
-            num_outputs (int): Number of output features.
-            hidden_dims (list[int]): Number of features for each hidden layer.
-            layer (nn.Module): Layer class.
-            activation (Callable): Activation function.
-            layer_args (Dict): Arguments for the layer class.
-            dropout_rate (float): Dropout probability.
-            dist_family (str): Distribution family name. ``None`` means point-wise
-                prediction.
-            dist_args (Dict): Arguments for the distribution layer class.
-            flatten_start_dim (int): Dimension to start flattening the input.
+            in_features: Number of input features.
+            num_outputs: Number of output features.
+            hidden_dims: Number of features for each hidden layer.
+            layer: Layer class.
+            activation: Activation function.
+            layer_args: Arguments for the layer class.
+            dropout_rate: Dropout probability.
+            dist_family: Distribution family name. ``None`` means point-wise prediction.
+            dist_args: Arguments for the distribution layer class.
+            flatten_start_dim: Dimension to start flattening the input.
         """
         super().__init__()
         self.activation = activation
@@ -194,17 +193,14 @@ def mlp(
     """Multi-layer perceptron.
 
     Args:
-        in_features (int): Number of input features.
-        num_outputs (int): Number of output features.
-        hidden_dims (list[int]): Number of features in each hidden layer.
-        activation (Callable): Activation function. Defaults to
-            ``F.relu``.
-        dropout_rate (float): Dropout probability. Defaults to ``0.0``.
-        dist_family (str): Distribution family. Defaults to ``None``.
-        dist_args (Dict): Arguments for the distribution layer class. Defaults
-            to ``None``.
-        flatten_start_dim (int): Dimension to start flattening the input.
-            Defaults to ``-1``.
+        in_features: Number of input features.
+        num_outputs: Number of output features.
+        hidden_dims: Number of features in each hidden layer.
+        activation: Activation function. Defaults to ``F.relu``.
+        dropout_rate: Dropout probability. Defaults to ``0.0``.
+        dist_family: Distribution family. Defaults to ``None``.
+        dist_args: Arguments for the distribution layer class. Defaults to ``None``.
+        flatten_start_dim: Dimension to start flattening the input. Defaults to ``-1``.
 
     Returns:
         _MLP: A Multi-Layer-Perceptron model.

--- a/src/torch_uncertainty/models/segmentation/deeplab.py
+++ b/src/torch_uncertainty/models/segmentation/deeplab.py
@@ -24,13 +24,13 @@ class SeparableConv2d(nn.Module):
         """Separable Convolution with dilation.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            kernel_size (_size_2_t): Kernel size.
-            stride (_size_2_t): Stride. Defaults to 1.
-            padding (_size_2_t): Padding. Defaults to 0.
-            dilation (_size_2_t): Dilation. Defaults to 1.
-            bias (bool): Use biases. Defaults to True.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            kernel_size: Kernel size.
+            stride: Stride. Defaults to ``1``.
+            padding: Padding. Defaults to ``0``.
+            dilation: Dilation. Defaults to ``1``.
+            bias: Use biases. Defaults to ``True``.
         """
         super().__init__()
         self.separable = nn.Conv2d(
@@ -69,10 +69,10 @@ class InnerConv(nn.Module):
         """Inner convolution block.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            dilation (_size_2_t): Dilation.
-            separable (bool): Use separable convolutions to reduce the number
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            dilation: Dilation.
+            separable: Use separable convolutions to reduce the number
                 of parameters.
         """
         super().__init__()
@@ -105,8 +105,8 @@ class InnerPooling(nn.Module):
         """Inner pooling block.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
         """
         super().__init__()
         self.pool = nn.AdaptiveAvgPool2d(1)
@@ -130,11 +130,11 @@ class ASPP(nn.Module):
         """Atrous Spatial Pyramid Pooling.
 
         Args:
-            in_channels (int): Number of input channels.
-            atrous_rates (list[int]): Atrous rates for the ASPP module.
-            separable (bool): Use separable convolutions to reduce the number
+            in_channels: Number of input channels.
+            atrous_rates: Atrous rates for the ASPP module.
+            separable: Use separable convolutions to reduce the number
                 of parameters.
-            dropout_rate (float): Dropout rate of the ASPP.
+            dropout_rate: Dropout rate of the ASPP.
         """
         super().__init__()
         out_channels = 256
@@ -175,10 +175,10 @@ class DeepLabV3Backbone(Backbone):
         """DeepLab V3(+) backbone.
 
         Args:
-            backbone_name (str): Backbone name.
-            style (str): Whether to use a DeepLab V3 or V3+ model.
-            pretrained (bool): Use pretrained backbone.
-            norm_momentum (float): BatchNorm momentum.
+            backbone_name: Backbone name.
+            style: Whether to use a DeepLab V3 or V3+ model.
+            pretrained: Use pretrained backbone.
+            norm_momentum: BatchNorm momentum.
         """
         # TODO: handle dilations
         if backbone_name == "resnet50":
@@ -203,12 +203,12 @@ class DeepLabV3Decoder(nn.Module):
     """Decoder for the DeepLabV3 model.
 
     Args:
-        in_channels (int): Number of channels of the input latent space.
-        num_classes (int): Number of classes.
-        aspp_dilate (list[int]): Atrous rates for the ASPP module.
-        separable (bool): Use separable convolutions to reduce the number
-            of parameters. Defaults to False.
-        dropout_rate (float): Dropout rate of the ASPP. Defaults to 0.1.
+        in_channels: Number of channels of the input latent space.
+        num_classes: Number of classes.
+        aspp_dilate: Atrous rates for the ASPP module.
+        separable: Use separable convolutions to reduce the number
+            of parameters. Defaults to ``False``.
+        dropout_rate: Dropout rate of the ASPP. Defaults to ``0.1``.
     """
 
     conv: nn.Module
@@ -250,14 +250,13 @@ class DeepLabV3PlusDecoder(nn.Module):
         """Decoder for the DeepLabV3+ model.
 
         Args:
-            in_channels (int): Number of channels of the input latent space.
-            low_level_channels (int): Number of low-level features channels.
-            num_classes (int): Number of classes.
-            aspp_dilate (list[int]): Atrous rates for the ASPP module.
-            separable (bool): Use separable convolutions to reduce the number
+            in_channels: Number of channels of the input latent space.
+            low_level_channels: Number of low-level features channels.
+            num_classes: Number of classes.
+            aspp_dilate: Atrous rates for the ASPP module.
+            separable: Use separable convolutions to reduce the number
                 of parameters.
-            dropout_rate (float): Dropout rate of the ASPP. Defaults
-                to 0.1.
+            dropout_rate: Dropout rate of the ASPP. Defaults to ``0.1``.
         """
         super().__init__()
         self.project = nn.Sequential(
@@ -301,17 +300,13 @@ class _DeepLabV3(nn.Module):
         """DeepLab V3(+) model.
 
         Args:
-            num_classes (int): Number of classes.
-            backbone_name (Literal["resnet50", "resnet101"]): Backbone name.
-            style (Literal["v3", "v3+"]):  Whether to use a DeepLab V3 or
-                V3+ model.
-            output_stride (int): Output stride. Defaults to 16.
-            separable (bool): Use separable convolutions. Defaults
-                to False.
-            pretrained_backbone (bool): Use pretrained backbone.
-                Defaults to True.
-            norm_momentum (float): BatchNorm momentum. Defaults to
-                0.01.
+            num_classes: Number of classes.
+            backbone_name: Backbone name.
+            style: Whether to use a DeepLab V3 or V3+ model.
+            output_stride: Output stride. Defaults to ``16``.
+            separable: Use separable convolutions. Defaults to ``False``.
+            pretrained_backbone: Use pretrained backbone. Defaults to ``True``.
+            norm_momentum: BatchNorm momentum. Defaults to ``0.01``.
 
         References:
             - Rethinking atrous convolution for semantic image segmentation.
@@ -369,14 +364,14 @@ def deep_lab_v3_resnet(
     """DeepLab V3(+) model with ResNet-50/101 backbone.
 
     Args:
-        num_classes (int): Number of classes.
-        arch (int): Number of layers of the underlying ResNet model: 50 or 101.
+        num_classes: Number of classes.
+        arch: Number of layers of the underlying ResNet model: 50 or 101.
         style (Literal["v3", "v3+"]): Whether to use a DeepLab V3 or V3+ model.
-        output_stride (int): Output stride. Defaults to 16.
-        separable (bool): Use separable convolutions. Defaults to
-            False.
-        pretrained_backbone (bool): Use pretrained backbone. Defaults
-            to True.
+        output_stride: Output stride. Defaults to 16.
+        separable: Use separable convolutions. Defaults to
+            ``False``.
+        pretrained_backbone: Use pretrained backbone. Defaults
+            to ``True``.
     """
     return _DeepLabV3(
         num_classes,

--- a/src/torch_uncertainty/models/segmentation/segformer.py
+++ b/src/torch_uncertainty/models/segmentation/segformer.py
@@ -486,7 +486,6 @@ class SegFormerHead(nn.Module):
         References:
             [1] `SegFormer: Simple and Efficient Design for Semantic Segmentation with Transformers
             <https://arxiv.org/abs/2105.15203>`_.
-
         """
         super().__init__()
         self.in_channels = in_channels
@@ -556,6 +555,15 @@ class _SegFormer(nn.Module):
 
 
 def seg_former(num_classes: int, arch: int) -> _SegFormer:
+    """Create a SegFormer model.
+
+    Args:
+        num_classes: Number of segmentation classes.
+        arch: MiT architecture index (0-5).
+
+    Returns:
+        _SegFormer: Configured SegFormer model.
+    """
     in_channels = _get_embed_dims(arch)
     return _SegFormer(
         in_channels=in_channels,

--- a/src/torch_uncertainty/models/segmentation/unet/batched.py
+++ b/src/torch_uncertainty/models/segmentation/unet/batched.py
@@ -19,10 +19,10 @@ class _DoubleConv(nn.Module):
         """Initialize the DoubleConv module: (Conv2d => BN => ReLU) * 2.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            num_estimators (int): Number of estimators.
-            mid_channels (int | None): Number of intermediate channels.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            num_estimators: Number of estimators.
+            mid_channels: Number of intermediate channels.
                 If ``None``, defaults to :attr:`out_channels`. Defaults to ``None``.
         """
         super().__init__()
@@ -46,9 +46,9 @@ class _Down(nn.Module):
         """Initialize the Down module: (Conv2d => BN => ReLU) * 2 + MaxPool2d.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            num_estimators (int): Number of estimators.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            num_estimators: Number of estimators.
         """
         super().__init__()
         self.mpconv = nn.Sequential(
@@ -111,16 +111,16 @@ class _BatchedUNet(nn.Module):
         bilinear: bool = False,
         dropout_rate: float = 0.0,
     ) -> None:
-        """Batched U-Net model using Batch layers for uncertainty estimation.
+        """Batched U-Net model using BatchEnsemble layers for uncertainty estimation.
 
         Args:
-            in_channels (int): Number of input channels.
-            num_classes (int): Number of output classes.
-            num_blocks (list[int]): Number of channels in each layer of the U-Net.
-            num_estimators (int): Number of estimators.
-            bilinear (bool): If ``True``, use bilinear interpolation instead of
+            in_channels: Number of input channels.
+            num_classes: Number of output classes.
+            num_blocks: Number of channels in each layer of the U-Net.
+            num_estimators: Number of estimators.
+            bilinear: If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. Defaults to ``False``.
-            dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+            dropout_rate: Dropout rate. Defaults to ``0.0``.
 
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
@@ -187,13 +187,13 @@ def _batched_unet(
     """Create a Batched U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_blocks (list[int]): Number of channels in each layer of the U-Net.
-        num_estimators (int): Number of estimators.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each layer of the U-Net.
+        num_estimators: Number of estimators.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Batched U-Net model.
@@ -218,12 +218,12 @@ def batched_small_unet(
     """Create a Small Batched U-Net model (channels divided by 2).
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Small Batched U-Net model.
@@ -249,12 +249,12 @@ def batched_unet(
     """Create a Batched U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Batched U-Net model.

--- a/src/torch_uncertainty/models/segmentation/unet/masked.py
+++ b/src/torch_uncertainty/models/segmentation/unet/masked.py
@@ -20,11 +20,11 @@ class _DoubleConv(nn.Module):
         """Initialize the DoubleConv module: (Conv2d => BN => ReLU) * 2.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            num_estimators (int): Number of estimators.
-            scale (float): Scale for the MaskedConv2d layer.
-            mid_channels (int | None): Number of intermediate channels.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            num_estimators: Number of estimators.
+            scale: Scale for the MaskedConv2d layer.
+            mid_channels: Number of intermediate channels.
                 If ``None``, defaults to :attr:`out_channels`. Defaults to ``None``.
         """
         super().__init__()
@@ -50,10 +50,10 @@ class _Down(nn.Module):
         """Initialize the Down module: (Conv2d => BN => ReLU) * 2 + MaxPool2d.
 
         Args:
-            in_channels (int): Number of input channels.
-            out_channels (int): Number of output channels.
-            num_estimators (int): Number of estimators.
-            scale (float): Scale for the MaskedConv2d layer.
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            num_estimators: Number of estimators.
+            scale: Scale for the MaskedConv2d layer.
         """
         super().__init__()
         self.mpconv = nn.Sequential(
@@ -122,17 +122,17 @@ class _MaskedUNet(nn.Module):
         bilinear: bool = False,
         dropout_rate: float = 0.0,
     ) -> None:
-        """Masked U-Net model using Batch layers for uncertainty estimation.
+        """Masked U-Net model using Masksembles layers for uncertainty estimation.
 
         Args:
-            in_channels (int): Number of input channels.
-            num_classes (int): Number of output classes.
-            num_blocks (list[int]): Number of channels in each layer of the U-Net.
-            num_estimators (int): Number of estimators.
-            scale (float): Scale for the MaskedConv2d layer.
-            bilinear (bool): If ``True``, use bilinear interpolation instead of
+            in_channels: Number of input channels.
+            num_classes: Number of output classes.
+            num_blocks: Number of channels in each layer of the U-Net.
+            num_estimators: Number of estimators.
+            scale: Scale for the MaskedConv2d layer.
+            bilinear: If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. Defaults to ``False``.
-            dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+            dropout_rate: Dropout rate. Defaults to ``0.0``.
 
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
@@ -228,14 +228,14 @@ def _masked_unet(
     """Create a Masked U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_blocks (list[int]): Number of channels in each layer of the U-Net.
-        num_estimators (int): Number of estimators.
-        scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each layer of the U-Net.
+        num_estimators: Number of estimators.
+        scale: Scale for the MaskedConv2d layer.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Masked U-Net model.
@@ -262,13 +262,13 @@ def masked_small_unet(
     """Create a Small Masked U-Net model (channels divided by 2).
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators.
-        scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        scale: Scale for the MaskedConv2d layer.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Small Masked U-Net model.
@@ -296,13 +296,13 @@ def masked_unet(
     """Create a Masked U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators.
-        scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        scale: Scale for the MaskedConv2d layer.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Masked U-Net model.

--- a/src/torch_uncertainty/models/segmentation/unet/mimo.py
+++ b/src/torch_uncertainty/models/segmentation/unet/mimo.py
@@ -14,6 +14,16 @@ class _MIMOUNet(_UNet):
         bilinear: bool = False,
         dropout_rate: float = 0.0,
     ) -> None:
+        """MIMO U-Net for segmentation.
+
+        Args:
+            in_channels : Number of input channels.
+            num_classes : Number of output classes.
+            num_blocks: Number of channels in each U-Net stage.
+            num_estimators: Number of estimators in the MIMO setup.
+            bilinear: If ``True``, uses bilinear upsampling. Defaults to ``False``.
+            dropout_rate: Dropout rate. Defaults to ``0.0``.
+        """
         super().__init__(
             in_channels=in_channels * num_estimators,
             num_classes=num_classes * num_estimators,
@@ -38,6 +48,19 @@ def _mimo_unet(
     bilinear: bool = False,
     dropout_rate: float = 0.0,
 ) -> _MIMOUNet:
+    """Create a MIMO U-Net model.
+
+    Args:
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each U-Net stage.
+        num_estimators: Number of estimators in the MIMO setup.
+        bilinear: If ``True``, uses bilinear upsampling. Defaults to ``False``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+
+    Returns:
+        _MIMOUNet: MIMO U-Net model.
+    """
     return _MIMOUNet(
         in_channels, num_classes, num_blocks, num_estimators, bilinear, dropout_rate=dropout_rate
     )
@@ -50,6 +73,18 @@ def mimo_small_unet(
     bilinear: bool = False,
     dropout_rate: float = 0.0,
 ) -> _MIMOUNet:
+    """Create a small MIMO U-Net model.
+
+    Args:
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        bilinear: If ``True``, uses bilinear upsampling. Defaults to ``False``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+
+    Returns:
+        _MIMOUNet: Small MIMO U-Net model.
+    """
     num_blocks = [32, 64, 128, 256, 512]
     return _mimo_unet(
         in_channels, num_classes, num_blocks, num_estimators, bilinear, dropout_rate=dropout_rate
@@ -63,6 +98,18 @@ def mimo_unet(
     bilinear: bool = False,
     dropout_rate: float = 0.0,
 ) -> _MIMOUNet:
+    """Create a MIMO U-Net model.
+
+    Args:
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators.
+        bilinear: If ``True``, uses bilinear upsampling. Defaults to ``False``.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+
+    Returns:
+        _MIMOUNet: MIMO U-Net model.
+    """
     num_blocks = [64, 128, 256, 512, 1024]
     return _mimo_unet(
         in_channels, num_classes, num_blocks, num_estimators, bilinear, dropout_rate=dropout_rate

--- a/src/torch_uncertainty/models/segmentation/unet/packed.py
+++ b/src/torch_uncertainty/models/segmentation/unet/packed.py
@@ -248,20 +248,21 @@ def _packed_unet(
     gamma: int = 1,
     dropout_rate: float = 0.0,
 ) -> _PackedUNet:
-    """_summary_.
+    """Create a packed U-Net model.
 
     Args:
-        in_channels (int): _description_
-        num_classes (int): _description_
-        num_blocks (list[int]): _description_
-        bilinear (bool): _description_. Defaults to False.
-        alpha (float): _description_. Defaults to 1.
-        num_estimators (int): _description_. Defaults to 1.
-        gamma (int): _description_. Defaults to 1.
-        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each U-Net stage.
+        bilinear: If ``True``, use bilinear upsampling instead of
+            transposed convolutions. Defaults to ``False``.
+        alpha: Width multiplier for packed layers. Defaults to ``1``.
+        num_estimators: Number of estimators in the packed ensemble. Defaults to ``1``.
+        gamma: Number of groups per estimator. Defaults to ``1``.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
-        PackedUNet: _description_
+        _PackedUNet: Packed U-Net model.
     """
     return _PackedUNet(
         in_channels=in_channels,
@@ -287,15 +288,15 @@ def packed_small_unet(
     """Create a Packed-Ensembles of small U-Net models.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of classes to predict.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of classes to predict.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        alpha (float): Expansion factor affecting the width of the estimators. Defaults to ``1``.
-        num_estimators (int): Number of estimators in the ensemble. Defaults to ``1``.
-        gamma (int):  Number of groups within each estimator.. Defaults to ``1``.
-        dropout_rate (float): Dropout rate for the model. Defaults to ``0.0``.
+        alpha: Expansion factor affecting the width of the estimators. Defaults to ``1``.
+        num_estimators: Number of estimators in the ensemble. Defaults to ``1``.
+        gamma: Number of groups within each estimator. Defaults to ``1``.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
         PackedUNet: U-Net model.
@@ -324,15 +325,15 @@ def packed_unet(
     """Create a Packed-Ensembles of U-Net models.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        bilinear (bool): If ``True``, use bilinear interpolation instead
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        bilinear: If ``True``, use bilinear interpolation instead
             of transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        alpha (float): Expansion factor affecting the width of the estimators. Defaults to ``1``.
-        num_estimators (int): Number of estimators in the ensemble. Defaults to ``1``.
-        gamma (int): Number of groups within each estimator. Defaults to ``1``.
-        dropout_rate (float): Dropout rate for the model. Defaults to ``0.0``.
+        alpha: Expansion factor affecting the width of the estimators. Defaults to ``1``.
+        num_estimators: Number of estimators in the ensemble. Defaults to ``1``.
+        gamma: Number of groups within each estimator. Defaults to ``1``.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
         PackedUNet: U-Net model.

--- a/src/torch_uncertainty/models/segmentation/unet/standard.py
+++ b/src/torch_uncertainty/models/segmentation/unet/standard.py
@@ -14,10 +14,10 @@ def check_unet_parameters(
     """Check the parameters for the U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_blocks (list[int]): Number of channels in each layer of the U-Net.
-        bilinear (bool): Whether to use bilinear interpolation for upsampling.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each layer of the U-Net.
+        bilinear: Whether to use bilinear interpolation for upsampling.
     """
     if len(num_blocks) != 5:
         raise ValueError(f"num_blocks must be a list of 5 integers. Got {len(num_blocks)} blocks.")
@@ -130,13 +130,13 @@ class _UNet(nn.Module):
         (encoder) and an expansive path (decoder).
 
         Args:
-            in_channels (int): Number of input channels.
-            num_classes (int): Number of output classes.
-            num_blocks (list[int]): Number of channels in each layer of the U-Net.
-            bilinear (bool): If ``True``, use bilinear interpolation instead of
+            in_channels: Number of input channels.
+            num_classes: Number of output classes.
+            num_blocks: Number of channels in each layer of the U-Net.
+            bilinear: If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. This can help to reduce the number
                 of parameters and improve the performance of the model. Defaults to ``False``.
-            dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
+            dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
         super().__init__()
@@ -191,13 +191,13 @@ def _unet(
     """Create a U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_blocks (list[int]): Number of channels in each layer of the U-Net.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_blocks: Number of channels in each layer of the U-Net.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
         _UNet: U-Net model.
@@ -220,15 +220,15 @@ def small_unet(
     """Create a Small U-Net model (channels divided by 2).
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
-        _SmallUNet: Small U-Net model.
+        _UNet: Small U-Net model.
     """
     num_blocks = [32, 64, 128, 256, 512]
     return _unet(
@@ -249,12 +249,12 @@ def unet(
     """Create a U-Net model.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        bilinear (bool): If ``True``, use bilinear interpolation instead of
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        bilinear: If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate: Dropout rate for the model. Defaults to ``0.0``.
 
     Returns:
         _UNet: U-Net model.

--- a/src/torch_uncertainty/models/utils.py
+++ b/src/torch_uncertainty/models/utils.py
@@ -10,8 +10,8 @@ class Backbone(nn.Module):
         :attr:`feat_names`.
 
         Args:
-            model (nn.Module): Base model.
-            feat_names (list[str]): list of the feature names.
+            model: Base model.
+            feat_names: List of the feature names.
         """
         super().__init__()
         self.model = model
@@ -21,7 +21,7 @@ class Backbone(nn.Module):
         """Encoder forward pass.
 
         Args:
-            x (Tensor): Input tensor.
+            x: Input tensor.
 
         Returns:
             list[Tensor]: list of the features.
@@ -41,8 +41,8 @@ def set_bn_momentum(model: nn.Module, momentum: float) -> None:
     """Set the momentum of all batch normalization layers in the model.
 
     Args:
-        model (nn.Module): Model.
-        momentum (float): Momentum of the batch normalization layers.
+        model: Model.
+        momentum: Momentum of the batch normalization layers.
     """
     for m in model.modules():
         if isinstance(m, _BatchNorm):

--- a/src/torch_uncertainty/ood_criteria.py
+++ b/src/torch_uncertainty/ood_criteria.py
@@ -11,13 +11,11 @@ class OODCriterionInputType(Enum):
     """Enum representing the type of input expected by the OOD (Out-of-Distribution) criteria.
 
     Attributes:
-        LOGIT (int): The input of the OOD Criterion is in the form of logits (pre-softmax values).
-        PROB (int): The input is in the form of probabilities (post-softmax values), also called
-            likelihoods.
-        ESTIMATOR_PROB (int): The input is in the form of estimated probabilities from an ensemble
+        LOGIT: The input of the OOD criterion is in the form of logits (pre-softmax values).
+        PROB: The input is in the form of probabilities (post-softmax values).
+        ESTIMATOR_PROB: The input is in the form of estimated probabilities from an ensemble
             or another probabilistic model.
-        POST_PROCESSING (int): The input is the prediction score given by the post-processing
-            method.
+        POST_PROCESSING: The input is the prediction score given by the post-processing method.
     """
 
     LOGIT = 1
@@ -38,8 +36,8 @@ class TUOODCriterion(nn.Module, ABC):
         criteria. Subclasses must implement the `forward` method.
 
         Attributes:
-            input_type (OODCriterionInputType): Type of input expected by the criterion.
-            ensemble_only (bool): Whether the criterion requires ensemble outputs.
+            input_type: Type of input expected by the criterion.
+            ensemble_only: Whether the criterion requires ensemble outputs.
         """
         super().__init__()
 
@@ -48,7 +46,7 @@ class TUOODCriterion(nn.Module, ABC):
         """Forward pass for the OOD criterion.
 
         Args:
-            inputs (Tensor): The input tensor representing model outputs.
+            inputs: The input tensor representing model outputs.
 
         Returns:
             Tensor: OOD score computed according to the criterion.
@@ -66,7 +64,7 @@ class MaxLogitCriterion(TUOODCriterion):
         the output dimensions. Lower maximum logits indicate greater uncertainty.
 
         Attributes:
-            input_type (OODCriterionInputType): Expected input type is logits.
+            input_type: Expected input type is logits.
         """
         super().__init__()
 
@@ -74,7 +72,7 @@ class MaxLogitCriterion(TUOODCriterion):
         """Compute the negative of the maximum logit value.
 
         Args:
-            inputs (Tensor): Tensor of logits with shape (batch_size, num_classes).
+            inputs: Tensor of logits with shape (batch_size, num_classes).
 
         Returns:
             Tensor: Negative of the maximum logit value for each sample.
@@ -98,7 +96,7 @@ class EnergyCriterion(TUOODCriterion):
         where :math:`\mathbf{z} = [z_1, z_2, \dots, z_C]` is the logit vector.
 
         Attributes:
-            input_type (OODCriterionInputType): Expected input type is logits.
+            input_type: Expected input type is logits.
         """
         super().__init__()
 
@@ -106,7 +104,7 @@ class EnergyCriterion(TUOODCriterion):
         """Compute the negative energy score.
 
         Args:
-            inputs (Tensor): Tensor of logits with shape (batch_size, num_classes).
+            inputs: Tensor of logits with shape (batch_size, num_classes).
 
         Returns:
             Tensor: Negative energy score for each sample.
@@ -121,7 +119,7 @@ class MaxSoftmaxCriterion(TUOODCriterion):
         r"""OOD criterion based on maximum softmax probability.
 
         This criterion computes the negative of the highest softmax probability.
-        Lower maximum probabilities indicate greater uncertainty. Probabilities are also called*
+        Lower maximum probabilities indicate greater uncertainty. Probabilities are also called
         likelihoods in a more formal context.
 
         .. math::
@@ -130,7 +128,7 @@ class MaxSoftmaxCriterion(TUOODCriterion):
         where :math:`\mathbf{p} = [p_1, p_2, \dots, p_C]` is the probability vector.
 
         Attributes:
-            input_type (OODCriterionInputType): Expected input type is probabilities.
+            input_type: Expected input type is probabilities.
         """
         super().__init__()
 
@@ -138,7 +136,7 @@ class MaxSoftmaxCriterion(TUOODCriterion):
         """Compute the negative of the maximum softmax probability.
 
         Args:
-            inputs (Tensor): Tensor of probabilities with shape (batch_size, num_classes).
+            inputs: Tensor of probabilities with shape (batch_size, num_classes).
 
         Returns:
             Tensor: Negative of the highest softmax probability for each sample.
@@ -165,7 +163,7 @@ class EntropyCriterion(TUOODCriterion):
         where :math:`\mathbf{p} = [p_1, p_2, \dots, p_C]` is the probability vector.
 
         Attributes:
-            input_type (OODCriterionInputType): Expected input type is estimated probabilities.
+            input_type: Expected input type is estimated probabilities.
         """
         super().__init__()
 
@@ -173,7 +171,7 @@ class EntropyCriterion(TUOODCriterion):
         """Compute the entropy of the predicted probability distribution.
 
         Args:
-            inputs (Tensor): Tensor of estimated probabilities with shape (batch_size, num_classes).
+            inputs: Tensor of estimated probabilities with shape (batch_size, num_classes).
 
         Returns:
             Tensor: Mean entropy value for each sample.
@@ -197,8 +195,8 @@ class MutualInformationCriterion(TUOODCriterion):
             I(y, \theta) = H\Big(\frac{1}{K}\sum_{k=1}^{K} \mathbf{p}^{(k)}\Big) - \frac{1}{K}\sum_{k=1}^{K} H(\mathbf{p}^{(k)})
 
         Attributes:
-            ensemble_only (bool): Requires ensemble predictions.
-            input_type (OODCriterionInputType): Expected input type is estimated probabilities.
+            ensemble_only: Requires ensemble predictions.
+            input_type: Expected input type is estimated probabilities.
         """
         super().__init__()
         self.mi_metric = MutualInformation(reduction="none")
@@ -207,7 +205,7 @@ class MutualInformationCriterion(TUOODCriterion):
         """Compute mutual information from ensemble predictions.
 
         Args:
-            inputs (Tensor): Tensor of ensemble probabilities with shape
+            inputs: Tensor of ensemble probabilities with shape
                 (ensemble_size, batch_size, num_classes).
 
         Returns:
@@ -233,8 +231,8 @@ class VariationRatioCriterion(TUOODCriterion):
             \text{VR} = 1 - \frac{n_{\text{mode}}}{K}
 
         Attributes:
-            ensemble_only (bool): Requires ensemble predictions.
-            input_type (OODCriterionInputType): Expected input type is estimated probabilities.
+            ensemble_only: Requires ensemble predictions.
+            input_type: Expected input type is estimated probabilities.
         """
         super().__init__()
         self.vr_metric = VariationRatio(reduction="none", probabilistic=False)
@@ -243,7 +241,7 @@ class VariationRatioCriterion(TUOODCriterion):
         """Compute variation ratio from ensemble predictions.
 
         Args:
-            inputs (Tensor): Tensor of ensemble probabilities with shape
+            inputs: Tensor of ensemble probabilities with shape
                 (ensemble_size, batch_size, num_classes).
 
         Returns:
@@ -256,7 +254,7 @@ def get_ood_criterion(ood_criterion: type[TUOODCriterion] | TUOODCriterion | str
     """Get an OOD criterion instance based on a string identifier or class type.
 
     Args:
-        ood_criterion (str, type or TUOODCriterion): A string identifier for a predefined OOD criterion
+        ood_criterion: A string identifier for a predefined OOD criterion
             or a subclass of `TUOODCriterion`.
 
     Returns:

--- a/src/torch_uncertainty/optim/sghmc.py
+++ b/src/torch_uncertainty/optim/sghmc.py
@@ -20,15 +20,15 @@ class SGHMC(Optimizer):
             Use torch_uncertainty.methods.CheckpointCollector to collect the samples.
 
         Args:
-            params (ParamsT): Iterable of parameters or named_parameters to optimize or iterable of
+            params: Iterable of parameters or named_parameters to optimize or iterable of
                 dicts defining parameter groups. When using named_parameters, all parameters in all
                 groups should be named.
-            lr (float): Learning rate :math:`\epsilon`. Defaults to ``1e-2``.
-            burn_in_steps (int): Number of discarded steps used to update the state. Defaults to ``200``.
-            friction (float): The friction term :math:`C`. Defaults to ``0.05``.
-            noise_factor (float): A factor to reduce the amount of noise and stabilize the training.
+            lr: Learning rate :math:`\epsilon`. Defaults to ``1e-2``.
+            burn_in_steps: Number of discarded steps used to update the state. Defaults to ``200``.
+            friction: The friction term :math:`C`. Defaults to ``0.05``.
+            noise_factor: A factor to reduce the amount of noise and stabilize the training.
                 This parameter was not proposed in the original paper. Defaults to ``1e-2``.
-            weight_decay (float): Weight decay (L2 penalty). Defaults to ``0``.
+            weight_decay: Weight decay (L2 penalty). Defaults to ``0``.
 
         Reference:
             - [1] `Stochastic Gradient Hamiltonian Monte Carlo <https://arxiv.org/pdf/1402.4102>`_.
@@ -49,6 +49,7 @@ class SGHMC(Optimizer):
     def step(
         self, closure: Callable[[], float] | None = None, burn_in: bool = False
     ) -> float | None:
+        # TODO: Check this implementation
         loss = None
         if closure is not None:
             loss = closure()
@@ -108,5 +109,4 @@ class SGHMC(Optimizer):
 
                 # update parameter, Eq. 10 in [2] left equation
                 p.data.add_(momentum)
-
         return loss

--- a/src/torch_uncertainty/optim/sgld.py
+++ b/src/torch_uncertainty/optim/sgld.py
@@ -18,13 +18,13 @@ class SGLD(Optimizer):
             Use torch_uncertainty.methods.CheckpointCollector to collect the samples.
 
         Args:
-            params (ParamsT): Iterable of parameters or named_parameters to optimize or iterable of
+            params: Iterable of parameters or named_parameters to optimize or iterable of
                 dicts defining parameter groups. When using named_parameters, all parameters in all
                 groups should be named.
-            lr (float): Learning rate for the optimization. Defaults to ``1e-3``.
-            noise_factor (float): A factor to reduce the amount of noise and stabilize the training.
+            lr: Learning rate for the optimization. Defaults to ``1e-3``.
+            noise_factor: A factor to reduce the amount of noise and stabilize the training.
                 This parameter was not proposed in the original paper. Defaults to ``1e-2``.
-            weight_decay (float): Weight decay (L2 penalty). Defaults to ``0``.
+            weight_decay: Weight decay (L2 penalty). Defaults to ``0``.
 
         Reference:
             - `Bayesian Learning via Stochastic Gradient Langevin Dynamics <https://www.stats.ox.ac.uk/~teh/research/compstats/WelTeh2011a.pdf>`_.

--- a/src/torch_uncertainty/optim_recipes.py
+++ b/src/torch_uncertainty/optim_recipes.py
@@ -202,9 +202,9 @@ def optim_imagenet_resnet50_a3(model: nn.Module, effective_batch_size: int | Non
         procedure in timm.
 
     Args:
-        model (nn.Module): The model to be optimized.
-        effective_batch_size (int): The batch size of the model
-            (taking multiple GPUs into account). Defaults to None.
+        model: The model to be optimized.
+        effective_batch_size: The batch size of the model
+            (taking multiple GPUs into account). Defaults to ``None``.
 
     Returns:
         dict: The optimizer and the scheduler for the training.
@@ -329,6 +329,22 @@ def optim_tinyimagenet_resnet50(
 
 
 def batch_ensemble_wrapper(model: nn.Module, optim_recipe: Callable) -> dict:
+    """Wrap an existing optimizer recipe for BatchEnsemble-style models.
+
+    The wrapper calls the provided ``optim_recipe`` to obtain an optimizer
+    and scheduler, inspects defaults (weight decay, lr, momentum) and builds
+    a new optimizer that applies different weight decay to the BatchEnsemble
+    multiplicative parameters while keeping the core parameters regularized.
+
+    Args:
+        model: The model containing BatchEnsemble parameter names (e.g. containing
+            'R' and 'S' layers).
+        optim_recipe: Callable that returns the optimizer procedure for the base model.
+
+    Returns:
+        A dict containing the new ``optimizer`` and the ``lr_scheduler`` returned by
+        the original procedure (with the optimizer replaced).
+    """
     procedure = optim_recipe(model)
     param_optimizer = procedure["optimizer"]
     scheduler = procedure["lr_scheduler"]
@@ -375,11 +391,10 @@ def get_procedure(
     """Get the optimization recipe for a given architecture and dataset.
 
     Args:
-        arch_name (str): The name of the architecture.
-        ds_name (str): The name of the dataset.
-        method (str): The name of the method. Defaults to "".
-        imagenet_recipe (str): The recipe to use for
-            ImageNet. Defaults to None.
+        arch_name: The name of the architecture.
+        ds_name: The name of the dataset.
+        method: The name of the method. Defaults to ``""``.
+        imagenet_recipe: The recipe to use for ImageNet. Defaults to ``None``.
 
     Returns:
         callable: The optimization recipe.
@@ -447,14 +462,14 @@ class WarmupScheduler(SequentialLR):
         """Scheduler with linear warmup.
 
         Args:
-            optimizer (Optimizer): The optimizer to be used.*
-            base_scheduler (type[LRScheduler]): The base scheduler class to use after
+            optimizer: The optimizer to be used.
+            base_scheduler: The base scheduler class to use after
                 the warmup.
-            warmup_start_factor (float): The multiplicative factor to apply to
+            warmup_start_factor: The multiplicative factor to apply to
                 the learning rate at the start of the warmup.
-            warmup_epochs (int): The number of epochs to warmup the learning
+            warmup_epochs: The number of epochs to warmup the learning
                 rate.
-            scheduler_args (dict[str, float]): The arguments to pass to the base
+            scheduler_args: The arguments to pass to the base
                 scheduler.
         """
         warmup_scheduler = LinearLR(
@@ -483,13 +498,13 @@ class CosineAnnealingWarmup(WarmupScheduler):
         """Cosine annealing scheduler with linear warmup.
 
         Args:
-            optimizer (Optimizer): The optimizer to be used.
-            warmup_start_factor (float): The multiplicative factor to apply to
+            optimizer: The optimizer to be used.
+            warmup_start_factor: The multiplicative factor to apply to
                 the learning rate at the start of the warmup.
-            warmup_epochs (int): The number of epochs to warmup the learning
+            warmup_epochs: The number of epochs to warmup the learning
                 rate.
-            max_epochs (int): The total number of epochs including warmup.
-            eta_min (float): The minimum learning rate.
+            max_epochs: The total number of epochs including warmup.
+            eta_min: The minimum learning rate.
         """
         super().__init__(
             optimizer=optimizer,
@@ -520,12 +535,12 @@ class CosineSWALR(SequentialLR):
         example.
 
         Args:
-            optimizer (Optimizer): The optimizer to be used.
-            milestone (int): The epoch to start the SWA.
-            swa_lr (float): The learning rate to use for the SWA model.
-            anneal_epochs (int): The number of epochs to anneal the learning rate.
-            optim_eta_min (float): The minimum learning rate for the first optimizer.
-            anneal_strategy (Literal["cos", "linear"]): The strategy to anneal the learning rate.
+            optimizer: The optimizer to be used.
+            milestone: The epoch to start the SWA.
+            swa_lr: The learning rate to use for the SWA model.
+            anneal_epochs: The number of epochs to anneal the learning rate.
+            optim_eta_min: The minimum learning rate for the first optimizer. Defaults to ``0``.
+            anneal_strategy: The strategy to anneal the learning rate. Defaults to ``"cos"``.
         """
         optim_scheduler = CosineAnnealingLR(
             optimizer=optimizer, T_max=milestone, eta_min=optim_eta_min

--- a/src/torch_uncertainty/post_processing/abnn.py
+++ b/src/torch_uncertainty/post_processing/abnn.py
@@ -31,24 +31,17 @@ class ABNN(PostProcessing):
         """ABNN post-processing.
 
         Args:
-            num_classes (int): Number of classes of the inner model.
-                random_prior (float): Random prior specializing estimators on
-                certain classes.
-            random_prior (float): Random prior value to specialize
-                estimators on certain classes.
-            alpha (float): Alpha value for ABNN to control the diversity of
-                the predictions.
-            num_models (int): Number of stochastic models.
-            num_samples (int): Number of samples per model.
-            base_lr (float): Base learning rate.
-            device (torch.device): Device to use.
-            max_epochs (int): Number of training epochs. Defaults
-                to ``5``.
-            use_original_model (bool): Use original model during
-                evaluation. Defaults to ``True``.
-            precision (str): Machine precision for training & eval.
-                Defaults to ``"32"``.
-            model (nn.Module | None): Model to use. Defaults to ``None``.
+            num_classes: Number of classes of the inner model.
+            random_prior: Random prior value to specialize estimators on certain classes.
+            alpha: Alpha value for ABNN to control the diversity of the predictions.
+            num_models: Number of stochastic models.
+            num_samples: Number of samples per model.
+            base_lr: Base learning rate.
+            device: Device to use.
+            max_epochs: Number of training epochs. Defaults to ``5``.
+            use_original_model: Use original model during evaluation. Defaults to ``True``.
+            precision: Machine precision for training & eval. Defaults to ``"32"``.
+            model: Model to use. Defaults to ``None``.
         """
         super().__init__(model)
         _abnn_checks(
@@ -163,8 +156,8 @@ def _replace_bn_layers(model: nn.Module, alpha: float) -> None:
     """Recursively replace batch normalization layers with ABNN layers.
 
     Args:
-        model (nn.Module): Model to replace batch normalization layers.
-        alpha (float): Alpha value for ABNN.
+        model: Model to replace batch normalization layers.
+        alpha: Alpha value for ABNN.
     """
     for name, module in model.named_children():
         if len(list(module.children())) > 0:

--- a/src/torch_uncertainty/post_processing/abstract.py
+++ b/src/torch_uncertainty/post_processing/abstract.py
@@ -6,16 +6,19 @@ from torch.utils.data import DataLoader
 
 class PostProcessing(nn.Module, ABC):
     def __init__(self, model: nn.Module | None = None) -> None:
-        """Abstract post-processing class."""
+        """Base class for post-processing modules."""
         super().__init__()
         self.model = model
         self.trained = False
 
     def set_model(self, model: nn.Module) -> None:
+        """Attach a model to the post-processing module."""
         self.model = model
 
     @abstractmethod
-    def fit(self, dataloader: DataLoader) -> None: ...
+    def fit(self, dataloader: DataLoader) -> None:
+        """Fit the post-processing module on a calibration dataloader."""
 
     @abstractmethod
-    def forward(self, inputs: Tensor) -> Tensor: ...
+    def forward(self, inputs: Tensor) -> Tensor:
+        """Transform model outputs into post-processed predictions."""

--- a/src/torch_uncertainty/post_processing/calibration/bbq.py
+++ b/src/torch_uncertainty/post_processing/calibration/bbq.py
@@ -36,20 +36,18 @@ class BBQScaler(PostProcessing):
         strategy, fitting independent Bayesian ensembles per class.
 
         Args:
-            model (nn.Module | None): Model to calibrate. Defaults to ``None``.
-            max_bins (int): The maximum number of bins to consider. The scaler
+            model: Model to calibrate. Defaults to ``None``.
+            max_bins: The maximum number of bins to consider. The scaler
                 will evaluate all binning schemes from 2 up to ``max_bins``.
                 Defaults to ``15``.
-            prior_weight (float): The equivalent sample size ($N'$) for the
+            prior_weight: The equivalent sample size ($N'$) for the
                 uniform prior distributed across bins to penalize models with
-                too many bins. Defaults to ``2.0``(the value used in the original)
-                paper.
-            model_pruning (float | None): Prune a model if its weight is below :attr:`model_pruning`.
+                too many bins. Defaults to ``2.0``(the value used in the original) paper.
+            model_pruning: Prune a model if its weight is below :attr:`model_pruning`.
                 Do not prune if ``None``. Defaults to ``1e-9``.
-            eps (float): Small value for stability when converting probs back
-                to logits. Defaults to ``1e-6``.
-            device (Literal["cpu", "cuda"]]= | torch.device | None): Device to use
-                for tensor operations. Defaults to ``None``.
+            eps: Small value for stability when converting probs back to logits.
+                Defaults to ``1e-6``.
+            device: Device to use for tensor operations. Defaults to ``None``.
 
         References:
             [1] Obtaining Well Calibrated Probabilities Using Bayesian Binning.
@@ -80,8 +78,8 @@ class BBQScaler(PostProcessing):
         """Fit the BBQ ensembles to the calibration data.
 
         Args:
-            dataloader (DataLoader): Dataloader providing the calibration data.
-            progress (bool): Whether to show a progress bar.
+            dataloader: Dataloader providing the calibration data.
+            progress: Whether to show a progress bar.
                 Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):

--- a/src/torch_uncertainty/post_processing/calibration/dirichlet_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/dirichlet_scaler.py
@@ -27,21 +27,19 @@ class DirichletScaler(MatrixScaler):
         """Dirichlet scaling post-processing for calibrated probabilities.
 
         Args:
-            num_classes (int): Number of classes.
-            model (nn.Module | None): Model to calibrate. Defaults to ``None``.
-            init_weight_temperature (float): Initial value for the weight matrix. Defaults to ``1``.
-            init_bias_temperature (float | None): Initial value for the bias. The inverse bias will be
+            num_classes: Number of classes.
+            model: Model to calibrate. Defaults to ``None``.
+            init_weight_temperature: Initial value for the weight matrix. Defaults to ``1``.
+            init_bias_temperature: Initial value for the bias. The inverse bias will be
                 set to the ``0`` vector if set to ``None``. Defaults to ``None``.
-            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``200``.
-            lambda_reg (float | None): Regularization coefficient applied to the
+            lr: Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter: Maximum number of iterations for the optimizer. Defaults to ``200``.
+            lambda_reg: Regularization coefficient applied to the
                 off-diagonal elements of the weight matrix. Used to mitigate overfitting.
                 Defaults to ``None``.
-            mu_reg (float | None): Regularization coefficient applied to the
-                bias vector. Defaults to ``None``.
-            eps (float): Small value for numerical stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization.
-                Defaults to ``None``.
+            mu_reg: Regularization coefficient applied to the bias vector. Defaults to ``None``.
+            eps: Small value for numerical stability. Defaults to ``1e-8``.
+            device: Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `Beyond temperature scaling: Obtaining well-calibrated multiclass
@@ -77,12 +75,10 @@ class DirichletScaler(MatrixScaler):
         """Fit the temperature parameters to the calibration data.
 
         Args:
-            dataloader (DataLoader): Dataloader with the calibration data. If there is no model,
+            dataloader: Dataloader with the calibration data. If there is no model,
                 the dataloader should include the confidence score directly and not the logits.
-            save_logits (bool): Whether to save the logits and
-                labels in memory. Defaults to ``False``.
-            progress (bool): Whether to show a progress bar.
-                Defaults to ``True``.
+            save_logits: Whether to save the logits and labels in memory. Defaults to ``False``.
+            progress: Whether to show a progress bar. Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):
             logging.warning(

--- a/src/torch_uncertainty/post_processing/calibration/histogram_binning.py
+++ b/src/torch_uncertainty/post_processing/calibration/histogram_binning.py
@@ -30,12 +30,11 @@ class HistogramBinningScaler(PostProcessing):
         it computes the empirical probability of the positive class.
 
         Args:
-            model (nn.Module): Model to calibrate. Defaults to ``None``.
-            num_bins (int): Number of equal-width bins to use. Defaults to ``15``.
-            eps (float): Small value for stability when converting probs back to logits.
+            model: Model to calibrate. Defaults to ``None``.
+            num_bins: Number of equal-width bins to use. Defaults to ``15``.
+            eps: Small value for stability when converting probs back to logits.
                 Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for
-                tensor operations. Defaults to ``None``.
+            device: Device to use for tensor operations. Defaults to ``None``.
 
         References:
             [1] Obtaining calibrated probability estimates from decision trees
@@ -59,9 +58,8 @@ class HistogramBinningScaler(PostProcessing):
         """Fit the histogram binning model to the calibration data.
 
         Args:
-            dataloader (DataLoader): Dataloader providing the calibration data.
-            progress (bool): Whether to show a progress bar.
-                Defaults to ``True``.
+            dataloader: Dataloader providing the calibration data.
+            progress: Whether to show a progress bar. Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):  # coverage: ignore
             logging.warning(

--- a/src/torch_uncertainty/post_processing/calibration/isotonic_regression.py
+++ b/src/torch_uncertainty/post_processing/calibration/isotonic_regression.py
@@ -37,11 +37,10 @@ class IsotonicRegressionScaler(PostProcessing):
         Multi-class calibration is handled using a one-vs-rest approach per class.
 
         Args:
-            model (nn.Module): Model to calibrate. Defaults to ``None``.
-            eps (float): Small value for stability when converting probs back to logits.
+            model: Model to calibrate. Defaults to ``None``.
+            eps: Small value for stability when converting probs back to logits.
                 Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for
-                tensor operations. Defaults to ``None``.
+            device: Device to use for tensor operations. Defaults to ``None``.
 
         References:
             [1] Transforming Classifier Scores into Accurate Multiclass
@@ -80,10 +79,8 @@ class IsotonicRegressionScaler(PostProcessing):
         class versus all others.
 
         Args:
-            dataloader (DataLoader): Dataloader providing the calibration data
-                (logits and targets).
-            progress (bool): Whether to show a progress bar during
-                data extraction. Defaults to ``True``.
+            dataloader: Dataloader providing the calibration data (logits and targets).
+            progress: Whether to show a progress bar during data extraction. Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):  # coverage: ignore
             logging.warning(
@@ -122,7 +119,7 @@ class IsotonicRegressionScaler(PostProcessing):
         downstream loss functions or metrics.
 
         Args:
-            inputs (Tensor): Input logits to be calibrated.
+            inputs: Input logits to be calibrated.
 
         Returns:
             Tensor: Calibrated logits.

--- a/src/torch_uncertainty/post_processing/calibration/matrix_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/matrix_scaler.py
@@ -23,15 +23,15 @@ class MatrixScaler(Scaler):
         """Matrix scaling post-processing for calibrated probabilities.
 
         Args:
-            num_classes (int): Number of classes.
-            model (nn.Module | None): Model to calibrate. Defaults to ``None``.
-            init_weight_temperature (float | Tensor ): Initial value for the weights. Defaults to ``1``.
-            init_bias_temperature (float | Tensor | None): Initial value for the bias. The inverse bias will be
+            num_classes: Number of classes.
+            model: Model to calibrate. Defaults to ``None``.
+            init_weight_temperature: Initial value for the weights. Defaults to ``1``.
+            init_bias_temperature: Initial value for the bias. The inverse bias will be
                 set to the ``0`` vector if set to ``None``. Defaults to ``None``.
-            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
-            eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
+            lr: Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter: Maximum number of iterations for the optimizer. Defaults to ``100``.
+            eps: Small value for stability. Defaults to ``1e-8``.
+            device: Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017
@@ -51,8 +51,8 @@ class MatrixScaler(Scaler):
         """Set the temperature matrix to a given value.
 
         Args:
-            val_weight (float | Tensor): Weight temperature value.
-            val_bias (float | Tensor): Bias temperature value.
+            val_weight: Weight temperature value.
+            val_bias: Bias temperature value.
         """
         eye = torch.eye(self.num_classes, device=self.device)
         self.inv_temperature_weight = nn.Parameter(

--- a/src/torch_uncertainty/post_processing/calibration/scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/scaler.py
@@ -28,11 +28,11 @@ class Scaler(PostProcessing):
         """Virtual class for scaling post-processing for calibrated probabilities.
 
         Args:
-            model (nn.Module): Model to calibrate. Defaults to ``None``.
-            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
-            eps (float): Small value for stability. Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
+            model: Model to calibrate. Defaults to ``None``.
+            lr: Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter: Maximum number of iterations for the optimizer. Defaults to ``100``.
+            eps: Small value for stability. Defaults to ``1e-6``.
+            device: Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017
@@ -66,11 +66,9 @@ class Scaler(PostProcessing):
         """Fit the temperature parameters to the calibration data.
 
         Args:
-            dataloader (DataLoader): Dataloader with the logits and target of the calibration data.
-            save_logits (bool): Whether to save the logits and
-                labels in memory. Defaults to ``False``.
-            progress (bool): Whether to show a progress bar.
-                Defaults to ``True``.
+            dataloader: Dataloader with the logits and target of the calibration data.
+            save_logits: Whether to save the logits and labels in memory. Defaults to ``False``.
+            progress: Whether to show a progress bar. Defaults to ``True``.
 
         Warning:
             Please provide logits and not probabilities/likelihoods within the dataloader, otherwise
@@ -140,7 +138,7 @@ class Scaler(PostProcessing):
         """Scale the logits with the optimal temperature.
 
         Args:
-            logits (Tensor): Logits to be scaled.
+            logits: Logits to be scaled.
 
         Returns:
             Tensor: Scaled logits.

--- a/src/torch_uncertainty/post_processing/calibration/temperature_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/temperature_scaler.py
@@ -21,12 +21,12 @@ class TemperatureScaler(Scaler):
         """Temperature scaling post-processing for calibrated probabilities.
 
         Args:
-            model (nn.Module): Model to calibrate.
-            init_temperature (float | Tensor): Initial value for the temperature. Defaults to ``1``.
-            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
-            eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
+            model: Model to calibrate.
+            init_temperature: Initial value for the temperature. Defaults to ``1``.
+            lr: Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter: Maximum number of iterations for the optimizer. Defaults to ``100``.
+            eps: Small value for stability. Defaults to ``1e-8``.
+            device: Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017
@@ -62,7 +62,7 @@ class TemperatureScaler(Scaler):
         """Set the temperature to a fixed value.
 
         Args:
-            val (float | Tensor): Temperature value.
+            val: Temperature value.
         """
         if val <= 0:
             raise ValueError(f"Temperature value must be strictly positive. Got {val}.")

--- a/src/torch_uncertainty/post_processing/calibration/utils.py
+++ b/src/torch_uncertainty/post_processing/calibration/utils.py
@@ -23,11 +23,10 @@ def _extract_data(
     """Extract logits and labels from the dataloader.
 
     Args:
-        dataloader (DataLoader): The calibration dataloader.
-        model (nn.Module): Model to calibrate.
-        device (Optional[Literal["cpu", "cuda"]]): Device to use for
-            tensor operations.
-        progress (bool): Whether to show the progress bar.
+        dataloader: The calibration dataloader.
+        model: Model to calibrate.
+        device: Device to use for tensor operations.
+        progress: Whether to show the progress bar.
 
     Returns:
         tuple[Tensor, Tensor]: Tensors containing all logits and labels

--- a/src/torch_uncertainty/post_processing/calibration/vector_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/vector_scaler.py
@@ -21,13 +21,13 @@ class VectorScaler(Scaler):
         """Vector scaling post-processing for calibrated probabilities.
 
         Args:
-            model (nn.Module): Model to calibrate.
-            num_classes (int): Number of classes.
-            init_temperature (float | Tensor): Initial value for the weights. Defaults to ``1``.
-            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
-            eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
+            model: Model to calibrate.
+            num_classes: Number of classes.
+            init_temperature: Initial value for the weights. Defaults to ``1``.
+            lr: Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter: Maximum number of iterations for the optimizer. Defaults to ``100``.
+            eps: Small value for stability. Defaults to ``1e-8``.
+            device: Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017
@@ -47,7 +47,7 @@ class VectorScaler(Scaler):
         """Set the temperature vector to a given value.
 
         Args:
-            val (float | Tensor): Weight temperature vector, or float.
+            val: Weight temperature vector, or float.
         """
         if isinstance(val, float | int) or (isinstance(val, Tensor) and val.size == 1):
             if val <= 0:

--- a/src/torch_uncertainty/post_processing/conformal/abstract.py
+++ b/src/torch_uncertainty/post_processing/conformal/abstract.py
@@ -9,12 +9,6 @@ from torch_uncertainty.post_processing.abstract import PostProcessing
 
 
 class Conformal(PostProcessing):
-    """Conformal base class.
-
-    Warning:
-        This implementation only works in the multiclass setting. Raise an issue if binary is needed.
-    """
-
     q_hat: Tensor | None = None
 
     def __init__(
@@ -27,6 +21,11 @@ class Conformal(PostProcessing):
         enable_ts: bool,
         device: Literal["cpu", "cuda"] | torch.device | None,
     ) -> None:
+        """Conformal base class.
+
+        Warning:
+            This implementation only works in the multiclass setting. Raise an issue if binary is needed.
+        """
         super().__init__(model=model)
         self.alpha = alpha
         self.enable_ts = enable_ts
@@ -56,7 +55,8 @@ class Conformal(PostProcessing):
         return self.model(inputs.to(self.device)).softmax(-1)
 
     @abstractmethod
-    def conformal(self, inputs: Tensor) -> Tensor: ...
+    def conformal(self, inputs: Tensor) -> Tensor:
+        """Apply the conformal prediction rule to the inputs."""
 
     def forward(self, inputs: Tensor) -> Tensor:
         return self.conformal(inputs)

--- a/src/torch_uncertainty/post_processing/conformal/aps.py
+++ b/src/torch_uncertainty/post_processing/conformal/aps.py
@@ -22,17 +22,15 @@ class ConformalClsAPS(Conformal):
         r"""Conformal prediction with APS scores.
 
         Args:
-            alpha (float): The confidence level meaning we allow :math:`1-\alpha` error.
-            model (nn.Module | None): Trained classification model. Defaults to ``None``.
-            randomized (bool): Whether to use randomized smoothing in APS. Defaults to ``True``.
-            ts_init_val (float): Initial value for the temperature.
-                Defaults to ``1.0``.
-            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int): Maximum number of iterations for the temperature scaling
-                optimizer. Defaults to ``100``.
-            enable_ts (bool): Whether to scale the logits. Defaults to ``False``.
-            device (Literal["cpu", "cuda"] | torch.device | None): device.
-                Defaults to ``None``.
+            alpha: The confidence level meaning we allow :math:`1-\alpha` error.
+            model: Trained classification model. Defaults to ``None``.
+            randomized: Whether to use randomized smoothing in APS. Defaults to ``True``.
+            ts_init_val: Initial value for the temperature. Defaults to ``1.0``.
+            ts_lr: Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter: Maximum number of iterations for the temperature scaling optimizer.
+                Defaults to ``100``.
+            enable_ts: Whether to scale the logits. Defaults to ``False``.
+            device: device. Defaults to ``None``.
 
         Warning:
             This implementation only works in the multiclass setting. Raise an issue if binary is needed.

--- a/src/torch_uncertainty/post_processing/conformal/raps.py
+++ b/src/torch_uncertainty/post_processing/conformal/raps.py
@@ -23,19 +23,17 @@ class ConformalClsRAPS(ConformalClsAPS):
         r"""Conformal prediction with RAPS scores.
 
         Args:
-            alpha (float): The confidence level meaning we allow :math:`1-\alpha` error.
-            model (nn.Module | None): Trained classification model. Defaults to ``None``.
-            randomized (bool): Whether to use randomized smoothing in RAPS. Defaults to ``True``.
-            penalty (float): Regularization weight. Defaults to ``0.1``.
-            regularization_rank (int): Rank threshold for regularization. Defaults to ``1``.
-            ts_init_val (float): Initial value for the temperature.
-                Defaults to ``1.0``.
-            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int): Maximum number of iterations for the temperature scaling
-                optimizer. Defaults to ``100``.
-            enable_ts (bool): Whether to scale the logits. Defaults to ``False``.
-            device (Literal["cpu", "cuda"] | torch.device | None): device.
-                Defaults to ``None``.
+            alpha: The confidence level meaning we allow :math:`1-\alpha` error.
+            model: Trained classification model. Defaults to ``None``.
+            randomized: Whether to use randomized smoothing in RAPS. Defaults to ``True``.
+            penalty: Regularization weight. Defaults to ``0.1``.
+            regularization_rank: Rank threshold for regularization. Defaults to ``1``.
+            ts_init_val: Initial value for the temperature. Defaults to ``1.0``.
+            ts_lr: Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter: Maximum number of iterations for the temperature scaling optimizer.
+                Defaults to ``100``.
+            enable_ts: Whether to scale the logits. Defaults to ``False``.
+            device: device. Defaults to ``None``.
 
         Warning:
             This implementation only works in the multiclass setting. Raise an issue if binary is needed.

--- a/src/torch_uncertainty/post_processing/conformal/thr.py
+++ b/src/torch_uncertainty/post_processing/conformal/thr.py
@@ -21,16 +21,14 @@ class ConformalClsTHR(Conformal):
         r"""Conformal prediction post-processing for calibrated models.
 
         Args:
-            alpha (float): The confidence level, meaning we allow :math:`1-\alpha` error.
-            model (nn.Module | None): Model to be calibrated. Defaults to ``None``.
-            ts_init_val (float): Initial value for the temperature.
-                Defaults to ``1.0``.
-            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int): Maximum number of iterations for the temperature scaling
+            alpha: The confidence level, meaning we allow :math:`1-\alpha` error.
+            model: Model to be calibrated. Defaults to ``None``.
+            ts_init_val: Initial value for the temperature. Defaults to ``1.0``.
+            ts_lr: Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter: Maximum number of iterations for the temperature scaling
                 optimizer. Defaults to ``100``.
-            enable_ts (bool): Whether to scale the logits. Defaults to ``True``.
-            device (Literal["cpu", "cuda"] | torch.device | None): device.
-                Defaults to ``None``.
+            enable_ts: Whether to scale the logits. Defaults to ``True``.
+            device: device. Defaults to ``None``.
 
         Warning:
             This implementation only works in the multiclass setting. Raise an issue if binary is needed.

--- a/src/torch_uncertainty/post_processing/laplace.py
+++ b/src/torch_uncertainty/post_processing/laplace.py
@@ -30,19 +30,15 @@ class LaplaceApprox(PostProcessing):
         This class is a wrapper of Laplace classes from the laplace-torch library.
 
         Args:
-            task (Literal[``"classification"``, ``"regression"``]): task type.
-            model (nn.Module): model to be converted.
-            weight_subset (str): subset of weights to be considered. Defaults to
-                "last_layer".
-            hessian_struct (str): structure of the Hessian matrix. Defaults to
-                "kron".
-            pred_type (Literal["glm", "nn"]): type of posterior predictive,
-                See the Laplace library for more details. Defaults to "glm".
-            link_approx (Literal["mc", "probit", "bridge", "bridge_norm"]):
-                how to approximate the classification link function for the `'glm'`.
+            task: task type.
+            model: model to be converted.
+            weight_subset: subset of weights to be considered. Defaults to ``"last_layer"``.
+            hessian_struct: structure of the Hessian matrix. Defaults to ``"kron"``.
+            pred_type: type of posterior predictive, see the Laplace library for more details.
+                Defaults to ``"glm"``.
+            link_approx: how to approximate the classification link function for the ``"glm"``.
                 See the Laplace library for more details. Defaults to "probit".
-            optimize_prior_precision (bool): whether to optimize the prior
-                precision. Defaults to True.
+            optimize_prior_precision: whether to optimize the prior precision. Defaults to ``True``.
 
         References:
             [1] `Daxberger et al. Laplace Redux - Effortless Bayesian Deep Learning. In NeurIPS 2021

--- a/src/torch_uncertainty/post_processing/mc_batch_norm.py
+++ b/src/torch_uncertainty/post_processing/mc_batch_norm.py
@@ -25,13 +25,12 @@ class MCBatchNorm(PostProcessing):
         """Monte Carlo Batch Normalization wrapper for 2d inputs.
 
         Args:
-            model (nn.Module): model to be converted.
-            num_estimators (int): number of estimators.
-            convert (bool): whether to convert the model. Defaults to ``True``.
-            mc_batch_size (int): Monte Carlo batch size. The smaller the more variability
-                in the predictions. Defaults to ``32``.
-            device (Literal["cpu", "cuda"] | torch.device | None): device.
-                Defaults to ``None``.
+            model: model to be converted.
+            num_estimators: number of estimators.
+            convert: whether to convert the model. Defaults to ``True``.
+            mc_batch_size: Monte-Carlo batch size. The smaller the more variability in the
+                predictions. Defaults to ``32``.
+            device: device. Defaults to ``None``.
 
         Warning:
             The update of the batch statistics slightly differs from the method as worded in the
@@ -75,7 +74,7 @@ class MCBatchNorm(PostProcessing):
         """Fit the model on the dataset.
 
         Args:
-            dataloader (DataLoader): DataLoader with the post-processing dataset.
+            dataloader: DataLoader with the post-processing dataset.
 
         Warning:
             The ``batch_size`` of the DataLoader (i.e. :attr:`mc_batch_size`) should be carefully
@@ -146,7 +145,7 @@ class MCBatchNorm(PostProcessing):
         """Set the accumulate flag for all MCBatchNorm2d layers.
 
         Args:
-            accumulate (bool): accumulate flag.
+            accumulate: accumulate flag.
         """
         for layer in self.mc_batch_norm_layers:
             layer.accumulate = accumulate
@@ -155,7 +154,7 @@ class MCBatchNorm(PostProcessing):
         """Replace all BatchNorm2d layers with MCBatchNorm2d layers.
 
         Args:
-            model (nn.Module): model to be converted.
+            model: model to be converted.
         """
         for name, module in model.named_children():
             if len(list(module.children())) > 0:
@@ -190,8 +189,8 @@ def init_dataloader(dataloader: DataLoader, batch_size: int):
     It is impossible to change the ``batch_size`` of an already-instantiated dataloader.
 
     Args:
-        dataloader (DataLoader): the dataloader to be reinitialized with
-        batch_size (int): the given batch_size.
+        dataloader: the dataloader to be reinitialized with
+        batch_size: the given batch_size.
     """
     return DataLoader(
         dataloader.dataset,

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -72,48 +72,40 @@ class ClassificationRoutine(LightningModule):
         post_processing: PostProcessing | None = None,
         num_bins_calibration_error: int = 15,
         log_plots: bool = False,
-        save_in_csv: bool = False,
+        save_to_csv: bool = False,
         csv_filename: str = "results.csv",
     ) -> None:
         r"""Routine for training & testing on **classification** tasks.
 
         Args:
-            model (torch.nn.Module): Model to train.
-            num_classes (int): Number of classes.
-            loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
+            model: Model to train.
+            num_classes: Number of classes.
+            loss: Loss function to optimize the :attr:`model`. Defaults to ``None``.
+            is_ensemble: Indicates whether the model is an ensemble at test time or not.
+                Defaults to ``False``.
+            num_tta: Number of test-time augmentations (TTA). If ``1``: no TTA. Defaults to ``1``.
+            format_batch_fn: Function to format the batch. Defaults to ``None``.
+            optim_recipe: The optimizer and optionally the scheduler to use, or a callable that returns them.
                 Defaults to ``None``.
-            is_ensemble (bool): Indicates whether the model is an
-                ensemble at test time or not. Defaults to ``False``.
-            num_tta (int): Number of test-time augmentations (TTA). If ``1``: no TTA.
-                Defaults to ``1``.
-            format_batch_fn (torch.nn.Module): Function to format the batch.
+            mixup_params: Mixup parameters dictionary. Can include mixup type, mixup mode, distance similarity,
+                kernel tau max, kernel tau std, mixup alpha, and cutmix alpha. If None, no mixup augmentations.
                 Defaults to ``None``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
-                optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            mixup_params (dict): Mixup parameters. Can include mixup type,
-                mixup mode, distance similarity, kernel tau max, kernel tau std,
-                mixup alpha, and cutmix alpha. If None, no mixup augmentations.
+            eval_ood: Indicates whether to evaluate the OOD detection performance.
+                Defaults to ``False``.
+            eval_shift: Indicates whether to evaluate the Distribution shift performance.
+                Defaults to ``False``.
+            eval_grouping_loss: Indicates whether to evaluate the grouping loss or not.
+                Defaults to ``False``.
+            ood_criterion: Criterion for the binary OOD detection task. Defaults to ``msp``, the Maximum Softmax
+                Probability score.
+            post_processing: Post-processing method to train on the calibration set. No post-processing if None.
                 Defaults to ``None``.
-            eval_ood (bool): Indicates whether to evaluate the OOD
-                detection performance. Defaults to ``False``.
-            eval_shift (bool): Indicates whether to evaluate the Distribution
-                shift performance. Defaults to ``False``.
-            eval_grouping_loss (bool): Indicates whether to evaluate the
-                grouping loss or not. Defaults to ``False``.
-            ood_criterion (TUOODCriterion | str): Criterion for the binary OOD detection
-                task. Defaults to ``msp``, the Maximum Softmax Probability score.
-            post_processing (PostProcessing): Post-processing method
-                to train on the calibration set. No post-processing if None.
-                Defaults to ``None``.
-            num_bins_calibration_error (int): Number of bins to compute calibration
-                error metrics. Defaults to ``15``.
-            log_plots (bool): Indicates whether to log plots from
-                metrics. Defaults to ``False``.
-            save_in_csv (bool): Save the results in csv. Defaults to
-                ``False``.
-            csv_filename (str): Name of the csv file. Defaults to
-                ``"results.csv"``. Note that this is only used if
-                :attr:`save_in_csv` is ``True``.
+            num_bins_calibration_error: Number of bins to compute calibration error metrics.
+                Defaults to ``15``.
+            log_plots: Indicates whether to log plots from metrics. Defaults to ``False``.
+            save_to_csv: Save the results in csv. Defaults to ``False``.
+            csv_filename: Name of the csv file. Defaults to ``"results.csv"``.
+                Note that this is only used if ``save_to_csv`` is ``True``.
 
         Warning:
             You must define :attr:`optim_recipe` if you do not use the Lightning CLI.
@@ -161,7 +153,7 @@ class ClassificationRoutine(LightningModule):
         self.num_tta = num_tta
         self.ood_criterion = get_ood_criterion(ood_criterion)
         self.log_plots = log_plots
-        self.save_in_csv = save_in_csv
+        self.save_to_csv = save_to_csv
         self.csv_filename = csv_filename
         self.binary_cls = num_classes == 1
         self.needs_epoch_update = isinstance(model, EPOCH_UPDATE_MODEL)
@@ -294,8 +286,7 @@ class ClassificationRoutine(LightningModule):
         """Setup the optional mixup augmentation based on the :attr:`mixup_params` dict.
 
         Args:
-            mixup_params (dict | None): the detailed parameters of the mixup augmentation. None if
-                unused.
+            mixup_params: the detailed parameters of the mixup augmentation. ``None`` if unused.
         """
         if mixup_params is None:
             mixup_params = {}
@@ -308,7 +299,7 @@ class ClassificationRoutine(LightningModule):
         """Apply the mixup augmentation on a :attr:`batch` of images.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the images and the corresponding targets.
+            batch: the images and the corresponding targets.
 
         Returns:
             tuple[Tensor, Tensor]: the images and the corresponding targets transformed with mixup.
@@ -371,9 +362,8 @@ class ClassificationRoutine(LightningModule):
         """Forward pass of the inner model.
 
         Args:
-            inputs (Tensor): input tensor.
-            save_feats (bool): whether to store the features or
-                not. Defaults to ``False``.
+            inputs: input tensor.
+            save_feats: whether to store the features or not. Defaults to ``False``.
 
         Note:
             The features are stored in the :attr:`self.features` attribute.
@@ -393,7 +383,7 @@ class ClassificationRoutine(LightningModule):
         """Perform a single training step based on the input tensors.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the training data and their corresponding targets.
+            batch: the training data and their corresponding targets.
 
         Returns:
             Tensor: the loss corresponding to this training step.
@@ -430,7 +420,7 @@ class ClassificationRoutine(LightningModule):
         Compute the prediction of the model and the value of the metrics on the validation batch.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the validation data and their corresponding targets
+            batch: the validation data and their corresponding targets
         """
         inputs, targets = batch
         # remove duplicates when doing TTA
@@ -461,9 +451,9 @@ class ClassificationRoutine(LightningModule):
         handle OOD and distribution-shifted images.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the test data and their corresponding targets.
-            batch_idx (int): the number of the current batch (unused).
-            dataloader_idx (int): 0 if in-distribution, 1 if out-of-distribution and 2 if
+            batch: the test data and their corresponding targets.
+            batch_idx: the number of the current batch (unused).
+            dataloader_idx: 0 if in-distribution, 1 if out-of-distribution and 2 if
                 distribution-shifted.
         """
         inputs, targets = batch
@@ -609,7 +599,7 @@ class ClassificationRoutine(LightningModule):
             if self.is_ensemble:
                 self.test_shift_ens_metrics.reset()
 
-        if self.save_in_csv and self.logger is not None:
+        if self.save_to_csv and self.logger is not None:
             csv_writer(
                 Path(self.logger.log_dir) / self.csv_filename,
                 result_dict,
@@ -662,15 +652,15 @@ def _classification_routine_checks(
     """Check the domains of the arguments of the classification routine.
 
     Args:
-        model (nn.Module): the model used to make classification predictions.
-        num_classes (int): the number of classes in the dataset.
-        is_ensemble (bool): whether the model is an ensemble or a single model.
-        ood_criterion (TUOODCriterion): OOD criterion for the binary OOD detection task.
-        eval_grouping_loss (bool): whether to evaluate the grouping loss.
-        num_bins_calibration_error (int): the number of bins for the evaluation of the calibration.
-        mixup_params (dict | None): the dictionary to setup the mixup augmentation.
-        post_processing (PostProcessing | None): the post-processing module.
-        format_batch_fn (nn.Module | None): the function for formatting the batch for ensembles.
+        model: the model used to make classification predictions.
+        num_classes: the number of classes in the dataset.
+        is_ensemble: whether the model is an ensemble or a single model.
+        ood_criterion: OOD criterion for the binary OOD detection task.
+        eval_grouping_loss: whether to evaluate the grouping loss.
+        num_bins_calibration_error: the number of bins for the evaluation of the calibration.
+        mixup_params: the dictionary to setup the mixup augmentation.
+        post_processing: the post-processing module.
+        format_batch_fn: the function for formatting the batch for ensembles.
     """
     ood_criterion = get_ood_criterion(ood_criterion)
     if not is_ensemble and ood_criterion.ensemble_only:

--- a/src/torch_uncertainty/routines/pixel_regression.py
+++ b/src/torch_uncertainty/routines/pixel_regression.py
@@ -66,37 +66,31 @@ class PixelRegressionRoutine(LightningModule):
         eval_shift: bool = False,
         num_image_plot: int = 4,
         log_plots: bool = False,
-        save_in_csv: bool = False,
+        save_to_csv: bool = False,
         csv_filename: str = "results.csv",
     ) -> None:
         r"""Routine for training & testing on **pixel regression** tasks.
 
         Args:
-            model (nn.Module): Model to train.
-            output_dim (int): Number of outputs of the model.
-            loss (nn.Module): Loss function to optimize the :attr:`model`.
+            model: Model to train.
+            output_dim: Number of outputs of the model.
+            loss: Loss function to optimize the :attr:`model`.
                 Defaults to ``None``.
-            dist_family (str): The distribution family to use for
-                probabilistic pixel regression. If ``None`` then point-wise regression.
+            dist_family: The distribution family to use for probabilistic pixel regression.
+                If ``None`` then point-wise regression. Defaults to ``None``.
+            dist_estimate: The estimate to use when computing the point-wise metrics.
+                Defaults to ``"mean"``.
+            is_ensemble: Whether the model is an ensemble. Defaults to ``False``.
+            optim_recipe: The optimizer and optionally the scheduler to use, or a callable that returns them.
                 Defaults to ``None``.
-            dist_estimate (str): The estimate to use when computing the
-                point-wise metrics. Defaults to ``"mean"``.
-            is_ensemble (bool): Whether the model is an ensemble.
+            eval_shift: Indicates whether to evaluate the Distribution shift performance.
                 Defaults to ``False``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
-                optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool): Indicates whether to evaluate the Distribution
-                shift performance. Defaults to ``False``.
-            format_batch_fn (nn.Module): The function to format the
-                batch. Defaults to ``None``.
-            num_image_plot (int): Number of images to plot. Defaults to ``4``.
-            log_plots (bool): Indicates whether to log plots from
-                metrics. Defaults to ``False``.
-            save_in_csv (bool): Save the results in csv. Defaults to
-                ``False``.
-            csv_filename (str): Name of the csv file. Defaults to
-                ``"results.csv"``. Note that this is only used if
-                :attr:`save_in_csv` is ``True``.
+            format_batch_fn: The function to format the batch. Defaults to ``None``.
+            num_image_plot: Number of images to plot. Defaults to ``4``.
+            log_plots: Indicates whether to log plots from metrics. Defaults to ``False``.
+            save_to_csv: Save the results in csv. Defaults to ``False``.
+            csv_filename: Name of the csv file. Defaults to ``"results.csv"``.
+                Note that this is only used if :attr:`save_to_csv` is ``True``.
         """
         super().__init__()
         _depth_routine_checks(output_dim, num_image_plot, log_plots)
@@ -112,7 +106,7 @@ class PixelRegressionRoutine(LightningModule):
         self.dist_estimate = dist_estimate
         self.probabilistic = dist_family is not None
         self.loss = loss
-        self.save_in_csv = save_in_csv
+        self.save_to_csv = save_to_csv
         self.csv_filename = csv_filename
         self.num_image_plot = num_image_plot
         self.is_ensemble = is_ensemble
@@ -197,7 +191,7 @@ class PixelRegressionRoutine(LightningModule):
         is one-dimensional and if the routine contains a single model.
 
         Args:
-            inputs (Tensor): The input tensor.
+            inputs: The input tensor.
 
         Returns:
             Tensor: The output tensor.
@@ -215,7 +209,7 @@ class PixelRegressionRoutine(LightningModule):
         """Perform a single training step based on the input tensors.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the training data and their corresponding targets
+            batch: the training data and their corresponding targets
 
         Returns:
             Tensor: the loss corresponding to this training step.
@@ -254,7 +248,7 @@ class PixelRegressionRoutine(LightningModule):
         """Get the prediction and handle predicted eventual distribution parameters.
 
         Args:
-            inputs (Tensor): the input data.
+            inputs: the input data.
 
         Returns:
             tuple[Tensor, Distribution | None]: the prediction as a Tensor and a distribution.
@@ -283,8 +277,8 @@ class PixelRegressionRoutine(LightningModule):
         Compute the prediction of the model and the value of the metrics on the validation batch.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the validation images and their corresponding targets.
-            batch_idx (int): the id of the batch. Optionally plot images and the predictions with
+            batch: the validation images and their corresponding targets.
+            batch_idx : the id of the batch. Optionally plot images and the predictions with
                 the first batch.
         """
         inputs, targets = batch
@@ -318,9 +312,9 @@ class PixelRegressionRoutine(LightningModule):
         handle OOD and distribution-shifted images.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the test data and their corresponding targets.
-            batch_idx (int): the number of the current batch (unused).
-            dataloader_idx (int): 0 if in-distribution, 1 if out-of-distribution.
+            batch: the test data and their corresponding targets.
+            batch_idx : the number of the current batch (unused).
+            dataloader_idx : 0 if in-distribution, 1 if out-of-distribution.
         """
         if dataloader_idx != 0:
             raise NotImplementedError(
@@ -387,7 +381,7 @@ class PixelRegressionRoutine(LightningModule):
         if self.probabilistic:
             self.test_prob_metrics.reset()
 
-        if self.save_in_csv and self.logger is not None:
+        if self.save_to_csv and self.logger is not None:
             csv_writer(
                 Path(self.logger.log_dir) / self.csv_filename,
                 result_dict,
@@ -428,10 +422,10 @@ def colorize(
     """Colorize a tensor of depth values.
 
     Args:
-        value (Tensor): The tensor of depth values.
-        vmin (float): The minimum depth value. Defaults to None.
-        vmax (float): The maximum depth value. Defaults to None.
-        cmap (str): The colormap to use. Defaults to 'magma'.
+        value: The tensor of depth values.
+        vmin: The minimum depth value. Defaults to ``None``.
+        vmax: The maximum depth value. Defaults to ``None``.
+        cmap: The colormap to use. Defaults to ``'magma'``.
     """
     vmin = value.min().item() if vmin is None else vmin
     vmax = value.max().item() if vmax is None else vmax
@@ -448,9 +442,9 @@ def _depth_routine_checks(output_dim: int, num_image_plot: int, log_plots: bool)
     """Check the domains of the routine's parameters.
 
     Args:
-        output_dim (int): the dimension of the output of the regression task.
-        num_image_plot (int): the number of images to plot at evaluation time.
-        log_plots (bool): whether to plot images and predictions during evaluation.
+        output_dim : the dimension of the output of the regression task.
+        num_image_plot : the number of images to plot at evaluation time.
+        log_plots: whether to plot images and predictions during evaluation.
     """
     if output_dim < 1:
         raise ValueError(f"output_dim must be positive, got {output_dim}.")

--- a/src/torch_uncertainty/routines/regression.py
+++ b/src/torch_uncertainty/routines/regression.py
@@ -51,29 +51,25 @@ class RegressionRoutine(LightningModule):
         format_batch_fn: nn.Module | None = None,
         log_plots: bool = False,
         num_bins_calibration_error: int = 15,
-        save_in_csv: bool = False,
+        save_to_csv: bool = False,
         csv_filename: str = "results.csv",
     ) -> None:
         r"""Routine for training & testing on **regression** tasks.
 
         Args:
-            model (torch.nn.Module): Model to train.
-            output_dim (int): Number of outputs of the model.
-            loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
-                Defaults to ``None``.
-            dist_family (str): The distribution family to use for probabilistic regression. If ``None`` then point-wise regression. Defaults to ``None``.
-            dist_estimate (str | DistEstimate): The estimate to use when computing the point-wise metrics. Defaults to ``"mean"``.
-            is_ensemble (bool): Whether the model is an ensemble. Defaults to ``False``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool): Indicates whether to evaluate the Distribution shift performance. Defaults to ``False``.
-            format_batch_fn (torch.nn.Module): The function to format the batch. Defaults to ``None``.
-            log_plots (bool): Indicates whether to log figures in the logger.
-                Defaults to ``False``.
-            num_bins_calibration_error (int): Number of bins to compute calibration
-                error metrics. Defaults to ``15``.
-            save_in_csv (bool): Save the results in csv. Defaults to ``False``.
-            csv_filename (str): Name of the csv file. Defaults to ``"results.csv"``. Note that this is only used if
-                :attr:`save_in_csv` is ``True``.
+            model: Model to train.
+            output_dim: Number of outputs of the model.
+            loss: Loss function to optimize the :attr:`model`. Defaults to ``None``.
+            dist_family: Distribution family to use for probabilistic regression. If ``None``, performs point-wise regression. Defaults to ``None``.
+            dist_estimate: The estimate to use when computing point-wise metrics. Defaults to ``mean``.
+            is_ensemble: Whether the model is an ensemble. Defaults to ``False``.
+            optim_recipe: The optimizer and optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
+            eval_shift: Whether to evaluate distribution-shift performance. Defaults to ``False``.
+            format_batch_fn: Function to format a batch. Defaults to ``None``.
+            log_plots: Whether to log figures in the logger. Defaults to ``False``.
+            num_bins_calibration_error: Number of bins used for calibration error metrics. Defaults to ``15``.
+            save_to_csv: Save the results in CSV. Defaults to ``False``.
+            csv_filename: Name of the CSV file. Defaults to ``results.csv``. Used only when ``save_to_csv`` is ``True``.
 
         Warning:
             If :attr:`probabilistic` is True, the model must output a `PyTorch
@@ -103,7 +99,7 @@ class RegressionRoutine(LightningModule):
         self.loss = loss
         self.is_ensemble = is_ensemble
         self.log_plots = log_plots
-        self.save_in_csv = save_in_csv
+        self.save_to_csv = save_to_csv
         self.csv_filename = csv_filename
         self.needs_epoch_update = isinstance(model, EPOCH_UPDATE_MODEL)
         self.needs_step_update = isinstance(model, STEP_UPDATE_MODEL)
@@ -188,7 +184,7 @@ class RegressionRoutine(LightningModule):
         is one-dimensional and if the routine contains a single model.
 
         Args:
-            inputs (Tensor): The input tensor.
+            inputs: The input tensor.
 
         Returns:
             Tensor | dict[str, Tensor]: The output tensor or the parameters of the output
@@ -217,7 +213,7 @@ class RegressionRoutine(LightningModule):
         """Perform a single training step based on the input tensors.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the training data and their corresponding targets
+            batch: Tuple of training inputs and targets.
 
         Returns:
             Tensor: the loss corresponding to this training step.
@@ -255,7 +251,7 @@ class RegressionRoutine(LightningModule):
         """Get the prediction and handle predicted eventual distribution parameters.
 
         Args:
-            inputs (Tensor): the input data.
+            inputs: The input data.
 
         Returns:
             tuple[Tensor, Distribution | None]: the prediction as a Tensor and a distribution.
@@ -280,7 +276,7 @@ class RegressionRoutine(LightningModule):
         Compute the prediction of the model and the value of the metrics on the validation batch.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the validation data and their corresponding targets.
+            batch: Tuple of validation inputs and targets.
         """
         inputs, targets = batch
         if self.one_dim_regression:
@@ -303,9 +299,9 @@ class RegressionRoutine(LightningModule):
         handle OOD and distribution-shifted images.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the test data and their corresponding targets.
-            batch_idx (int): the number of the current batch (unused).
-            dataloader_idx (int): 0 if in-distribution, 1 if out-of-distribution.
+            batch: Tuple of test inputs and targets.
+            batch_idx: Index of the batch in the dataloader (unused here).
+            dataloader_idx: 0 for in-distribution, 1 for out-of-distribution.
         """
         if dataloader_idx != 0:
             raise NotImplementedError(
@@ -384,7 +380,7 @@ class RegressionRoutine(LightningModule):
         if self.probabilistic:
             self.test_prob_metrics.reset()
 
-        if self.save_in_csv and self.logger is not None:
+        if self.save_to_csv and self.logger is not None:
             csv_writer(
                 Path(self.logger.log_dir) / self.csv_filename,
                 result_dict,
@@ -395,7 +391,7 @@ def _regression_routine_checks(output_dim: int) -> None:
     """Check the domains of the routine's parameters.
 
     Args:
-        output_dim (int): the dimension of the output of the regression task.
+        output_dim : the dimension of the output of the regression task.
     """
     if output_dim < 1:
         raise ValueError(f"output_dim must be positive, got {output_dim}.")

--- a/src/torch_uncertainty/routines/regression.py
+++ b/src/torch_uncertainty/routines/regression.py
@@ -391,7 +391,7 @@ def _regression_routine_checks(output_dim: int) -> None:
     """Check the domains of the routine's parameters.
 
     Args:
-        output_dim : the dimension of the output of the regression task.
+        output_dim: the dimension of the output of the regression task.
     """
     if output_dim < 1:
         raise ValueError(f"output_dim must be positive, got {output_dim}.")

--- a/src/torch_uncertainty/routines/segmentation.py
+++ b/src/torch_uncertainty/routines/segmentation.py
@@ -64,42 +64,34 @@ class SegmentationRoutine(LightningModule):
         log_plots: bool = False,
         num_samples_to_plot: int = 3,
         num_bins_calibration_error: int = 15,
-        save_in_csv: bool = False,
+        save_to_csv: bool = False,
         csv_filename: str = "results.csv",
     ) -> None:
         r"""Routine for training & testing on **segmentation** tasks.
 
         Args:
-            model (torch.nn.Module): Model to train.
-            num_classes (int): Number of classes in the segmentation task.
-            loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
+            model: Model to train.
+            num_classes: Number of classes in the segmentation task.
+            loss: Loss function to optimize the :attr:`model`. Defaults to ``None``.
+            optim_recipe: The optimizer and optionally the scheduler to use, or a callable that returns them.
                 Defaults to ``None``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
-                optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool): Indicates whether to evaluate the Distribution
-                shift performance. Defaults to ``False``.
-            format_batch_fn (torch.nn.Module): The function to format the
-                batch. Defaults to ``None``.
-            metric_subsampling_rate (float): The rate of subsampling for the
-                memory consuming metrics. Defaults to ``1e-2``.
-            eval_ood (bool): Indicates whether to evaluate the OOD
-                performance. Defaults to ``False``.
-            ood_criterion (TUOODCriterion): Criterion for the binary OOD detection task.
-                Defaults to ``"msp"`` which amounts to the maximum softmax probability score (MSP).
-            post_processing (PostProcessing): The post-processing
-                technique to use. Defaults to ``None``. Warning: There is no
-                post-processing technique implemented yet for segmentation tasks.
-            log_plots (bool): Indicates whether to log figures in the logger.
+            eval_shift: Indicates whether to evaluate the Distribution shift performance.
                 Defaults to ``False``.
-            num_samples_to_plot (int): Number of segmentation prediction and
-                target to plot in the logger. Note that this is only used if
-                :attr:`log_plots` is set to ``True``. Defaults to ``3``.
-            num_bins_calibration_error (int): Number of bins to compute calibration
-                error metrics. Defaults to ``15``.
-            save_in_csv (bool): Save the results in csv. Defaults to
-                ``False``.
-            csv_filename (str): The name of the csv file to save the results in.
-                Defaults to ``"results.csv"``.
+            format_batch_fn: The function to format the batch. Defaults to ``None``.
+            metric_subsampling_rate: The rate of subsampling for the memory consuming metrics.
+                Defaults to ``1e-2``.
+            eval_ood: Indicates whether to evaluate the OOD performance. Defaults to ``False``.
+            ood_criterion: Criterion for the binary OOD detection task. Defaults to ``"msp"`` which amounts to the
+                maximum softmax probability score (MSP).
+            post_processing: The post-processing technique to use. Defaults to ``None``. Warning: There is no
+                post-processing technique implemented yet for segmentation tasks.
+            log_plots: Indicates whether to log figures in the logger. Defaults to ``False``.
+            num_samples_to_plot: Number of segmentation prediction and target to plot in the logger. Note that this
+                is only used if :attr:`log_plots` is set to ``True``. Defaults to ``3``.
+            num_bins_calibration_error: Number of bins to compute calibration error metrics.
+                Defaults to ``15``.
+            save_to_csv: Save the results in csv. Defaults to ``False``.
+            csv_filename: The name of the csv file to save the results in. Defaults to ``"results.csv"``.
 
         Warning:
             You must define :attr:`optim_recipe` if you do not use the CLI.
@@ -134,7 +126,7 @@ class SegmentationRoutine(LightningModule):
         self.format_batch_fn = format_batch_fn
         self.metric_subsampling_rate = metric_subsampling_rate
         self.log_plots = log_plots
-        self.save_in_csv = save_in_csv
+        self.save_to_csv = save_to_csv
         self.csv_filename = csv_filename
         self.ood_criterion = get_ood_criterion(ood_criterion)
         self.eval_ood = eval_ood
@@ -218,7 +210,7 @@ class SegmentationRoutine(LightningModule):
         """Forward pass of the model.
 
         Args:
-            inputs (Tensor): input tensor.
+            inputs: input tensor.
 
         Returns:
             Tensor: the prediction of the model.
@@ -258,7 +250,7 @@ class SegmentationRoutine(LightningModule):
         """Perform a single training step based on the input tensors.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the training images and their corresponding targets
+            batch: the training images and their corresponding targets
 
         Returns:
             Tensor: the loss corresponding to this training step.
@@ -286,7 +278,7 @@ class SegmentationRoutine(LightningModule):
         Compute the prediction of the model and the value of the metrics on the validation batch.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the validation images and their corresponding targets
+            batch: the validation images and their corresponding targets
         """
         img, targets = batch
         logits = self.forward(img)
@@ -315,9 +307,9 @@ class SegmentationRoutine(LightningModule):
         Compute the prediction of the model and the value of the metrics on the test batch.
 
         Args:
-            batch (tuple[Tensor, Tensor]): the test images and their corresponding targets
-            batch_idx (int): the index of the batch in the test dataloader.
-            dataloader_idx (int): the index of the dataloader. Defaults to ``0``.
+            batch: the test images and their corresponding targets
+            batch_idx : the index of the batch in the test dataloader.
+            dataloader_idx : the index of the dataloader. Defaults to ``0``.
         """
         img, targets = batch
 
@@ -414,7 +406,7 @@ class SegmentationRoutine(LightningModule):
         if self.eval_ood:
             self.test_ood_metrics.reset()
 
-        if self.save_in_csv and self.logger is not None:
+        if self.save_to_csv and self.logger is not None:
             csv_writer(
                 Path(self.logger.log_dir) / self.csv_filename,
                 result_dict,
@@ -466,8 +458,8 @@ class SegmentationRoutine(LightningModule):
         """Select a random sample of the data to compute the loss onto.
 
         Args:
-            pred (Tensor): the prediction tensor.
-            target (Tensor): the target tensor.
+            pred: the prediction tensor.
+            target: the target tensor.
 
         Returns:
             Tuple[Tensor, Tensor]: the subsampled prediction and target tensors.
@@ -486,9 +478,9 @@ def _segmentation_routine_checks(
     """Check the domains of the routine's parameters.
 
     Args:
-        num_classes (int): the number of classes in the dataset.
-        metric_subsampling_rate (float): the rate of subsampling to compute the metrics.
-        num_bins_calibration_error (int): the number of bins for the evaluation of the calibration.
+        num_classes : the number of classes in the dataset.
+        metric_subsampling_rate: the rate of subsampling to compute the metrics.
+        num_bins_calibration_error : the number of bins for the evaluation of the calibration.
     """
     if num_classes < 2:
         raise ValueError(f"num_classes must be at least 2, got {num_classes}.")

--- a/src/torch_uncertainty/transforms/corruption.py
+++ b/src/torch_uncertainty/transforms/corruption.py
@@ -116,7 +116,7 @@ class GaussianNoise(TUCorruption):
         """Apply a Gaussian noise corruption to tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         self.scale = [0.08, 0.12, 0.18, 0.26, 0.38][severity - 1]
@@ -125,7 +125,7 @@ class GaussianNoise(TUCorruption):
         """Apply Gaussian noise on an input image.
 
         Args:
-            img (Tensor): A potentially batched image of shape (C, H, W) or (B, C, H, W)
+            img: A potentially batched image of shape (C, H, W) or (B, C, H, W)
         """
         if self.severity == 0:
             return img
@@ -139,7 +139,7 @@ class ShotNoise(TUCorruption):
         """Apply a shot (Poisson) noise corruption to tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         self.scale = [60, 25, 12, 5, 3][severity - 1]
@@ -148,7 +148,7 @@ class ShotNoise(TUCorruption):
         """Apply Poisson noise on an input image.
 
         Args:
-            img (Tensor): A potentially batched image of shape (C, H, W) or (B, C, H, W)
+            img: A potentially batched image of shape (C, H, W) or (B, C, H, W)
         """
         if self.severity == 0:
             return img
@@ -163,8 +163,8 @@ class ImpulseNoise(TUCorruption):
         tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            black_white (bool): If black and white, set all pixel channel values to 0 or 1.
+            severity: Severity level of the corruption.
+            black_white: If black and white, set all pixel channel values to 0 or 1.
                 Defaults to ``False`` (as in the original paper).
         """
         super().__init__(severity)
@@ -228,7 +228,7 @@ class DefocusBlur(TUCorruption):
         """Apply a defocus blur corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         if not kornia_installed:
@@ -303,8 +303,8 @@ class GlassBlur(TUCorruption):
         Faster implementation using a symetrized offset distribution.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
 
         Note:
             The hyperparameters have been adapted to output images qualitatively calibrated with
@@ -376,8 +376,8 @@ class OriginalGlassBlur(TUCorruption):
         Original, likely incorrect and very slow implementation.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
         """
         super().__init__(severity)
         if not kornia_installed:
@@ -435,8 +435,8 @@ class MotionBlur(TUCorruption):
         """Apply a motion blur corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
 
         Note:
             Originally, Hendrycks et al. used Gaussian motion blur. To remove the dependency with
@@ -493,7 +493,7 @@ class ZoomBlur(TUCorruption):
         """Apply a zoom blur corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         self.zooms = [
@@ -526,8 +526,8 @@ class Snow(TUCorruption):
         """Apply a snow effect on unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
 
         Note:
             The transformation has been slightly modified, see MotionBlur for details.
@@ -578,8 +578,8 @@ class Frost(TUCorruption):
         """Apply a frost corruption effect on unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
         """
         super().__init__(severity)
         self.rng = np.random.default_rng(seed)
@@ -650,8 +650,8 @@ class Fog(TUCorruption):
         """Apply a fog corruption effect on unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
         """
         super().__init__(severity)
         self.mix = [(1.5, 2), (2, 2), (2.5, 1.7), (2.5, 1.5), (3, 1.4)][severity - 1]
@@ -682,7 +682,7 @@ class Brightness(IBrightness, TUCorruption):
         """Apply a brightness corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
 
         Note:
             The values have been changed to better reflect the magnitude of the original
@@ -704,7 +704,7 @@ class Contrast(IContrast, TUCorruption):
         """Apply a contrast corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         TUCorruption.__init__(self, severity)
         self.level = [0.4, 0.3, 0.2, 0.1, 0.05][severity - 1]
@@ -720,7 +720,7 @@ class Pixelate(TUCorruption):
         """Apply a pixelation corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         self.quality = [0.6, 0.5, 0.4, 0.3, 0.25][severity - 1]
@@ -744,7 +744,7 @@ class JPEGCompression(TUCorruption):
         """Apply a JPEG compression corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         self.quality = [25, 18, 15, 10, 7][severity - 1]
@@ -762,8 +762,8 @@ class Elastic(TUCorruption):
         """Apply an elastic corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
 
         Note:
             mix[0][1] has been changed to 0.5 to avoid errors when dealing with small images.
@@ -872,8 +872,8 @@ class SpeckleNoise(TUCorruption):
         """Apply speckle noise to tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
-            seed (int | None): Optional seed for the rng.
+            severity: Severity level of the corruption.
+            seed: Optional seed for the rng.
         """
         super().__init__(severity)
         self.scale = [0.15, 0.2, 0.35, 0.45, 0.6][severity - 1]
@@ -883,7 +883,7 @@ class SpeckleNoise(TUCorruption):
         """Apply speckle noise on images.
 
         Args:
-            img (Tensor): A potentially batched image of shape (C, H, W) or (B, C, H, W).
+            img: A potentially batched image of shape (C, H, W) or (B, C, H, W).
         """
         if self.severity == 0:
             return img
@@ -901,7 +901,7 @@ class GaussianBlur(TUCorruption):
         """Apply a Gaussian blur corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         super().__init__(severity)
         if not kornia_installed:
@@ -937,7 +937,7 @@ class Saturation(ISaturation, TUCorruption):
         """Apply a saturation corruption to unbatched tensor images.
 
         Args:
-            severity (int): Severity level of the corruption.
+            severity: Severity level of the corruption.
         """
         TUCorruption.__init__(self, severity)
         self.severity = severity

--- a/src/torch_uncertainty/transforms/cutout.py
+++ b/src/torch_uncertainty/transforms/cutout.py
@@ -7,8 +7,8 @@ class Cutout(nn.Module):
         """Cutout augmentation class.
 
         Args:
-            length (int): Length of the cutout square.
-            value (int): Pixel value to be filled in the cutout square.
+            length: Length of the cutout square.
+            value: Pixel value to be filled in the cutout square.
         """
         super().__init__()
 

--- a/src/torch_uncertainty/transforms/image.py
+++ b/src/torch_uncertainty/transforms/image.py
@@ -266,14 +266,14 @@ class RandomRescale(Transform):
         the image can have ``[..., C, H, W]`` shape. A bounding box can have ``[..., 4]`` shape.
 
         Args:
-            min_scale (int): Minimum scale for random sampling
-            max_scale (int): Maximum scale for random sampling
+            min_scale: Minimum scale for random sampling
+            max_scale: Maximum scale for random sampling
             interpolation (InterpolationMode): Desired interpolation enum defined by
                 :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.
                 If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.NEAREST_EXACT``,
                 ``InterpolationMode.BILINEAR`` and ``InterpolationMode.BICUBIC`` are supported.
                 The corresponding Pillow integer constants, e.g. ``PIL.Image.BILINEAR`` are accepted as well.
-            antialias (bool): Whether to apply antialiasing.
+            antialias: Whether to apply antialiasing.
                 It only affects **tensors** with bilinear or bicubic modes and it is
                 ignored otherwise: on PIL images, antialiasing is always applied on
                 bilinear or bicubic modes; on other modes (for PIL images and

--- a/src/torch_uncertainty/transforms/mixup.py
+++ b/src/torch_uncertainty/transforms/mixup.py
@@ -109,11 +109,11 @@ class AbstractMixup(nn.Module, ABC):
         """Abstract Mixup class.
 
         Args:
-            alpha (float): Mixup alpha.
-            num_classes (int): Number of classes.
-            isobatch (bool): Whether to use a single coefficient for the whole batch
+            alpha: Mixup alpha.
+            num_classes: Number of classes.
+            isobatch: Whether to use a single coefficient for the whole batch
                 instead of for each pair. Defaults to ``False``.
-            **kwargs (Any): Keyword arguments for compatibility.
+            **kwargs: Keyword arguments for compatibility.
         """
         super().__init__()
         self.alpha = alpha
@@ -163,10 +163,10 @@ class AbstractMixup(nn.Module, ABC):
         """Apply mixup on a batch of inputs and targets.
 
         Args:
-            x (Tensor): input or input batch.
-            y (Tensor): target or target batch.
-            feats (Tensor | None): features for warping mixup.
-            warp_param (float | None): warping parameter.
+            x: input or input batch.
+            y: target or target batch.
+            feats: features for warping mixup.
+            warp_param: warping parameter.
 
         Returns:
             tuple[Tensor, Tensor]: mixed-up inputs and targets.
@@ -209,13 +209,13 @@ class MixupMP(AbstractMixup):
         inputs and targets, all concatenated.
 
         Args:
-            alpha (float): Mixup alpha.
-            num_classes (int): Number of classes.
-            mixup_ratio (float): Ratio of the number of mixup-ed pairs and normal pairs. Defaults
+            alpha: Mixup alpha.
+            num_classes: Number of classes.
+            mixup_ratio: Ratio of the number of mixup-ed pairs and normal pairs. Defaults
                 to ``1``. This parameter is named "r" in the paper.
-            isobatch (bool): Whether to use a single coefficient for the whole batch
+            isobatch: Whether to use a single coefficient for the whole batch
                 instead of for each pair. Defaults to ``False``.
-            **kwargs (Any): Keyword arguments for compatibility.
+            **kwargs: Keyword arguments for compatibility.
 
         Warning:
             When training MixupMP models with r != 1, you should use the MixupMPLoss

--- a/src/torch_uncertainty/transforms/pixmix.py
+++ b/src/torch_uncertainty/transforms/pixmix.py
@@ -49,13 +49,12 @@ class PixMix(nn.Module):
         """PixMix augmentation class.
 
         Args:
-            mixing_set (MixingSet): Dataset to be mixed with.
-            mixing_iterations (int): Number of mixing iterations.
-            augmentation_severity (float): Severity of augmentation.
-            mixing_severity (float): Severity of mixing.
-            all_ops (bool): Whether to use augmentations included in ImageNet-C.
-                Defaults to True.
-            seed (int): Seed for random number generator. Defaults to 12345.
+            mixing_set: Dataset to be mixed with.
+            mixing_iterations: Number of mixing iterations.
+            augmentation_severity: Severity of augmentation.
+            mixing_severity: Severity of mixing.
+            all_ops: Whether to use augmentations included in ImageNet-C. Defaults to ``True``.
+            seed: Seed for random number generator. Defaults to ``12345``.
 
         Note:
             Default arguments are set to follow original guidelines.

--- a/src/torch_uncertainty/utils/checkpoints.py
+++ b/src/torch_uncertainty/utils/checkpoints.py
@@ -5,11 +5,9 @@ def get_version(root: str | Path, version: int, checkpoint: int | None = None) -
     """Find the path to the checkpoint corresponding to the version.
 
     Args:
-        root (Union[str, Path]): The root of the dataset containing the
-            checkpoints.
-        version (int): The version of the checkpoint.
-        checkpoint (int): The number of the checkpoint. Defaults
-            to None.
+        root: The root of the dataset containing the checkpoints.
+        version: The version of the checkpoint.
+        checkpoint: The number of the checkpoint. Defaults to ``None``.
 
     Raises:
         FileNotFoundError: if the checkpoint cannot be found.

--- a/src/torch_uncertainty/utils/cli.py
+++ b/src/torch_uncertainty/utils/cli.py
@@ -81,51 +81,40 @@ class TULightningCLI(LightningCLI):
         """Custom LightningCLI for torch-uncertainty.
 
         Args:
-            model_class (type[LightningModule] | Callable[..., LightningModule] | None):
-                An optional `LightningModule` class to train or a callable which returns a
+            model_class: An optional `LightningModule` class to train or a callable which returns a
                 ``LightningModule`` instance when called. If ``None``, you can pass a registered model
                 with ``--model=MyModel``. Defaults to ``None``.
-            datamodule_class (type[LightningDataModule] | Callable[..., LightningDataModule] | None):
-                An optional ``LightningDataModule`` class or a callable which returns a ``LightningDataModule``
+            datamodule_class: An optional ``LightningDataModule`` class or a callable which returns a ``LightningDataModule``
                 instance when called. If ``None``, you can pass a registered datamodule with ``--data=MyDataModule``.
                 Defaults to ``None``.
-            save_config_callback (type[SaveConfigCallback] | None): A callback class to
-                save the config. Defaults to ``TUSaveConfigCallback``.
-            save_config_kwargs (dict[str, Any] | None): Parameters that will be used to
-                instantiate the save_config_callback. Defaults to ``None``.
-            trainer_class (type[Trainer] | Callable[..., Trainer]): An optional subclass
-                of the Trainer class or a callable which returns a ``Trainer`` instance when called.
+            save_config_callback: A callback class to save the config. Defaults to ``TUSaveConfigCallback``.
+            save_config_kwargs: Parameters that will be used to instantiate the save_config_callback. Defaults to ``None``.
+            trainer_class: An optional subclass of the Trainer class or a callable which returns a ``Trainer`` instance when called.
                 Defaults to ``TUTrainer``.
-            trainer_defaults (dict[str, Any] | None): Set to override Trainer defaults
-                or add persistent callbacks. The callbacks added through this argument will not
+            trainer_defaults: Set to override Trainer defaults or add persistent callbacks. The callbacks added through this argument will not
                 be configurable from a configuration file and will always be present for this
                 particular CLI. Alternatively, configurable callbacks can be added as explained
                 in the CLI docs. Defaults to ``None``.
-            seed_everything_default (bool | int): Number for the ``seed_everything()``
-                seed value. Set to ``True`` to automatically choose a seed value. Setting it to ``False``
+            seed_everything_default: Number for the ``seed_everything()`` seed value. Set to ``True`` to automatically choose a seed value. Setting it to ``False``
                 will avoid calling seed_everything. Defaults to ``True``.
-            parser_kwargs (dict[str, Any] | dict[str, dict[str, Any]] | None): Additional
-                arguments to instantiate each ``LightningArgumentParser``. Defaults to
-                ``LightningArgumentParser``. Defaults to ``None``.
-            subclass_mode_model (bool): Whether model can be any subclass of the given
-                class. Defaults to ``False``.
-            subclass_mode_data (bool): Whether datamodule can be any subclass of the
+            parser_kwargs: Additional arguments to instantiate each ``LightningArgumentParser``. Defaults to ``None``.
+            subclass_mode_model: Whether model can be any subclass of the given class. Defaults to ``False``.
+            subclass_mode_data: Whether datamodule can be any subclass of the
                 given class. Defaults to ``False``.
-            args (ArgsType): Arguments to parse. If `None` the arguments are taken from
+            args: Arguments to parse. If `None` the arguments are taken from
                 ``sys.argv``. Command line style arguments can be given in a ``list``. Alternatively,
                 structured config options can be given in a ``dict`` or ``jsonargparse.Namespace``.
-                Defaults to `None`.
-            run (bool): Whether subcommands should be added to run a ``Trainer`` method. If
+                Defaults to ``None``.
+            run: Whether subcommands should be added to run a ``Trainer`` method. If
                 set to `False`, the trainer and model classes will be instantiated only. Defaults
                 to ``True``.
-            auto_configure_optimizers (bool): Defaults to ``True``.
-            eval_after_fit_default (bool): Store whether an evaluation should be performed
+            auto_configure_optimizers: Defaults to ``True``.
+            eval_after_fit_default: Store whether an evaluation should be performed
                 after the training. Defaults to ``False``.
             **kwargs: Additional keyword arguments to pass to the parent class added for
-                ``lightning>2.5.0``:
-
-                    - parser_class: The parser class to use. Defaults to `LightningArgumentParser`.
-                      Available in ``lightning>=2.5.1``
+                ``lightning>2.5.0``.
+                - parser_class: The parser class to use. Defaults to ``LightningArgumentParser``.
+                  Available in ``lightning>=2.5.1``.
         """
         self.eval_after_fit_default = eval_after_fit_default
         super().__init__(

--- a/src/torch_uncertainty/utils/distributions.py
+++ b/src/torch_uncertainty/utils/distributions.py
@@ -32,7 +32,7 @@ def get_dist_class(dist_family: str) -> type[Distribution]:
     """Get the distribution class from a string.
 
     Args:
-        dist_family (str): The distribution family.
+        dist_family: The distribution family.
 
     Returns:
         type[Distribution]: The distribution class.
@@ -58,8 +58,8 @@ def get_dist_estimate(dist: Distribution, dist_estimate: DistEstimate) -> Tensor
     """Get a point-wise prediction from a distribution.
 
     Args:
-        dist (Distribution): The distribution.
-        dist_estimate (DistEstimate): The estimate to use.
+        dist: The distribution.
+        dist_estimate: The estimate to use.
 
     Returns:
         Tensor: The estimated value.

--- a/src/torch_uncertainty/utils/hub.py
+++ b/src/torch_uncertainty/utils/hub.py
@@ -24,8 +24,8 @@ def load_hf(weight_id: str, version: int = 0) -> tuple[dict[str, torch.Tensor], 
     """Load a model from the HuggingFace hub.
 
     Args:
-        weight_id (str): The id of the model to load.
-        version (int): The id of the version when there are several on HF.
+        weight_id: The id of the model to load.
+        version: The id of the version when there are several on HF.
 
     Returns:
         tuple[dict[str, torch.Tensor], dict[str, str]]: The model weights and config.

--- a/src/torch_uncertainty/utils/misc.py
+++ b/src/torch_uncertainty/utils/misc.py
@@ -2,12 +2,12 @@ import csv
 from pathlib import Path
 
 
-def csv_writer(path: Path, dic: dict) -> None:
-    """Write a dictionary to a csv file.
+def csv_writer(path: Path, metrics_dict: dict) -> None:
+    """Write a dictionary of metric values to a csv file.
 
     Args:
-        path (Path): Path to the csv file.
-        dic (dict): Dictionary to write.
+        path: Path to the csv file.
+        metrics_dict: Dictionary to write.
     """
     if path.is_file():  # Check that the file already exists
         append_mode = True
@@ -15,10 +15,10 @@ def csv_writer(path: Path, dic: dict) -> None:
     else:
         append_mode = False
         rw_mode = "w"
-    # Write dic
+    # Write metrics_dict
     with path.open(rw_mode) as csvfile:
         writer = csv.writer(csvfile, delimiter=",")
         # Do not write header in append mode
         if append_mode is False:
-            writer.writerow(dic.keys())
-        writer.writerow([f"{elem:.4f}" for elem in dic.values()])
+            writer.writerow(metrics_dict.keys())
+        writer.writerow([f"{elem:.4f}" for elem in metrics_dict.values()])

--- a/src/torch_uncertainty/utils/plotting.py
+++ b/src/torch_uncertainty/utils/plotting.py
@@ -30,10 +30,10 @@ def plot_hist(
     """Plot a confidence histogram.
 
     Args:
-        conf (Any): The confidence values.
-        bins (int): The number of bins. Defaults to ``20``.
-        title (str): The title of the plot. Defaults to ``"Histogram with 'auto' bins"``.
-        dpi (int): The dpi of the plot. Defaults to ``60``.
+        conf: The confidence values.
+        bins: The number of bins. Defaults to ``20``.
+        title: The title of the plot. Defaults to ``"Histogram with 'auto' bins"``.
+        dpi: The dpi of the plot. Defaults to ``60``.
 
     Returns:
         Tuple[Figure, Axes]: The figure and axes of the plot.

--- a/tests/_dummies/baseline.py
+++ b/tests/_dummies/baseline.py
@@ -31,7 +31,7 @@ class DummyClassificationBaseline:
         eval_shift: bool = False,
         eval_grouping_loss: bool = False,
         calibrate: bool = False,
-        save_in_csv: bool = False,
+        save_to_csv: bool = False,
         mixtype: str | None = "mixup",
         isobatch: bool = False,
         kw_on_embeddings: bool = True,
@@ -81,7 +81,7 @@ class DummyClassificationBaseline:
                 eval_shift=eval_shift,
                 eval_grouping_loss=eval_grouping_loss,
                 post_processing=TemperatureScaler() if calibrate else None,
-                save_in_csv=save_in_csv,
+                save_to_csv=save_to_csv,
             )
         # baseline_type == "ensemble":
         model = deep_ensembles(
@@ -101,7 +101,7 @@ class DummyClassificationBaseline:
             eval_shift=eval_shift,
             eval_grouping_loss=eval_grouping_loss,
             post_processing=TemperatureScaler() if calibrate else None,
-            save_in_csv=save_in_csv,
+            save_to_csv=save_to_csv,
         )
 
 

--- a/tests/_dummies/dataset.py
+++ b/tests/_dummies/dataset.py
@@ -13,19 +13,19 @@ class DummyClassificationDataset(Dataset):
     """Dummy dataset for testing purposes.
 
     Args:
-        root (string): Root directory containing the dataset (unused).
-        train (bool): If True, creates dataset from training set,
+        root: Root directory containing the dataset (unused).
+        train: If ``True``, creates dataset from training set,
             otherwise creates from test set (unused).
-        transform (callable): A function/transform that takes in
+        transform: A function/transform that takes in
             a PIL image and returns a transformed version. E.g,
             ``transforms.RandomCrop``
-        target_transform (callable): A function/transform that
+        target_transform: A function/transform that
             takes in the target and transforms it.
-        num_channels (int): Number of channels in the images.
-        image_size (int): Size of the images.
-        num_classes (int): Number of classes in the dataset.
-        num_images (int): Number of images in the dataset.
-        kwargs (Any): Other arguments.
+        num_channels: Number of channels in the images.
+        image_size: Size of the images.
+        num_classes: Number of classes in the dataset.
+        num_images: Number of images in the dataset.
+        kwargs: Other arguments.
     """
 
     def __init__(
@@ -77,7 +77,7 @@ class DummyClassificationDataset(Dataset):
         """Get item from dataset.
 
         Args:
-            index (int): Index.
+            index: Index.
 
         Returns:
             tuple: (image, target) where target is index of the target class.
@@ -136,7 +136,7 @@ class DummyRegressionDataset(Dataset):
         """Get item from dataset.
 
         Args:
-            index (int): Index.
+            index: Index.
 
         Returns:
             tuple: (image, target) where target is index of the target class.

--- a/tests/_dummies/model.py
+++ b/tests/_dummies/model.py
@@ -111,12 +111,12 @@ def dummy_model(
     """Dummy model for testing purposes.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        num_estimators (int): Number of estimators in the ensemble.
-        dropout_rate (float): Dropout rate. Defaults to 0.0.
-        with_feats (bool): Whether to include features. Defaults to True.
-        dist_family (str): Distribution family. Defaults to None.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        num_estimators: Number of estimators in the ensemble.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+        with_feats: Whether to include features. Defaults to ``True``.
+        dist_family: Distribution family. Defaults to ``None``.
 
     Returns:
         _Dummy: Dummy model.
@@ -146,11 +146,11 @@ def dummy_segmentation_model(
     """Dummy segmentation model for testing purposes.
 
     Args:
-        in_channels (int): Number of input channels.
-        num_classes (int): Number of output classes.
-        image_size (int): Size of the input image.
-        dropout_rate (float): Dropout rate. Defaults to 0.0.
-        dist_family (str): Distribution family. Defaults to None.
+        in_channels: Number of input channels.
+        num_classes: Number of output classes.
+        image_size: Size of the input image.
+        dropout_rate: Dropout rate. Defaults to ``0.0``.
+        dist_family: Distribution family. Defaults to ``None``.
 
     Returns:
         nn.Module: Dummy segmentation model.

--- a/tests/routines/test_classification.py
+++ b/tests/routines/test_classification.py
@@ -382,7 +382,7 @@ class TestClassification:
             baseline_type="ensemble",
             ood_criterion="variation_ratio",
             eval_ood=True,
-            save_in_csv=True,
+            save_to_csv=True,
         )
 
         trainer.fit(model, dm)

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/9d/dd87e1071bcb2e438c14e2e4497aa0037faf2c9775ac1d172f578f448668/cuda_bindings-12.9.6-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb2f1eedc8f65902b34e807c21a3b7c922dc8de1f51d0829ecbb5c6a5e9c5ff1", size = 7094433, upload-time = "2026-03-11T14:47:22.811Z" },
@@ -722,37 +722,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cufile = [
     { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version >= '3.11' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'linux' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -2099,7 +2099,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -2165,9 +2165,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -2193,7 +2193,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'darwin' and extra == 'extra-17-torch-uncertainty-gpu') or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-gpu') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'darwin' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'emscripten' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu') or (sys_platform == 'win32' and extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -3182,6 +3182,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-autodoc-typehints"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/cd/03e7b917230dc057922130a79ba0240df1693bfd76727ea33fae84b39138/sphinx_autodoc_typehints-2.3.0.tar.gz", hash = "sha256:535c78ed2d6a1bad393ba9f3dfa2602cf424e2631ee207263e07874c38fde084", size = 40709, upload-time = "2024-08-29T16:25:48.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f3/e0a4ce49da4b6f4e4ce84b3c39a0677831884cb9d8a87ccbf1e9e56e53ac/sphinx_autodoc_typehints-2.3.0-py3-none-any.whl", hash = "sha256:3098e2c6d0ba99eacd013eb06861acc9b51c6e595be86ab05c08ee5506ac0c67", size = 19836, upload-time = "2024-08-29T16:25:46.707Z" },
+]
+
+[[package]]
 name = "sphinx-codeautolink"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3710,6 +3722,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
@@ -3721,6 +3734,7 @@ dev = [
 docs = [
     { name = "pydata-sphinx-theme" },
     { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-17-torch-uncertainty-cpu' and extra == 'extra-17-torch-uncertainty-gpu')" },
@@ -3775,6 +3789,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff", specifier = "==0.15.7" },
     { name = "sphinx", specifier = "==7.4.7" },
+    { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
@@ -3785,6 +3800,7 @@ dev = [
 docs = [
     { name = "pydata-sphinx-theme" },
     { name = "sphinx", specifier = "==7.4.7" },
+    { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-codeautolink" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },


### PR DESCRIPTION
I removed (nearly) all type hints from the docs to make them more readable and added the auto-type hints Sphinx dependency that I also set up.

I fixed a lot of issues in the docs through Copilot agents.