### PR TITLE
:fire:(dosctrings): rm `optional`s from docstrings

### DIFF
--- a/auto_tutorial_source/Bayesian_Methods/tutorial_muad_mc_drop.py
+++ b/auto_tutorial_source/Bayesian_Methods/tutorial_muad_mc_drop.py
@@ -155,9 +155,9 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         dataloader (``data.Dataloader``): A data loader to iterate over the
             dataset.
         num_classes (``int``): The number of classes.
-        c (``int``, optional): AN additional hyper-parameter which restricts
+        c (``int``): An additional hyper-parameter which restricts
             the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``, optional): A list of indexes to ignore
+        ignore_indexes (``list``): A list of indexes to ignore
             when computing the weights. Default to `None`.
 
     """

--- a/auto_tutorial_source/Segmentation/tutorial_muad_deep_en.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_deep_en.py
@@ -160,9 +160,9 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         dataloader (``data.Dataloader``): A data loader to iterate over the
             dataset.
         num_classes (``int``): The number of classes.
-        c (``int``, optional): AN additional hyper-parameter which restricts
+        c (``int``): An additional hyper-parameter which restricts
             the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``, optional): A list of indexes to ignore
+        ignore_indexes (``list``): A list of indexes to ignore
             when computing the weights. Default to `None`.
 
     """

--- a/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_packed.py
@@ -152,9 +152,9 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         dataloader (``data.Dataloader``): A data loader to iterate over the
             dataset.
         num_classes (``int``): The number of classes.
-        c (``int``, optional): AN additional hyper-parameter which restricts
+        c (``int``): An additional hyper-parameter which restricts
             the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``, optional): A list of indexes to ignore
+        ignore_indexes (``list``): A list of indexes to ignore
             when computing the weights. Default to `None`.
 
     """

--- a/auto_tutorial_source/Segmentation/tutorial_muad_seg.py
+++ b/auto_tutorial_source/Segmentation/tutorial_muad_seg.py
@@ -153,9 +153,9 @@ def enet_weighing(dataloader, num_classes, c=1.02):
         dataloader (``data.Dataloader``): A data loader to iterate over the
             dataset.
         num_classes (``int``): The number of classes.
-        c (``int``, optional): AN additional hyper-parameter which restricts
+        c (``int``): An additional hyper-parameter which restricts
             the interval of values for the weights. Default: 1.02.
-        ignore_indexes (``list``, optional): A list of indexes to ignore
+        ignore_indexes (``list``): A list of indexes to ignore
             when computing the weights. Default to `None`.
 
     """

--- a/src/torch_uncertainty/callbacks/checkpoint.py
+++ b/src/torch_uncertainty/callbacks/checkpoint.py
@@ -68,7 +68,7 @@ class TUClsCheckpoint(_TUCheckpoint):
         Expected Calibration Error, Brier-Score and Negative Log-Likelihood.
 
         Args:
-            save_last (bool | "link", optional): When ``True``, saves a last.ckpt copy whenever a
+            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
                 manner. Default to ``False``.
@@ -107,7 +107,7 @@ class TUSegCheckpoint(_TUCheckpoint):
         over Union, Expected Calibration Error, Brier-Score and Negative Log-Likelihood.
 
         Args:
-            save_last (bool | "link", optional): When ``True``, saves a last.ckpt copy whenever a
+            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
                 manner. Default to ``False``.
@@ -154,9 +154,9 @@ class TURegCheckpoint(_TUCheckpoint):
         Error, and eventually the Negative Log-Likelihood and Quantile Calibration Error.
 
         Args:
-            probabilistic (bool, optional): If ``True``, also tracks the Negative Log-Likelihood and
+            probabilistic (bool): If ``True``, also tracks the Negative Log-Likelihood and
                 the Quantile Calibration Error. Default to ``False``.
-            save_last (bool | "link", optional): When ``True``, saves a last.ckpt copy whenever a
+            save_last (bool | "link"): When ``True``, saves a last.ckpt copy whenever a
                 checkpoint file gets saved. Can be set to ``"link"`` on a local filesystem to create a
                 symbolic link. This allows accessing the latest checkpoint in a deterministic
                 manner. Default to ``False``.

--- a/src/torch_uncertainty/callbacks/compound_checkpoint.py
+++ b/src/torch_uncertainty/callbacks/compound_checkpoint.py
@@ -32,24 +32,24 @@ class CompoundCheckpoint(ModelCheckpoint):
 
                 .. math:: \sum_{i} \text{metric}_i \times \text{value}_i
 
-            dirpath (str | Path | None, optional): The directory to save the checkpoints in.
+            dirpath (str | Path | None): The directory to save the checkpoints in.
                 Defaults to ``None``.
-            verbose (bool, optional): Whether to print verbose output. Defaults to False.
-            save_last (bool | Literal["link"], optional): Whether to save the last checkpoint.
+            verbose (bool): Whether to print verbose output. Defaults to False.
+            save_last (bool | Literal["link"]): Whether to save the last checkpoint.
                 Defaults to ``False``.
-            save_top_k (int, optional): The number of best checkpoints to save. Defaults to ``1``.
-            save_weights_only (bool, optional): Whether to save only the weights. Defaults to
+            save_top_k (int): The number of best checkpoints to save. Defaults to ``1``.
+            save_weights_only (bool): Whether to save only the weights. Defaults to
                 ``False``.
-            mode (str, optional): The mode to optimize the compound metric. Defaults to ``"min"``.
-            every_n_train_steps (int | None, optional): The number of training steps to wait
+            mode (str): The mode to optimize the compound metric. Defaults to ``"min"``.
+            every_n_train_steps (int | None): The number of training steps to wait
                 between saving checkpoints. Defaults to ``None``.
-            train_time_interval (timedelta | None, optional): The time interval to wait between
+            train_time_interval (timedelta | None): The time interval to wait between
                 saving checkpoints. Defaults to ``None``.
-            every_n_epochs (int | None, optional): The number of epochs to wait between saving
+            every_n_epochs (int | None): The number of epochs to wait between saving
                 checkpoints. Defaults to ``None``.
-            save_on_train_epoch_end (bool | None, optional): Whether to save the checkpoint at the
+            save_on_train_epoch_end (bool | None): Whether to save the checkpoint at the
                 end of each training epoch. Defaults to ``None``.
-            enable_version_counter (bool, optional): Whether to enable the version counter for the
+            enable_version_counter (bool): Whether to enable the version counter for the
                 saved checkpoints. Defaults to ``True``.
         """
         self.compound_metric_dict = compound_metric_dict

--- a/src/torch_uncertainty/datamodules/abstract.py
+++ b/src/torch_uncertainty/datamodules/abstract.py
@@ -159,7 +159,7 @@ class TUDataModule(LightningDataModule, ABC):
         Args:
             dataset (Dataset): Dataset to create a dataloader for.
             training (bool): Whether it is a training or evaluation dataloader.
-            shuffle (bool, optional): Whether to shuffle the dataset. Defaults
+            shuffle (bool): Whether to shuffle the dataset. Defaults
                 to False.
 
         Return:

--- a/src/torch_uncertainty/datamodules/classification/cifar10.py
+++ b/src/torch_uncertainty/datamodules/classification/cifar10.py
@@ -62,7 +62,7 @@ class CIFAR10DataModule(TUDataModule):
             eval_shift (bool): Whether to evaluate on shifted data. Defaults to ``False``.
             val_split (float): Share of samples to use for validation. Defaults
                 to ``0.0``.
-            postprocess_set (str, optional): The post-hoc calibration dataset to
+            postprocess_set (str): The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
             num_workers (int): Number of workers to use for data loading. Defaults
                 to ``1``.

--- a/src/torch_uncertainty/datamodules/classification/cifar100.py
+++ b/src/torch_uncertainty/datamodules/classification/cifar100.py
@@ -61,7 +61,7 @@ class CIFAR100DataModule(TUDataModule):
                 and test). Set to batch_size if ``None``. Defaults to ``None``.
             val_split (float): Share of samples to use for validation. Defaults
                 to ``0.0``.
-            postprocess_set (str, optional): The post-hoc calibration dataset to
+            postprocess_set (str): The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
             train_transform (nn.Module | None): Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.

--- a/src/torch_uncertainty/datamodules/classification/imagenet.py
+++ b/src/torch_uncertainty/datamodules/classification/imagenet.py
@@ -85,7 +85,7 @@ class ImageNetDataModule(TUDataModule):
             val_split (float or Path): Share of samples to use for validation
                 or path to a yaml file containing a list of validation images
                 ids. Defaults to ``0.0``.
-            postprocess_set (str, optional): The post-hoc calibration dataset to
+            postprocess_set (str): The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
             train_transform (nn.Module | None): Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.

--- a/src/torch_uncertainty/datamodules/classification/mnist.py
+++ b/src/torch_uncertainty/datamodules/classification/mnist.py
@@ -55,7 +55,7 @@ class MNISTDataModule(TUDataModule):
                 ``"fashion"``; `fashion` stands for FashionMNIST and `notMNIST` for notMNIST.
             val_split (float): Share of samples to use for validation. Defaults to ``0.0``.
             num_tta (int): Number of test-time augmentations (TTA). Defaults to ``1`` (no TTA).
-            postprocess_set (str, optional): The post-hoc calibration dataset to
+            postprocess_set (str): The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
             num_workers (int): Number of workers to use for data loading. Defaults
                 to ``1``.

--- a/src/torch_uncertainty/datamodules/classification/tiny_imagenet.py
+++ b/src/torch_uncertainty/datamodules/classification/tiny_imagenet.py
@@ -68,7 +68,7 @@ class TinyImageNetDataModule(TUDataModule):
             val_split (float or Path): Share of samples to use for validation
                 or path to a yaml file containing a list of validation images
                 ids. Defaults to ``0.0``.
-            postprocess_set (str, optional): The post-hoc calibration dataset to
+            postprocess_set (str): The post-hoc calibration dataset to
                 use for the post-processing method. Defaults to ``val``.
             train_transform (nn.Module | None): Custom training transform. Defaults
                 to ``None``. If not provided, a default transform is used.

--- a/src/torch_uncertainty/datamodules/classification/uci/bank_marketing.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/bank_marketing.py
@@ -25,16 +25,16 @@ class BankMarketingDataModule(UCIClassificationDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the
+            val_split (float): Share of validation samples among the
                 non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data
                 loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults
                 to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/classification/uci/dota2_games.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/dota2_games.py
@@ -25,12 +25,12 @@ class DOTA2GamesDataModule(UCIClassificationDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers. Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults to ``True``.
+            val_split (float): Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            binary (bool): Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/htru2.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/htru2.py
@@ -25,12 +25,12 @@ class HTRU2DataModule(UCIClassificationDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers. Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults to ``True``.
+            val_split (float): Share of validation samples among the non-test samples. Defaults to ``0``.
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data loading. Defaults to ``1``.
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            binary (bool): Whether to use binary classification. Defaults to ``True``.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/classification/uci/online_shoppers.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/online_shoppers.py
@@ -25,16 +25,16 @@ class OnlineShoppersDataModule(UCIClassificationDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the
+            val_split (float): Share of validation samples among the
                 non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data
                 loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults
                 to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
 
         """

--- a/src/torch_uncertainty/datamodules/classification/uci/spam_base.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/spam_base.py
@@ -25,16 +25,16 @@ class SpamBaseDataModule(UCIClassificationDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the
+            val_split (float): Share of validation samples among the
                 non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data
                 loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults
                 to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/classification/uci/uci_classification.py
+++ b/src/torch_uncertainty/datamodules/classification/uci/uci_classification.py
@@ -30,16 +30,16 @@ class UCIClassificationDataModule(TUDataModule):
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples among the
+            val_split (float): Share of validation samples among the
                 non-test samples. Defaults to ``0``.
-            test_split (float, optional): Share of test samples. Defaults to ``0.2``.
-            num_workers (int, optional): How many subprocesses to use for data
+            test_split (float): Share of test samples. Defaults to ``0.2``.
+            num_workers (int): How many subprocesses to use for data
                 loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults
                 to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
         """
         super().__init__(
@@ -64,7 +64,7 @@ class UCIClassificationDataModule(TUDataModule):
         """Split the datasets into train, val, and test.
 
         Args:
-            stage (str | None, optional): Stage to set up. Defaults to ``None``.
+            stage (str | None): Stage to set up. Defaults to ``None``.
         """
         if stage == "fit" or stage is None:
             full = self.dataset(

--- a/src/torch_uncertainty/datamodules/classification/ucr_uea.py
+++ b/src/torch_uncertainty/datamodules/classification/ucr_uea.py
@@ -32,11 +32,11 @@ class UCRUEADataModule(TUDataModule):
             val_split (float | None): Share of validation samples. Defaults to ``0``.
             eval_ood (bool): Whether to evaluate on out-of-distribution (OOD) data. Defaults to
                 ``False``.
-            num_workers (int, optional): How many subprocesses to use for data loading. Defaults
+            num_workers (int): How many subprocesses to use for data loading. Defaults
                 to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers. Defaults to ``True``.
-            split_seed (int, optional): The seed to use for splitting the dataset.
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults to ``True``.
+            persistent_workers (bool): Whether to use persistent workers. Defaults to ``True``.
+            split_seed (int): The seed to use for splitting the dataset.
                 Defaults to ``42``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/depth/base.py
+++ b/src/torch_uncertainty/datamodules/depth/base.py
@@ -39,10 +39,10 @@ class DepthDataModule(TUDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                     and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float, optional): Minimum depth value for evaluation.
-            max_depth (float, optional): Maximum depth value for training and
+            min_depth (float): Minimum depth value for evaluation.
+            max_depth (float): Maximum depth value for training and
                 evaluation.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,7 +50,7 @@ class DepthDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``None``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -61,11 +61,11 @@ class DepthDataModule(TUDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation.
-            num_workers (int, optional): Number of dataloaders to use.
-            pin_memory (bool, optional):  Whether to pin memory.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            num_workers (int): Number of dataloaders to use.
+            pin_memory (bool):  Whether to pin memory.
+            persistent_workers (bool): Whether to use persistent workers.
         """
         super().__init__(
             root=root,

--- a/src/torch_uncertainty/datamodules/depth/kitti.py
+++ b/src/torch_uncertainty/datamodules/depth/kitti.py
@@ -32,11 +32,11 @@ class KITTIDataModule(DepthDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float, optional): Minimum depth value for evaluation.
+            min_depth (float): Minimum depth value for evaluation.
                 Defaults to ``1e-3``.
-            max_depth (float, optional): Maximum depth value for training and
+            max_depth (float): Maximum depth value for training and
                 evaluation. Defaults to ``80.0``.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -44,7 +44,7 @@ class KITTIDataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``(375, 1242)``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -55,13 +55,13 @@ class KITTIDataModule(DepthDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional):  Whether to pin memory. Defaults to
+            pin_memory (bool):  Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/depth/muad.py
+++ b/src/torch_uncertainty/datamodules/depth/muad.py
@@ -35,10 +35,10 @@ class MUADDataModule(DepthDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                     and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float, optional): Minimum depth value for evaluation
-            max_depth (float, optional): Maximum depth value for training and
+            min_depth (float): Minimum depth value for evaluation
+            max_depth (float): Maximum depth value for training and
                 evaluation.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -46,7 +46,7 @@ class MUADDataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -57,13 +57,13 @@ class MUADDataModule(DepthDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional):  Whether to pin memory. Defaults to
+            pin_memory (bool):  Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/depth/nyu.py
+++ b/src/torch_uncertainty/datamodules/depth/nyu.py
@@ -32,11 +32,11 @@ class NYUv2DataModule(DepthDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            min_depth (float, optional): Minimum depth value for evaluation.
+            min_depth (float): Minimum depth value for evaluation.
                 Defaults to ``1e-3``.
-            max_depth (float, optional): Maximum depth value for training and
+            max_depth (float): Maximum depth value for training and
                 evaluation. Defaults to ``10.0``.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 depth mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -44,7 +44,7 @@ class NYUv2DataModule(DepthDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``(416, 544)``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 depth mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -55,13 +55,13 @@ class NYUv2DataModule(DepthDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional):  Whether to pin memory. Defaults to
+            pin_memory (bool):  Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datamodules/segmentation/camvid.py
+++ b/src/torch_uncertainty/datamodules/segmentation/camvid.py
@@ -42,7 +42,7 @@ class CamVidDataModule(TUDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,7 +50,7 @@ class CamVidDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``640``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 segmentation mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -61,17 +61,17 @@ class CamVidDataModule(TUDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            group_classes (bool, optional): Whether to group the 32 classes into
+            group_classes (bool): Whether to group the 32 classes into
                 11 superclasses. Default: ``True``.
             basic_augment (bool): Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional):  Whether to pin memory. Defaults to
+            pin_memory (bool):  Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
 
         Note:

--- a/src/torch_uncertainty/datamodules/segmentation/cityscapes.py
+++ b/src/torch_uncertainty/datamodules/segmentation/cityscapes.py
@@ -42,7 +42,7 @@ class CityscapesDataModule(TUDataModule):
             batch_size (int): Number of samples per batch during training.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -50,7 +50,7 @@ class CityscapesDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 segmentation mask sizes during evaluation. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -63,13 +63,13 @@ class CityscapesDataModule(TUDataModule):
                 ``None``. If not provided, a default transform is used.
             basic_augment (bool): Whether to apply base augmentations. Defaults to
                 ``True``. Only used if ``train_transform`` is not provided.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional): Whether to pin memory. Defaults to
+            pin_memory (bool): Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
 
         Note:

--- a/src/torch_uncertainty/datamodules/segmentation/muad.py
+++ b/src/torch_uncertainty/datamodules/segmentation/muad.py
@@ -42,14 +42,14 @@ class MUADDataModule(TUDataModule):
         Args:
             root (str or Path): Root directory of the datasets.
             batch_size (int): Number of samples per batch during training.
-            version (str, optional): Version of the dataset to use. Can be either
+            version (str): Version of the dataset to use. Can be either
                 ``full`` or ``small``. Defaults to ``full``.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
             eval_ood (bool): Whether to evaluate on the OOD dataset. Defaults to
                 ``False``. If set to ``True``, the OOD dataset will be used for
                 evaluation in addition of the test dataset.
-            crop_size (sequence or int, optional): Desired input image and
+            crop_size (sequence or int): Desired input image and
                 segmentation mask sizes during training. If :attr:`crop_size` is an
                 int instead of sequence like :math:`(H, W)`, a square crop
                 :math:`(\text{size},\text{size})` is made. If provided a sequence
@@ -57,7 +57,7 @@ class MUADDataModule(TUDataModule):
                 :math:`(\text{size[0]},\text{size[1]})`. Has to be provided if
                 :attr:`train_transform` is not provided. Otherwise has no effect.
                 Defaults to ``1024``.
-            eval_size (sequence or int, optional): Desired input image and
+            eval_size (sequence or int): Desired input image and
                 segmentation mask sizes during inference. If size is an int,
                 smaller edge of the images will be matched to this number, i.e.,
                 :math:`\text{height}>\text{width}`, then image will be rescaled to
@@ -68,13 +68,13 @@ class MUADDataModule(TUDataModule):
                 to ``None``. If not provided, a default transform is used.
             test_transform (nn.Module | None): Custom test transform. Defaults to
                 ``None``. If not provided, a default transform is used.
-            val_split (float or None, optional): Share of training samples to use
+            val_split (float or None): Share of training samples to use
                 for validation. Defaults to ``None``.
-            num_workers (int, optional): Number of dataloaders to use. Defaults to
+            num_workers (int): Number of dataloaders to use. Defaults to
                 ``1``.
-            pin_memory (bool, optional): Whether to pin memory. Defaults to
+            pin_memory (bool): Whether to pin memory. Defaults to
                 ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
 
         Note:

--- a/src/torch_uncertainty/datamodules/uci_regression.py
+++ b/src/torch_uncertainty/datamodules/uci_regression.py
@@ -29,24 +29,24 @@ class UCIRegressionDataModule(TUDataModule):
 
         Args:
             root (string): Root directory of the datasets.
-            dataset_name (string, optional): The name of the dataset. One of
+            dataset_name (string): The name of the dataset. One of
                 ``boston-housing``, ``concrete``, ``energy``, ``kin8nm``,
                 ``naval-propulsion-plant``, ``power-plant``, ``protein``,
                 ``wine-quality-red``, and ``yacht``.
             batch_size (int): The batch size for training and testing.
             eval_batch_size (int | None) : Number of samples per batch during evaluation (val
                 and test). Set to :attr:`batch_size` if ``None``. Defaults to ``None``.
-            val_split (float, optional): Share of validation samples. Defaults
+            val_split (float): Share of validation samples. Defaults
                 to ``0``.
-            num_workers (int, optional): How many subprocesses to use for data
+            num_workers (int): How many subprocesses to use for data
                 loading. Defaults to ``1``.
-            pin_memory (bool, optional): Whether to pin memory in the GPU. Defaults
+            pin_memory (bool): Whether to pin memory in the GPU. Defaults
                 to ``True``.
-            persistent_workers (bool, optional): Whether to use persistent workers.
+            persistent_workers (bool): Whether to use persistent workers.
                 Defaults to ``True``.
-            input_shape (tuple, optional): The shape of the input data. Defaults to
+            input_shape (tuple): The shape of the input data. Defaults to
                 ``None``.
-            split_seed (int, optional): The seed to use for splitting the dataset.
+            split_seed (int): The seed to use for splitting the dataset.
                 Defaults to ``42``.
         """
         super().__init__(

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_c.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_c.py
@@ -74,11 +74,11 @@ class CIFAR10C(VisionDataset):
 
         Args:
             root (str): Root directory of the datasets.
-            transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes in the target and transforms it. Defaults to ``None``.
+            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to ``None``.
             subset (str): The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
             shift_severity (int): The shift_severity of the corruption, between ``1`` and ``5``.
-            download (bool, optional): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
+            download (bool): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
 
         References:
             [1] `Benchmarking neural network robustness to common corruptions and perturbations. Dan Hendrycks and Thomas Dietterich. In ICLR, 2019 <https://arxiv.org/abs/1903.12261>`_.
@@ -229,11 +229,11 @@ class CIFAR100C(CIFAR10C):
 
         Args:
             root (str): Root directory of the datasets.
-            transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to None.
-            target_transform (callable, optional): A function/transform that takes in the target and transforms it. Defaults to None.
+            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to None.
+            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to None.
             subset (str): The subset to use, one of ``all`` or the keys in ``cifarc_subsets``.
             shift_severity (int): The shift_severity of the corruption, between 1 and 5.
-            download (bool, optional): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to False.
+            download (bool): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to False.
             kwargs: Additional keyword arguments passed to the parent class (CIFAR-10-C).
 
         .. seealso::

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_h.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_h.py
@@ -27,13 +27,13 @@ class CIFAR10H(CIFAR10):
             root (str): Root directory of dataset where file
                 ``cifar-10h-probs.npy`` exists or will be saved to if download
                 is set to ``True``.
-            train (bool, optional): For API consistency, not used.
-            transform (callable, optional): A function/transform that takes in
+            train (bool): For API consistency, not used.
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/cifar/cifar_n.py
+++ b/src/torch_uncertainty/datasets/classification/cifar/cifar_n.py
@@ -38,15 +38,15 @@ class CIFAR10N(CIFAR10):
             root (str): Root directory of dataset where file
                 ``cifar-10h-probs.npy`` exists or will be saved to if download
                 is set to ``True``.
-            train (bool, optional): For API consistency, not used.
-            file_arg (str, optional): The type of label noise to use. One of the following:
+            train (bool): For API consistency, not used.
+            file_arg (str): The type of label noise to use. One of the following:
                 ``"aggre_label"``, ``"worse_label"``, ``"random_label1"``, ``"random_label2"``, ``"random_label3"``.
-            transform (callable, optional): A function/transform that takes in
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """
@@ -109,15 +109,15 @@ class CIFAR100N(CIFAR100):
             root (string): Root directory of dataset where file
                 ``cifar-100h-probs.npy`` exists or will be saved to if download
                 is set to True.
-            train (bool, optional): For API consistency, not used.
-            file_arg (str, optional): The type of label noise to use. One of the following:
+            train (bool): For API consistency, not used.
+            file_arg (str): The type of label noise to use. One of the following:
                 ``"fine_label"``, ``"coarse_label"``.
-            transform (callable, optional): A function/transform that takes in
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If True, downloads the dataset from the
+            download (bool): If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/cub.py
+++ b/src/torch_uncertainty/datasets/classification/cub.py
@@ -28,15 +28,15 @@ class CUB(ImageFolder):
 
         Args:
             root (str): Root directory of the dataset.
-            train (bool, optional): If True, creates dataset from training set, otherwise creates
+            train (bool): If True, creates dataset from training set, otherwise creates
                 from test set. Defaults to True.
-            transform (callable, optional): A function/transform that takes in an PIL image and
+            transform (callable): A function/transform that takes in an PIL image and
                 returns a transformed version. E.g, transforms.RandomCrop. Defaults to None.
-            target_transform (callable, optional): A function/transform that takes in the target
+            target_transform (callable): A function/transform that takes in the target
                 and transforms it. Defaults to None.
-            return_attributes (bool, optional): If True, returns the attributes instead of the images.
+            return_attributes (bool): If True, returns the attributes instead of the images.
                 Defaults to False.
-            download (bool, optional): If True, downloads the dataset from the internet and puts it
+            download (bool): If True, downloads the dataset from the internet and puts it
                 in root directory. If dataset is already downloaded, it is not downloaded again.
 
         References:

--- a/src/torch_uncertainty/datasets/classification/imagenet/base.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/base.py
@@ -33,13 +33,13 @@ class ImageNetVariation(ImageFolder):
 
         Args:
         root (str | Path): Root directory of the datasets.
-        split (str, optional): For API consistency. Defaults to ``None``.
-        transform (callable, optional): A function/transform that takes in
+        split (str): For API consistency. Defaults to ``None``.
+        transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-        target_transform (callable, optional): A function/transform that
+        target_transform (callable): A function/transform that
             takes in the target and transforms it. Defaults to ``None``.
-        download (bool, optional): If ``True``, downloads the dataset from the
+        download (bool): If ``True``, downloads the dataset from the
             internet and puts it in root directory. If dataset is already
             downloaded, it is not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_a.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_a.py
@@ -16,12 +16,12 @@ class ImageNetA(ImageNetVariation):
             kwargs: Additional keyword arguments passed to the superclass, including:
 
                 - root (str): Root directory of the datasets.
-                - split (str, optional): For API consistency. Defaults to ``None``.
-                - transform (callable, optional): A function/transform that takes in a PIL image and
+                - split (str): For API consistency. Defaults to ``None``.
+                - transform (callable): A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable, optional): A function/transform that takes in the target
+                - target_transform (callable): A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool, optional): If ``True``, downloads the dataset from the internet
+                - download (bool): If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_c.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_c.py
@@ -43,12 +43,12 @@ class ImageNetC(ImageNetVariation):
             kwargs: Additional keyword arguments passed to the superclass, including:
 
                 - root (str): Root directory of the datasets.
-                - split (str, optional): For API consistency. Defaults to ``None``.
-                - transform (callable, optional): A function/transform that takes in a PIL image and
+                - split (str): For API consistency. Defaults to ``None``.
+                - transform (callable): A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable, optional): A function/transform that takes in the target
+                - target_transform (callable): A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool, optional): If ``True``, downloads the dataset from the internet
+                - download (bool): If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_o.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_o.py
@@ -16,12 +16,12 @@ class ImageNetO(ImageNetVariation):
             kwargs: Additional keyword arguments passed to the superclass, including:
 
                 - root (str): Root directory of the datasets.
-                - split (str, optional): For API consistency. Defaults to ``None``.
-                - transform (callable, optional): A function/transform that takes in a PIL image and
+                - split (str): For API consistency. Defaults to ``None``.
+                - transform (callable): A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable, optional): A function/transform that takes in the target
+                - target_transform (callable): A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool, optional): If ``True``, downloads the dataset from the internet
+                - download (bool): If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet_r.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet_r.py
@@ -16,12 +16,12 @@ class ImageNetR(ImageNetVariation):
             kwargs: Additional keyword arguments passed to the superclass, including:
 
                 - root (str): Root directory of the datasets.
-                - split (str, optional): For API consistency. Defaults to ``None``.
-                - transform (callable, optional): A function/transform that takes in a PIL image and
+                - split (str): For API consistency. Defaults to ``None``.
+                - transform (callable): A function/transform that takes in a PIL image and
                   returns a transformed version. E.g., transforms.RandomCrop. Defaults to ``None``.
-                - target_transform (callable, optional): A function/transform that takes in the target
+                - target_transform (callable): A function/transform that takes in the target
                   and transforms it. Defaults to ``None``.
-                - download (bool, optional): If ``True``, downloads the dataset from the internet
+                - download (bool): If ``True``, downloads the dataset from the internet
                   and puts it in the root directory. If the dataset is already downloaded, it is
                   not downloaded again. Defaults to ``False``.
         """

--- a/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet_c.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/tiny_imagenet_c.py
@@ -53,15 +53,15 @@ class TinyImageNetC(ImageFolder):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            transform (callable, optional): A function/transform that takes in
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
             subset (str): The subset to use, one of ``all`` or the keys in
                 ``cifarc_subsets``.
             shift_severity (int): The shift_severity of the corruption, between ``1`` and ``5``.
-            download (bool, optional): If True, downloads the dataset from the
+            download (bool): If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
 

--- a/src/torch_uncertainty/datasets/classification/mnist_c.py
+++ b/src/torch_uncertainty/datasets/classification/mnist_c.py
@@ -48,15 +48,15 @@ class MNISTC(VisionDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            transform (callable, optional): A function/transform that takes in
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to None.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to None.
-            split (str, optional): The split to use, either 'train' or 'test'.
+            split (str): The split to use, either 'train' or 'test'.
             subset (str): The subset to use, one of ``all`` or the keys in
                 ``mnistc_subsets``.
-            download (bool, optional): If True, downloads the dataset from the
+            download (bool): If True, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to False.
 

--- a/src/torch_uncertainty/datasets/classification/not_mnist.py
+++ b/src/torch_uncertainty/datasets/classification/not_mnist.py
@@ -32,12 +32,12 @@ class NotMNIST(ImageFolder):
         Args:
             root (str | Path): Root directory of the datasets.
             subset (str): The subset to use, one of ``small`` or ``large``.
-            transform (callable, optional): A function/transform that takes in
+            transform (callable): A function/transform that takes in
                 a PIL image and returns a transformed version. E.g,
                 ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that
+            target_transform (callable): A function/transform that
                 takes in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
 

--- a/src/torch_uncertainty/datasets/classification/openimage_o.py
+++ b/src/torch_uncertainty/datasets/classification/openimage_o.py
@@ -26,10 +26,10 @@ class OpenImageO(ImageFolder):
 
         Args:
             root (str): Root directory of the datasets.
-            split (str, optional): Unused, for API consistency. Defaults to ``None``.
-            transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
+            split (str): Unused, for API consistency. Defaults to ``None``.
+            transform (callable): A function/transform that takes in a PIL image and returns a transformed version. E.g, ``transforms.RandomCrop``. Defaults to ``None``.
+            target_transform (callable): A function/transform that takes in the target and transforms it. Defaults to ``None``.
+            download (bool): If True, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again. Defaults to ``False``.
 
         References:
             [1] `Original dataset: The open images dataset v4: Unified image classification, object detection, and visual relationship detection at scale. Kuznetsova, A., et al. The International Journal of Computer Vision

--- a/src/torch_uncertainty/datasets/classification/uci/bank_marketing.py
+++ b/src/torch_uncertainty/datasets/classification/uci/bank_marketing.py
@@ -35,13 +35,13 @@ class BankMarketing(UCIClassificationDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If True, creates dataset from training set, otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a numpy array and returns a transformed version.
-            target_transform (callable, optional): A function/transform that takes in the target and transforms it.
-            download (bool, optional): If true, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
-            binary (bool, optional): Whether to use binary classification. Defaults to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
-            split_seed (int, optional): The random seed for splitting the dataset. Defaults to ``21893027``.
+            train (bool): If True, creates dataset from training set, otherwise creates from test set.
+            transform (callable): A function/transform that takes in a numpy array and returns a transformed version.
+            target_transform (callable): A function/transform that takes in the target and transforms it.
+            download (bool): If true, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
+            binary (bool): Whether to use binary classification. Defaults to ``True``.
+            test_split (float): The fraction of the dataset to use as test set.
+            split_seed (int): The random seed for splitting the dataset. Defaults to ``21893027``.
 
         Note:
             The licenses of the datasets may differ from TorchUncertainty's license. Check before use.

--- a/src/torch_uncertainty/datasets/classification/uci/dota2_games.py
+++ b/src/torch_uncertainty/datasets/classification/uci/dota2_games.py
@@ -33,20 +33,20 @@ class DOTA2Games(UCIClassificationDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If ``True``, creates dataset from training set,
+            train (bool): If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``. Defaults to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
+            test_split (float): The fraction of the dataset to use as test set.
                 Defaults to ``0.2``.
-            split_seed (int, optional): The random seed for splitting the dataset.
+            split_seed (int): The random seed for splitting the dataset.
                 Defaults to ``21893027``.
 
         Note - License:

--- a/src/torch_uncertainty/datasets/classification/uci/htru2.py
+++ b/src/torch_uncertainty/datasets/classification/uci/htru2.py
@@ -29,20 +29,20 @@ class HTRU2(UCIClassificationDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If ``True``, creates dataset from training set,
+            train (bool): If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
+            test_split (float): The fraction of the dataset to use as test set.
                 Defaults to ``0.2``.
-            split_seed (int, optional): The random seed for splitting the dataset.
+            split_seed (int): The random seed for splitting the dataset.
                 Defaults to ``21893027``.
 
         Note:

--- a/src/torch_uncertainty/datasets/classification/uci/online_shoppers.py
+++ b/src/torch_uncertainty/datasets/classification/uci/online_shoppers.py
@@ -29,20 +29,20 @@ class OnlineShoppers(UCIClassificationDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If ``True``, creates dataset from training set,
+            train (bool): If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
+            test_split (float): The fraction of the dataset to use as test set.
                 Defaults to ``0.2``.
-            split_seed (int, optional): The random seed for splitting the dataset.
+            split_seed (int): The random seed for splitting the dataset.
                 Defaults to ``21893027``.
 
         Note:

--- a/src/torch_uncertainty/datasets/classification/uci/spam_base.py
+++ b/src/torch_uncertainty/datasets/classification/uci/spam_base.py
@@ -29,20 +29,20 @@ class SpamBase(UCIClassificationDataset):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If ``True``, creates dataset from training set,
+            train (bool): If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
+            test_split (float): The fraction of the dataset to use as test set.
                 Defaults to ``0.2``.
-            split_seed (int, optional): The random seed for splitting the dataset.
+            split_seed (int): The random seed for splitting the dataset.
                 Defaults to ``21893027``.
 
         Note:

--- a/src/torch_uncertainty/datasets/classification/uci/uci_classification.py
+++ b/src/torch_uncertainty/datasets/classification/uci/uci_classification.py
@@ -35,20 +35,20 @@ class UCIClassificationDataset(Dataset, ABC):
 
         Args:
             root (str | Path): Root directory of the datasets.
-            train (bool, optional): If ``True``, creates dataset from training set,
+            train (bool): If ``True``, creates dataset from training set,
                 otherwise creates from test set.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            binary (bool, optional): Whether to use binary classification. Defaults
+            binary (bool): Whether to use binary classification. Defaults
                 to ``True``.
-            test_split (float, optional): The fraction of the dataset to use as test set.
+            test_split (float): The fraction of the dataset to use as test set.
                 Defaults to ``0.2``.
-            split_seed (int, optional): The random seed for splitting the dataset.
+            split_seed (int): The random seed for splitting the dataset.
                 Defaults to ``21893027``.
 
         Note:

--- a/src/torch_uncertainty/datasets/classification/ucr_uea.py
+++ b/src/torch_uncertainty/datasets/classification/ucr_uea.py
@@ -28,12 +28,12 @@ class UCRUEADataset(Dataset):
 
         Args:
             dataset_name (str): Name of the dataset to load.
-            split (str, optional): Split to use (``"train"``, ``"test"`` or ``"ood"``). Defaults to ``"train"``.
-            transform (Callable | None, optional): Transform to apply to the input data. Defaults
+            split (str): Split to use (``"train"``, ``"test"`` or ``"ood"``). Defaults to ``"train"``.
+            transform (Callable | None): Transform to apply to the input data. Defaults
                 to ``None``.
-            target_transform (Callable | None, optional): Transform to apply to the target data.
+            target_transform (Callable | None): Transform to apply to the target data.
                 Defaults to ``None``.
-            create_ood (bool, optional): Whether to create an out-of-distribution (OOD) dataset based
+            create_ood (bool): Whether to create an out-of-distribution (OOD) dataset based
                 on the last class in the dataset. Defaults to ``False``.
 
         Raises:

--- a/src/torch_uncertainty/datasets/frost.py
+++ b/src/torch_uncertainty/datasets/frost.py
@@ -36,9 +36,9 @@ class FrostImages(VisionDataset):
         and each sample consists only of an image.
 
         Args:
-            transform (Callable[..., Any] | None, optional): A function/transform
+            transform (Callable[..., Any] | None): A function/transform
                 applied to the input image. Default: ``None``.
-            target_transform (Callable[..., Any] | None, optional): A function/transform
+            target_transform (Callable[..., Any] | None): A function/transform
                 applied to the target. Since no targets are provided, this argument is
                 kept for API compatibility. Default: ``None``.
 

--- a/src/torch_uncertainty/datasets/kitti.py
+++ b/src/torch_uncertainty/datasets/kitti.py
@@ -64,7 +64,7 @@ class KITTIDepth(VisionDataset):
                 smaller than or equal to this threshold are set to NaN.
             max_depth (float, default=80.0): Maximum valid depth value (in meters). Depth values
                 greater than this threshold are set to NaN.
-            transforms (Callable, optional): A function/transform that takes an ``(image, target)``
+            transforms (Callable): A function/transform that takes an ``(image, target)``
                 pair and returns the transformed pair.
             download (bool, default=False): If True, downloads and restructures the depth
                 annotations and raw KITTI data if not already present.

--- a/src/torch_uncertainty/datasets/muad.py
+++ b/src/torch_uncertainty/datasets/muad.py
@@ -121,21 +121,21 @@ class MUAD(VisionDataset):
         Args:
             root (str | Path): Root directory of dataset where directory ``leftImg8bit`` and ``leftLabel``
                 or ``leftDepth`` are located.
-            split (str, optional): The image split to use, ``train``, ``val``, ``test`` or ``ood``.
-            version (str, optional): The version of the dataset to use, ``small`` or ``full``.
+            split (str): The image split to use, ``train``, ``val``, ``test`` or ``ood``.
+            version (str): The version of the dataset to use, ``small`` or ``full``.
                 Defaults to ``full``.
-            min_depth (float, optional): The maximum depth value to use if target_type is ``depth``.
+            min_depth (float): The maximum depth value to use if target_type is ``depth``.
                 Defaults to ``None``.
-            max_depth (float, optional): The maximum depth value to use if target_type is ``depth``.
+            max_depth (float): The maximum depth value to use if target_type is ``depth``.
                 Defaults to ``None``.
-            target_type (str, optional): The type of target to use, ``semantic`` or ``depth``.
+            target_type (str): The type of target to use, ``semantic`` or ``depth``.
                 Defaults to ``semantic``.
-            transforms (callable, optional): A function/transform that takes in a tuple of PIL
+            transforms (callable): A function/transform that takes in a tuple of PIL
                 images and returns a transformed version. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the internet and puts
+            download (bool): If ``True``, downloads the dataset from the internet and puts
                 it in root directory. If dataset is already downloaded, it is not downloaded again.
                 Defaults to ``False``.
-            use_train_ids (bool, optional): If ``True``, uses the train ids instead of the original
+            use_train_ids (bool): If ``True``, uses the train ids instead of the original
                 ids. Defaults to ``True``. Note that this is only used for the ``semantic`` target
                 type.
 

--- a/src/torch_uncertainty/datasets/regression/toy.py
+++ b/src/torch_uncertainty/datasets/regression/toy.py
@@ -14,13 +14,13 @@ class Cubic(TensorDataset):
         """A dataset of samples drawn from the cube fct. with homoscedastic noise.
 
         Args:
-            lower_bound (float, optional): Lower bound of the samples. Defaults to
+            lower_bound (float): Lower bound of the samples. Defaults to
                 ``-4.0``.
-            upper_bound (float, optional): Upper bound of the samples. Defaults to
+            upper_bound (float): Upper bound of the samples. Defaults to
                 ``4.0``.
-            num_samples (int, optional): Number of samples. Defaults to ``5000``.
-            noise_mean (float, optional): Mean of the noise. Defaults to ``0.0``.
-            noise_std (float, optional): Standard deviation of the noise. Defaults
+            num_samples (int): Number of samples. Defaults to ``5000``.
+            noise_mean (float): Mean of the noise. Defaults to ``0.0``.
+            noise_std (float): Standard deviation of the noise. Defaults
                 to ``3.0``.
         """
         noise = (noise_mean, noise_std)

--- a/src/torch_uncertainty/datasets/regression/uci_regression.py
+++ b/src/torch_uncertainty/datasets/regression/uci_regression.py
@@ -117,20 +117,20 @@ class UCIRegression(Dataset):
 
         Args:
             root (str): Root directory of the datasets.
-            transform (callable, optional): A function/transform that takes in a
+            transform (callable): A function/transform that takes in a
                 numpy array and returns a transformed version. Defaults to ``None``.
-            target_transform (callable, optional): A function/transform that takes
+            target_transform (callable): A function/transform that takes
                 in the target and transforms it. Defaults to ``None``.
-            dataset_name (str, optional): The name of the dataset. One of
+            dataset_name (str): The name of the dataset. One of
                 ``boston-housing``, ``concrete``, ``energy``, ``kin8nm``,
                 ``naval-propulsion-plant``, ``power-plant``, ``protein``,
                 ``wine-quality-red``, and ``yacht``. Defaults to ``energy``.
-            download (bool, optional): If ``True``, downloads the dataset from the
+            download (bool): If ``True``, downloads the dataset from the
                 internet and puts it in root directory. If dataset is already
                 downloaded, it is not downloaded again. Defaults to ``False``.
-            seed (int, optional): The random seed for shuffling the dataset.
+            seed (int): The random seed for shuffling the dataset.
                 Defaults to ``42``.
-            shuffle (bool, optional): If ``True``, shuffles the dataset.
+            shuffle (bool): If ``True``, shuffles the dataset.
                 Defaults to ``True``.
 
         Note:

--- a/src/torch_uncertainty/datasets/segmentation/camvid.py
+++ b/src/torch_uncertainty/datasets/segmentation/camvid.py
@@ -119,10 +119,10 @@ class CamVid(VisionDataset):
 
         Args:
             root (str | Path): Root directory of dataset where ``camvid/`` exists or will be saved to if download is set to ``True``.
-            group_classes (bool, optional): Whether to group the 32 classes into 11 superclasses. Defaults to ``True``.
-            split (str, optional): The dataset split, supports ``train``, ``val`` and ``test``. Defaults to ``None``.
-            transforms (callable, optional): A function/transform that takes input sample and its target as entry and returns a transformed version. Defaults to ``None``.
-            download (bool, optional): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
+            group_classes (bool): Whether to group the 32 classes into 11 superclasses. Defaults to ``True``.
+            split (str): The dataset split, supports ``train``, ``val`` and ``test``. Defaults to ``None``.
+            transforms (callable): A function/transform that takes input sample and its target as entry and returns a transformed version. Defaults to ``None``.
+            download (bool): If ``True``, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
                 Defaults to ``False``.
         """
         if split not in ["train", "val", "test", None]:

--- a/src/torch_uncertainty/datasets/segmentation/cityscapes.py
+++ b/src/torch_uncertainty/datasets/segmentation/cityscapes.py
@@ -60,15 +60,15 @@ class Cityscapes(TVCityscapes):
 
         Args:
             root (str): Root directory of the Cityscapes dataset.
-            split (str, optional): Dataset split to use, such as "train", "val", or "test".
-            mode (str, optional): Annotation mode, e.g., "fine" or "coarse".
-            target_type (list[str] | str, optional):
+            split (str): Dataset split to use, such as "train", "val", or "test".
+            mode (str): Annotation mode, e.g., "fine" or "coarse".
+            target_type (list[str] | str):
                 One or more target types to load ("instance", "semantic", etc.).
-            transform (Callable[..., Any] | None, optional):
+            transform (Callable[..., Any] | None):
                 Transformation applied to the input image.
-            target_transform (Callable[..., Any] | None, optional):
+            target_transform (Callable[..., Any] | None):
                 Transformation applied to the target.
-            transforms (Callable[..., Any] | None, optional):
+            transforms (Callable[..., Any] | None):
                 Combined transformation for image and target.
 
         """

--- a/src/torch_uncertainty/datasets/utils.py
+++ b/src/torch_uncertainty/datasets/utils.py
@@ -15,7 +15,7 @@ def create_train_val_split(
     Args:
         dataset (Dataset): The dataset to be split.
         val_split_rate (float): The amount of the original dataset to use as validation split.
-        val_transforms (Callable | None, optional): The transformations to apply on the validation set.
+        val_transforms (Callable | None): The transformations to apply on the validation set.
             Defaults to ``None``.
 
     Returns:

--- a/src/torch_uncertainty/layers/batch_ensemble.py
+++ b/src/torch_uncertainty/layers/batch_ensemble.py
@@ -39,11 +39,11 @@ class BatchLinear(nn.Module):
             out_features (int): Number of output features.
             num_estimators (int): Number of estimators in the ensemble, referred as
                 :math:`M`.
-            bias (bool, optional): If ``True``, adds a learnable bias to the
+            bias (bool): If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            device (Any, optional): Device to use for the parameters and
+            device (Any): Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any, optional): Data type to use for the parameters and
+            dtype (Any): Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
 
         Reference:
@@ -249,19 +249,19 @@ class BatchConv1d(nn.Module):
             kernel_size (int): Size of the convolving kernel.
             num_estimators (int): Number of estimators in the ensemble referred as
                 :math:`M` here.
-            stride (int, optional): Stride of the convolution. Defaults to
+            stride (int): Stride of the convolution. Defaults to
                 ``1``.
-            padding (int or str, optional): Padding added to all four sides
+            padding (int or str): Padding added to all four sides
                 of the input. Defaults to ``0``.
-            dilation (int, optional): Spacing between kernel elements.
+            dilation (int): Spacing between kernel elements.
                 Defaults to ``1``.
-            groups (int, optional): Number of blocked connections from input
+            groups (int): Number of blocked connections from input
                 channels to output channels. Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the
+            bias (bool): If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            device (Any, optional): Device to use for the parameters and
+            device (Any): Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any, optional): Data type to use for the parameters and
+            dtype (Any): Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
 
         Attributes:
@@ -481,19 +481,19 @@ class BatchConv2d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             num_estimators (int): Number of estimators in the ensemble referred as
                 :math:`M` here.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to
+            stride (int or tuple): Stride of the convolution. Defaults to
                 ``1``.
-            padding (int, tuple or str, optional): Padding added to all four sides
+            padding (int, tuple or str): Padding added to all four sides
                 of the input. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements.
+            dilation (int or tuple): Spacing between kernel elements.
                 Defaults to ``1``.
-            groups (int, optional): Number of blocked connections from input
+            groups (int): Number of blocked connections from input
                 channels to output channels. Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the
+            bias (bool): If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            device (Any, optional): Device to use for the parameters and
+            device (Any): Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any, optional): Data type to use for the parameters and
+            dtype (Any): Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
 
         Attributes:
@@ -673,20 +673,20 @@ class BatchConvTranspose2d(nn.Module):
             kernel_size (_size_2_t): Size of the convolving kernel.
             num_estimators (int): Number of estimators in the ensemble referred as
                 :math:`M` here.
-            stride (_size_2_t, optional): Stride of the convolution. Defaults to ``1``.
-            padding (_size_2_t, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding
+            stride (_size_2_t): Stride of the convolution. Defaults to ``1``.
+            padding (_size_2_t): ``dilation * (kernel_size - 1) - padding`` zero-padding
                 will be added to both sides of each dimension in the input. Defaults to ``0``.
-            output_padding (_size_2_t, optional): Additional size added to one side
+            output_padding (_size_2_t): Additional size added to one side
                 of each dimension in the output shape. Defaults to ``0``.
-            groups (int, optional): Number of blocked connections from input channels to output
+            groups (int): Number of blocked connections from input channels to output
                 channels. Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to
                 ``True``.
-            dilation (_size_2_t, optional): Spacing between kernel elements. Defaults to ``1``.
-            padding_mode (str, optional): Padding mode for the convolution. Defaults to ``"zeros"``.
-            device (Any, optional): Device to use for the parameters and
+            dilation (_size_2_t): Spacing between kernel elements. Defaults to ``1``.
+            padding_mode (str): Padding mode for the convolution. Defaults to ``"zeros"``.
+            device (Any): Device to use for the parameters and
                 buffers of this module. Defaults to ``None``.
-            dtype (Any, optional): Data type to use for the parameters and
+            dtype (Any): Data type to use for the parameters and
                 buffers of this module. Defaults to ``None``.
         """
         factory_kwargs = {"device": device, "dtype": dtype}

--- a/src/torch_uncertainty/layers/bayesian/bayes_linear.py
+++ b/src/torch_uncertainty/layers/bayesian/bayes_linear.py
@@ -33,13 +33,13 @@ class BayesLinear(nn.Module):
         Args:
             in_features (int): Number of input features
             out_features (int): Number of output features
-            prior_sigma_1 (float, optional): Standard deviation of the first prior distribution. Defaults to ``0.1``.
-            prior_sigma_2 (float, optional): Standard deviation of the second prior distribution. Defaults to ``0.4``.
-            prior_pi (float, optional): Mixture control variable. Defaults to ``1``.
-            mu_init (float, optional): Initial mean of the posterior distribution. Defaults to ``0.0``.
-            sigma_init (float, optional): Initial standard deviation of the posterior distribution. Defaults to ``-7.0``.
-            frozen (bool, optional): Whether to freeze the posterior distribution. Defaults to ``False``.
-            bias (bool, optional): Whether to use a bias term. Defaults to ``True.``
+            prior_sigma_1 (float): Standard deviation of the first prior distribution. Defaults to ``0.1``.
+            prior_sigma_2 (float): Standard deviation of the second prior distribution. Defaults to ``0.4``.
+            prior_pi (float): Mixture control variable. Defaults to ``1``.
+            mu_init (float): Initial mean of the posterior distribution. Defaults to ``0.0``.
+            sigma_init (float): Initial standard deviation of the posterior distribution. Defaults to ``-7.0``.
+            frozen (bool): Whether to freeze the posterior distribution. Defaults to ``False``.
+            bias (bool): Whether to use a bias term. Defaults to ``True.``
             device (optional): Device to use. Defaults to ``None``.
             dtype (optional): Data type to use. Defaults to ``None``.
 

--- a/src/torch_uncertainty/layers/bayesian/lpbnn.py
+++ b/src/torch_uncertainty/layers/bayesian/lpbnn.py
@@ -171,9 +171,9 @@ class LPBNNConv2d(nn.Module):
             out_channels (int): Number of output channels.
             num_estimators (int): Number of models to sample from.
             kernel_size (int or tuple): Size of the convolving kernel.
-            stride (int or tuple, optional): Stride of the convolution. Default: ``1``.
-            padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: ``0``.
-            groups (int, optional): Number of blocked connections from input channels to output channels. Default: ``1``.
+            stride (int or tuple): Stride of the convolution. Default: ``1``.
+            padding (int or tuple): Zero-padding added to both sides of the input. Default: ``0``.
+            groups (int): Number of blocked connections from input channels to output channels. Default: ``1``.
             hidden_size (int): Size of the hidden layer. Defaults to ``32``.
             std_factor (float): Factor to multiply the standard deviation of the latent noise. Defaults to ``1e-2``.
             gamma (bool): If ``True``, adds a learnable gamma to the output. Defaults to ``True``.

--- a/src/torch_uncertainty/layers/filter_response_norm.py
+++ b/src/torch_uncertainty/layers/filter_response_norm.py
@@ -16,7 +16,7 @@ class _FilterResponseNormNd(nn.Module):
         Args:
             dimension (int): Dimension of the input tensor.
             num_channels (int): Number of channels.
-            eps (float, optional): Epsilon. Defaults to 1e-6.
+            eps (float): Epsilon. Defaults to 1e-6.
             device (optional): Device. Defaults to None.
             dtype (optional): Data type. Defaults to None.
         """
@@ -51,7 +51,7 @@ class FilterResponseNorm1d(_FilterResponseNormNd):
 
         Args:
             num_channels (int): Number of channels.
-            eps (float, optional): Epsilon. Defaults to 1e-6.
+            eps (float): Epsilon. Defaults to 1e-6.
             device (optional): Device. Defaults to None.
             dtype (optional): Data type. Defaults to None.
         """
@@ -70,7 +70,7 @@ class FilterResponseNorm2d(_FilterResponseNormNd):
 
         Args:
             num_channels (int): Number of channels.
-            eps (float, optional): Epsilon. Defaults to 1e-6.
+            eps (float): Epsilon. Defaults to 1e-6.
             device (optional): Device. Defaults to None.
             dtype (optional): Data type. Defaults to None.
         """
@@ -89,7 +89,7 @@ class FilterResponseNorm3d(_FilterResponseNormNd):
 
         Args:
             num_channels (int): Number of channels.
-            eps (float, optional): Epsilon. Defaults to 1e-6.
+            eps (float): Epsilon. Defaults to 1e-6.
             device (optional): Device. Defaults to None.
             dtype (optional): Data type. Defaults to None.
         """

--- a/src/torch_uncertainty/layers/functional/packed.py
+++ b/src/torch_uncertainty/layers/functional/packed.py
@@ -25,8 +25,8 @@ def packed_linear(
             - "sparse": uses a sparse weight tensor directly to apply the linear transformation.
             - "einsum": uses `torch.einsum` to apply the packed linear transformation.
             - "conv1d": uses `torch.nn.functional.conv1d` to apply the packed linear transformation.
-        rearrange (bool, optional): _description_. Defaults to True.
-        bias (Tensor | None, optional): _description_. Defaults to None.
+        rearrange (bool): _description_. Defaults to True.
+        bias (Tensor | None): _description_. Defaults to None.
 
     Returns:
         Tensor:
@@ -206,7 +206,7 @@ def packed_multi_head_attention_forward(  # noqa: D417
                        value sequences at dim=1.
         dropout_p: probability of an element to be zeroed.
         out_proj_weight, out_proj_bias: the output projection weight and bias.
-        implementation (str, optional): the implementation of the packed linear operation. Three
+        implementation (str): the implementation of the packed linear operation. Three
             implementations are currently supported:
             - ``"full"``: creates a block diagonal matrix from the weight tensor and applies the
                 linear transformation using `torch.nn.functional.linear`.

--- a/src/torch_uncertainty/layers/masksembles.py
+++ b/src/torch_uncertainty/layers/masksembles.py
@@ -177,10 +177,10 @@ class MaskedLinear(nn.Module):
             out_features (int): Number of channels produced by the linear layer.
             num_estimators (int): The number of estimators grouped in the layer.
             scale (float): The scale parameter for the masks.
-            bias (bool, optional): It ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            groups (int, optional): Number of blocked connections from input channels to output channels. Defaults to ``1``.
-            device (Any, optional): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any, optional): The desired data type of returned tensor. Defaults to ``None``.
+            bias (bool): It ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            groups (int): Number of blocked connections from input channels to output channels. Defaults to ``1``.
+            device (Any): The desired device of returned tensor. Defaults to ``None``.
+            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training
@@ -235,13 +235,13 @@ class MaskedConv2d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             num_estimators (int): Number of estimators in the ensemble.
             scale (float): The scale parameter for the masks.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int, tuple or str, optional): Padding added to all four sides of the input. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            groups (int, optional): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            device (Any, optional): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any, optional): The desired data type of returned tensor. Defaults to ``None``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int, tuple or str): Padding added to all four sides of the input. Defaults to ``0``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            groups (int): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            device (Any): The desired device of returned tensor. Defaults to ``None``.
+            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training
@@ -305,15 +305,15 @@ class MaskedConvTranspose2d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             num_estimators (int): Number of estimators in the ensemble.
             scale (float): The scale parameter for the masks.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int or tuple, optional): Padding added to all four sides of the input. Defaults to ``0``.
-            output_padding (int, tuple or str, optional): Additional size added to one side of each dimension in the output shape. Defaults to ``0``.
-            groups (int, optional): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            padding_mode (str, optional): _description_. Defaults to ``'zeros'``.
-            device (Any, optional): The desired device of returned tensor. Defaults to ``None``.
-            dtype (Any, optional): The desired data type of returned tensor. Defaults to ``None``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int or tuple): Padding added to all four sides of the input. Defaults to ``0``.
+            output_padding (int, tuple or str): Additional size added to one side of each dimension in the output shape. Defaults to ``0``.
+            groups (int): Number of blocked connexions from input channels to output channels for each estimator. Defaults to ``1``.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            padding_mode (str): _description_. Defaults to ``'zeros'``.
+            device (Any): The desired device of returned tensor. Defaults to ``None``.
+            dtype (Any): The desired data type of returned tensor. Defaults to ``None``.
 
         Warning:
             Be sure to apply a repeat on the batch at the start of the training

--- a/src/torch_uncertainty/layers/mc_batch_norm.py
+++ b/src/torch_uncertainty/layers/mc_batch_norm.py
@@ -20,10 +20,10 @@ class _MCBatchNorm(_BatchNorm):
         Args:
             num_features (int): number of input features.
             num_estimators (int): number of stochastic estimators.
-            eps (float, optional): eps arg. for the core batch normalization. Defaults to ``0.00001``.
-            affine (bool, optional): affine arg. for the core batch normalization. Defaults to `True`.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to ``None``.
-            device (Literal["cpu", "cuda"] | torch.device | None, optional): device.
+            eps (float): eps arg. for the core batch normalization. Defaults to ``0.00001``.
+            affine (bool): affine arg. for the core batch normalization. Defaults to `True`.
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
+            device (Literal["cpu", "cuda"] | torch.device | None): device.
                 Defaults to ``None``
 
         Warning:
@@ -107,8 +107,8 @@ class MCBatchNorm1d(_MCBatchNorm):
     Args:
         num_features (int): Number of features.
         num_estimators (int): Number of estimators.
-        eps (float, optional): Epsilon. Defaults to ``0.00001``.
-        affine (bool, optional): Affine. Defaults to ``True``.
+        eps (float): Epsilon. Defaults to ``0.00001``.
+        affine (bool): Affine. Defaults to ``True``.
         device (optional): Device. Defaults to ``None``.
         dtype (optional): Data type. Defaults to ``None``.
 
@@ -134,8 +134,8 @@ class MCBatchNorm2d(_MCBatchNorm):
     Args:
         num_features (int): Number of features.
         num_estimators (int): Number of estimators.
-        eps (float, optional): Epsilon. Defaults to ``0.00001``.
-        affine (bool, optional): Affine. Defaults to ``True``.
+        eps (float): Epsilon. Defaults to ``0.00001``.
+        affine (bool): Affine. Defaults to ``True``.
         device (optional): Device. Defaults to ``None``.
         dtype (optional): Data type. Defaults to ``None``.
 
@@ -161,8 +161,8 @@ class MCBatchNorm3d(_MCBatchNorm):
     Args:
         num_features (int): Number of features.
         num_estimators (int): Number of estimators.
-        eps (float, optional): Epsilon. Defaults to ``0.00001``.
-        affine (bool, optional): Affine. Defaults to ``True``.
+        eps (float): Epsilon. Defaults to ``0.00001``.
+        affine (bool): Affine. Defaults to ``True``.
         device (optional): Device. Defaults to ``None``.
         dtype (optional): Data type. Defaults to ``None``.
 

--- a/src/torch_uncertainty/layers/packed.py
+++ b/src/torch_uncertainty/layers/packed.py
@@ -63,22 +63,22 @@ class PackedLinear(nn.Module):
             out_features (int): Number of channels produced by the linear layer.
             alpha (float): The width multiplier of the linear layer.
             num_estimators (int): The number of estimators grouped in the layer.
-            gamma (int, optional): Defaults to ``1``.
-            bias (bool, optional): If ``True``, adds a learnable bias to the
+            gamma (int): Defaults to ``1``.
+            bias (bool): If ``True``, adds a learnable bias to the
                 output. Defaults to ``True``.
-            first (bool, optional): Whether this is the first layer of the
+            first (bool): Whether this is the first layer of the
                 network. Defaults to ``False``.
-            last (bool, optional): Whether this is the last layer of the network.
+            last (bool): Whether this is the last layer of the network.
                 Defaults to ``False``.
-            implementation (str, optional): The implementation to use. Available implementations:
+            implementation (str): The implementation to use. Available implementations:
 
                 - ``"conv1d"``: The conv1d implementation of the linear layer.
                 - ``"sparse"``: The sparse implementation of the linear layer.
                 - ``"full"``: The full implementation of the linear layer.
                 - ``"einsum"`` (default): The einsum implementation of the linear layer.
-            device (torch.device, optional): The device to use for the layer's
+            device (torch.device): The device to use for the layer's
                 parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's
+            dtype (torch.dtype): The dtype to use for the layer's
                 parameters. Defaults to ``None``.
 
         Shape:
@@ -220,20 +220,20 @@ class PackedConv1d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             alpha (int): The channel multiplier of the convolutional layer.
             num_estimators (int): Number of estimators in the ensemble.
-            gamma (int, optional): Defaults to ``1``.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int, tuple or str, optional): Padding added to both sides of the input. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            groups (int, optional): Number of blocked connexions from input
+            gamma (int): Defaults to ``1``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int, tuple or str): Padding added to both sides of the input. Defaults to ``0``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            groups (int): Number of blocked connexions from input
             channels to output channels for each estimator. Defaults to ``1``.
-            minimum_channels_per_group (int, optional): Smallest possible number of channels per group.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str, optional): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device, optional): The device to use for the layer's
+            minimum_channels_per_group (int): Smallest possible number of channels per group.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
+            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
+            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
+            device (torch.device): The device to use for the layer's
             parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's
+            dtype (torch.dtype): The dtype to use for the layer's
             parameters. Defaults to ``None``.
 
         Shape:
@@ -358,20 +358,20 @@ class PackedConv2d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             alpha (int): The channel multiplier of the convolutional layer.
             num_estimators (int): Number of estimators in the ensemble.
-            gamma (int, optional): Defaults to ``1``.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int, tuple or str, optional): Padding added to all four sides of the input. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            groups (int, optional): Number of blocked connexions from input channels to output channels for each
+            gamma (int): Defaults to ``1``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int, tuple or str): Padding added to all four sides of the input. Defaults to ``0``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            groups (int): Number of blocked connexions from input channels to output channels for each
                 estimator. Defaults to ``1``.
-            minimum_channels_per_group (int, optional): Smallest possible number of channels per group.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str, optional): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults
+            minimum_channels_per_group (int): Smallest possible number of channels per group.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults
                 to ``'zeros'``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to ``None``.
+            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
+            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
+            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input:
@@ -496,19 +496,19 @@ class PackedConv3d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             alpha (int): The channel multiplier of the convolutional layer.
             num_estimators (int): Number of estimators in the ensemble.
-            gamma (int, optional): Defaults to ``1``.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int, tuple or str, optional): Padding added to all six sides of the input. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            groups (int, optional): Number of blocked connexions from input
+            gamma (int): Defaults to ``1``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int, tuple or str): Padding added to all six sides of the input. Defaults to ``0``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            groups (int): Number of blocked connexions from input
             channels to output channels for each estimator. Defaults to ``1``.
-            minimum_channels_per_group (int, optional): Smallest possible number of channels per group.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            padding_mode (str, optional): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to ``None``.
+            minimum_channels_per_group (int): Smallest possible number of channels per group.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            padding_mode (str): ``'zeros'``, ``'reflect'``,``'replicate'`` or ``'circular'``. Defaults to ``'zeros'``.
+            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
+            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
+            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input:
@@ -634,18 +634,18 @@ class PackedConvTranspose2d(nn.Module):
             kernel_size (int or tuple): Size of the convolving kernel.
             alpha (int): The channel multiplier for the layer.
             num_estimators (int): Number of estimators in the ensemble.
-            gamma (int, optional): Defaults to ``1``.
-            stride (int or tuple, optional): Stride of the convolution. Defaults to ``1``.
-            padding (int or tuple, optional): Zero-padding added to both sides of the input. Defaults to ``0``.
-            output_padding (int or tuple, optional): Additional size added to one side of the output shape. Defaults to ``0``.
-            dilation (int or tuple, optional): Spacing between kernel elements. Defaults to ``1``.
-            groups (int, optional): Number of blocked connections from input channels to output channels. Defaults to ``1``.
-            minimum_channels_per_group (int, optional): Smallest possible number of channels per group.
-            bias (bool, optional): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to ``None``.
+            gamma (int): Defaults to ``1``.
+            stride (int or tuple): Stride of the convolution. Defaults to ``1``.
+            padding (int or tuple): Zero-padding added to both sides of the input. Defaults to ``0``.
+            output_padding (int or tuple): Additional size added to one side of the output shape. Defaults to ``0``.
+            dilation (int or tuple): Spacing between kernel elements. Defaults to ``1``.
+            groups (int): Number of blocked connections from input channels to output channels. Defaults to ``1``.
+            minimum_channels_per_group (int): Smallest possible number of channels per group.
+            bias (bool): If ``True``, adds a learnable bias to the output. Defaults to ``True``.
+            first (bool): Whether this is the first layer of the network. Defaults to ``False``.
+            last (bool): Whether this is the last layer of the network. Defaults to ``False``.
+            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
         """
         check_packed_parameters_consistency(alpha, gamma, num_estimators)
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -735,12 +735,12 @@ class PackedLayerNorm(nn.GroupNorm):
             embed_dim (int): the number of features in the input tensor.
             num_estimators (int): the number of estimators in the ensemble.
             alpha (float): the width multiplier of the layer.
-            eps (float, optional): a value added to the denominator for numerical stability. Defaults to 1e-5.
-            affine (bool, optional): a boolean value that when set to ``True``, this module has learnable per_channel affine parameters initialized to ones (for weights) and zeros (for biases). Defaults to ``True``.
-            first (bool, optional): Whether this layer processes the raw inputs of the model. Defaults to ``False``.
-            last (bool, optional): Whether this layer processes the final outputs of the model. Defaults to ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to ``None``.
+            eps (float): a value added to the denominator for numerical stability. Defaults to 1e-5.
+            affine (bool): a boolean value that when set to ``True``, this module has learnable per_channel affine parameters initialized to ones (for weights) and zeros (for biases). Defaults to ``True``.
+            first (bool): Whether this layer processes the raw inputs of the model. Defaults to ``False``.
+            last (bool): Whether this layer processes the final outputs of the model. Defaults to ``False``.
+            device (torch.device): The device to use for the layer's parameters. Defaults to ``None``.
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to ``None``.
 
         Shape:
             - Input: :math:`(N, *)` where :math:`*` means any number of additional dimensions.
@@ -807,28 +807,28 @@ class PackedMultiheadAttention(nn.Module):
             num_heads (int): Number of parallel attention heads.
             alpha (float): The width multiplier of the embedding dimension.
             num_estimators (int): The number of estimators packed in the layer.
-            gamma (int, optional): Defaults to ``1``.
-            dropout (float, optional): Dropout probability on ``attn_output_weights``. Defaults to ``0.0``
+            gamma (int): Defaults to ``1``.
+            dropout (float): Dropout probability on ``attn_output_weights``. Defaults to ``0.0``
                 (no dropout).
-            bias (bool, optional): If specified, adds bias to input / output projection layers.
+            bias (bool): If specified, adds bias to input / output projection layers.
                 Defaults to ``True``.
-            add_bias_kv (bool, optional): If specified, adds bias to the key and value sequences at
+            add_bias_kv (bool): If specified, adds bias to the key and value sequences at
                 ``dim=0``. Defaults to ``False``.
-            add_zero_attn (bool, optional): If specified, adds a new batch of zeros to the key and
+            add_zero_attn (bool): If specified, adds a new batch of zeros to the key and
                 value sequences at ``dim=1``. Defaults to ``False``.
-            kdim (int | None, optional): Total number of features for keys. Defaults to ``None``
+            kdim (int | None): Total number of features for keys. Defaults to ``None``
                 (uses ``kdim=embed_dim``).
-            vdim (int | None, optional): Total number of features for values. Defaults to ``None``
+            vdim (int | None): Total number of features for values. Defaults to ``None``
                 (uses ``vdim=embed_dim``).
-            batch_first (bool, optional): If ``True``, then the input and output tensors are provided
+            batch_first (bool): If ``True``, then the input and output tensors are provided
                 as (batch, seq, feature). Defaults to ``False`` (seq, batch, feature).
-            first (bool, optional): Whether this is the first layer of the network. Defaults to
+            first (bool): Whether this is the first layer of the network. Defaults to
                 ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to
+            last (bool): Whether this is the last layer of the network. Defaults to
                 ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults
+            device (torch.device): The device to use for the layer's parameters. Defaults
                 to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
                 ``None``.
 
         Reference:
@@ -988,18 +988,18 @@ class PackedMultiheadAttention(nn.Module):
                 :math:`(S, B, E_v)` when ``batch_first=False`` or :math:`(B, S, E_v)` when
                 ``batch_first=True``, where :math:`S` is the source sequence length, :math:`B` is
                 the batch size and :math:`E_v` is the value embedding dimension ``vdim``.
-            key_padding_mask (Tensor | None, optional): If specified, a mask of shape
+            key_padding_mask (Tensor | None): If specified, a mask of shape
                 :math:`(B, S)` indicating which elements within ``key`` to ignore for the purpose
                 of attention (i.e. treat as "padding"). For unbatched `query`, shape should be
                 :math:`(S)`. Binary and float masks are supported. For a binary mask, a ``True``
                 value indicates that the corresponding ``key`` value will be ignored for the
                 purpose of attention. For a float mask, it will be directly added to the
                 corresponding ``key`` value. Defaults to ``None``.
-            need_weights (bool, optional): If specified, returns ``attn_output_weights`` in
+            need_weights (bool): If specified, returns ``attn_output_weights`` in
                 addition to ``attn_outputs``. Set ``need_weights=False`` to use the optimized
                 ``scale_dot_product_attention`` and achieve the best performance for MHA.
                 Defaults to ``False``.
-            attn_mask (Tensor | None, optional): If specified, a 2D or 3D mask preventing attention
+            attn_mask (Tensor | None): If specified, a 2D or 3D mask preventing attention
                 to certain positions. Must be of shape :math:`(L,S)` or
                 :math:`(B \times \text{num_heads}, L, S)`, where :math:`B` is the batch size, :math:`L`
                 is the target sequence length, and :math:`S` is the source sequence length. A 2D mask
@@ -1009,11 +1009,11 @@ class PackedMultiheadAttention(nn.Module):
                 For a float mask, the mask values will be added to the attention weight. If both
                 ``attn_mask`` and ``key_padding_mask`` are provided, their types should match.
                 Defaults to ``None``.
-            average_attn_weights (bool, optional): If ``True``, indicates that the returned
+            average_attn_weights (bool): If ``True``, indicates that the returned
                 ``attn_weights`` should be averaged across heads. Otherwise, ``attn_weights`` are
                 provided separately per head. Note that this flag only has an effect when
                 ``need_weights=True``. Defaults to ``True``.
-            is_causal (bool, optional): If specified, applies a causal mask as ``attn_mask``.
+            is_causal (bool): If specified, applies a causal mask as ``attn_mask``.
                 Defaults to ``False``.
 
         Warning:
@@ -1153,29 +1153,29 @@ class PackedTransformerEncoderLayer(nn.Module):
             nhead (int): the number of heads in the multiheadattention models.
             alpha (float): the width multiplier of the layer.
             num_estimators (int): the number of estimators packed in the layer.
-            gamma (int, optional): Defaults to ``1``.
-            dim_feedforward (int, optional): the dimension of the feedforward network model. Defaults
+            gamma (int): Defaults to ``1``.
+            dim_feedforward (int): the dimension of the feedforward network model. Defaults
                 to ``2048``.
-            dropout (float, optional): the dropout value. Defaults to ``0.1``.
-            activation (Callable[[Tensor], Tensor], optional): the activation function of the
+            dropout (float): the dropout value. Defaults to ``0.1``.
+            activation (Callable[[Tensor], Tensor]): the activation function of the
                 intermediate layer, that is a unary callable. Defaults to ``F.relu``.
-            layer_norm_eps (float, optional): the eps value in layer normalization components. Defaults
+            layer_norm_eps (float): the eps value in layer normalization components. Defaults
                 to ``1e-5``.
-            bias (bool, optional): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
+            bias (bool): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
                 additive bias. Defaults to ``True``.
-            batch_first (bool, optional): If ``True``, then the input and output tensors are provided
+            batch_first (bool): If ``True``, then the input and output tensors are provided
                 as :math:`(\text{batch}, \text{seq}, \text{d_model})`. Defaults to ``False``
                 :math:`(\text{seq}, \text{batch}, \text{d_model})`.
-            norm_first (bool, optional): If ``True``, the layer norm is done prior to attention and
+            norm_first (bool): If ``True``, the layer norm is done prior to attention and
                 feedforward operations, respectively. Otherwise, it is done after. Defaults to
                 ``False``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to
+            first (bool): Whether this is the first layer of the network. Defaults to
                 ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to
+            last (bool): Whether this is the last layer of the network. Defaults to
                 ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults
+            device (torch.device): The device to use for the layer's parameters. Defaults
                 to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
                 ``None``.
 
         Reference:
@@ -1265,10 +1265,10 @@ class PackedTransformerEncoderLayer(nn.Module):
         Args:
             src (Tensor): The sequence to the encoder layer. Shape: :math:`(B, L, E)` or
                 :math:`(L, B, E)`.
-            src_mask (Tensor | None, optional): The mask for the ``src`` sequence. Defaults to ``None``.
-            src_key_padding_mask (Tensor | None, optional): The mask for the ``src`` keys per
+            src_mask (Tensor | None): The mask for the ``src`` sequence. Defaults to ``None``.
+            src_key_padding_mask (Tensor | None): The mask for the ``src`` keys per
                 batch. Defaults to ``None``.
-            is_causal (bool, optional): If specified, applies a causal mask as ``src_mask``.
+            is_causal (bool): If specified, applies a causal mask as ``src_mask``.
                 Defaults to ``False``. Warning: ``is_causal`` provides a hint the ``src_mask`` is
                 a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.
@@ -1364,29 +1364,29 @@ class PackedTransformerDecoderLayer(nn.Module):
             nhead (int): the number of heads in the multiheadattention models.
             alpha (float): the width multiplier of the layer.
             num_estimators (int): the number of estimators packed in the layer.
-            gamma (int, optional): Defaults to ``1``.
-            dim_feedforward (int, optional): the dimension of the feedforward network model. Defaults
+            gamma (int): Defaults to ``1``.
+            dim_feedforward (int): the dimension of the feedforward network model. Defaults
                 to ``2048``.
-            dropout (float, optional): the dropout value. Defaults to ``0.1``.
-            activation (Callable[[Tensor], Tensor], optional): the activation function of the
+            dropout (float): the dropout value. Defaults to ``0.1``.
+            activation (Callable[[Tensor], Tensor]): the activation function of the
                 intermediate layer, that is a unary callable. Defaults to ``F.relu``.
-            layer_norm_eps (float, optional): the eps value in layer normalization components. Defaults
+            layer_norm_eps (float): the eps value in layer normalization components. Defaults
                 to ``1e-5``.
-            bias (bool, optional): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
+            bias (bool): If ``False``, ``Linear`` and ``LayerNorm`` layers will not learn an
                 additive bias. Defaults to ``True``.
-            batch_first (bool, optional): If ``True``, then the input and output tensors are provided
+            batch_first (bool): If ``True``, then the input and output tensors are provided
                 as :math:`(\text{batch}, \text{seq}, \text{d_model})`. Defaults to ``False``
                 :math:`(\text{seq}, \text{batch}, \text{d_model})`.
-            norm_first (bool, optional): If ``True``, the layer norm is done prior to attention and
+            norm_first (bool): If ``True``, the layer norm is done prior to attention and
                 feedforward operations, respectively. Otherwise, it is done after. Defaults to
                 ``False``.
-            first (bool, optional): Whether this is the first layer of the network. Defaults to
+            first (bool): Whether this is the first layer of the network. Defaults to
                 ``False``.
-            last (bool, optional): Whether this is the last layer of the network. Defaults to
+            last (bool): Whether this is the last layer of the network. Defaults to
                 ``False``.
-            device (torch.device, optional): The device to use for the layer's parameters. Defaults
+            device (torch.device): The device to use for the layer's parameters. Defaults
                 to ``None``.
-            dtype (torch.dtype, optional): The dtype to use for the layer's parameters. Defaults to
+            dtype (torch.dtype): The dtype to use for the layer's parameters. Defaults to
                 ``None``.
 
         Reference:
@@ -1503,19 +1503,19 @@ class PackedTransformerDecoderLayer(nn.Module):
                 :math:`(L, B, E)`.
             memory (Tensor): The sequence from the last layer of the encoder. Shape:
                 :math:`(B, S, E)` or :math:`(S, B, E)`.
-            tgt_mask (Tensor | None, optional): The mask for the ``tgt`` sequence. Defaults to
+            tgt_mask (Tensor | None): The mask for the ``tgt`` sequence. Defaults to
                 ``None``.
-            memory_mask (Tensor | None, optional): The mask for the ``memory`` sequence. Defaults
+            memory_mask (Tensor | None): The mask for the ``memory`` sequence. Defaults
                 to ``None``.
-            tgt_key_padding_mask (Tensor | None, optional): The mask for the ``tgt`` keys per
+            tgt_key_padding_mask (Tensor | None): The mask for the ``tgt`` keys per
                 batch. Defaults to ``None``.
-            memory_key_padding_mask (Tensor | None, optional): The mask for the ``memory`` keys per
+            memory_key_padding_mask (Tensor | None): The mask for the ``memory`` keys per
                 batch. Defaults to ``None``.
-            tgt_is_causal (bool, optional): If specified, applies a causal mask as ``tgt_mask``.
+            tgt_is_causal (bool): If specified, applies a causal mask as ``tgt_mask``.
                 Defaults to ``False``. Warning: ``tgt_is_causal`` provides a hint the ``tgt_mask``
                 is a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.
-            memory_is_causal (bool, optional): If specified, applies a causal mask as ``memory_mask``.
+            memory_is_causal (bool): If specified, applies a causal mask as ``memory_mask``.
                 Defaults to ``False``. Warning: ``memory_is_causal`` provides a hint the ``memory_mask``
                 is a causal mask. Providing incorrect hints can result in incorrect execution,
                 including forward and backward compatibility.

--- a/src/torch_uncertainty/losses/bayesian.py
+++ b/src/torch_uncertainty/losses/bayesian.py
@@ -53,7 +53,7 @@ class ELBOLoss(nn.Module):
             inner_loss (nn.Module): The loss function to use during training
             kl_weight (float): The weight of the KL divergence term
             num_samples (int): The number of samples to use for the ELBO loss
-            dist_family (str, optional): The distribution family to use for the output of the
+            dist_family (str): The distribution family to use for the output of the
                 model. ``None`` means point-wise prediction. Defaults to ``None``.
 
         Note:

--- a/src/torch_uncertainty/losses/classification.py
+++ b/src/torch_uncertainty/losses/classification.py
@@ -18,9 +18,9 @@ class DECLoss(nn.Module):
                 regularization term. Defaults to None.
             reg_weight (float | None): Fixed weight of the regularization term.
                 Defaults to None.
-            loss_type (str, optional): Specifies the loss type to apply to the
+            loss_type (str): Specifies the loss type to apply to the
                 Dirichlet parameters: ``'mse'`` | ``'log'`` | ``'digamma'``.
-            reduction (str, optional): Specifies the reduction to apply to the
+            reduction (str): Specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:
@@ -175,10 +175,10 @@ class ConfidencePenaltyLoss(nn.Module):
         """The Confidence Penalty Loss.
 
         Args:
-            reg_weight (float, optional): The weight of the regularization term.
-            reduction (str, optional): specifies the reduction to apply to the
+            reg_weight (float): The weight of the regularization term.
+            reduction (str): specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``. Defaults to "mean".
-            eps (float, optional): A small value to avoid numerical instability.
+            eps (float): A small value to avoid numerical instability.
                 Defaults to ``1e-6.``
 
         References:
@@ -233,8 +233,8 @@ class ConflictualLoss(nn.Module):
         r"""The Conflictual Loss.
 
         Args:
-            reg_weight (float, optional): The weight of the regularization term.
-            reduction (str, optional): specifies the reduction to apply to the
+            reg_weight (float): The weight of the regularization term.
+            reduction (str): specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:
@@ -286,9 +286,9 @@ class FocalLoss(nn.Module):
         """Focal-Loss for classification tasks.
 
         Args:
-            gamma (float, optional): A constant, as described in the paper.
-            alpha (Tensor, optional): Weights for each class. Defaults to ``None``.
-            reduction (str, optional): ``'mean'``, ``'sum'`` or ``'none'``. Defaults to ``'mean'``.
+            gamma (float): A constant, as described in the paper.
+            alpha (Tensor): Weights for each class. Defaults to ``None``.
+            reduction (str): ``'mean'``, ``'sum'`` or ``'none'``. Defaults to ``'mean'``.
 
         References:
             [1] `Lin, T.-Y., Goyal, P., Girshick, R., He, K., & Dollár, P. (2017). Focal Loss for Dense Object Detection.
@@ -344,15 +344,15 @@ class BCEWithLogitsLSLoss(nn.BCEWithLogitsLoss):
         the BCEWithLogitsLoss.
 
         Args:
-            weight (Tensor, optional): A manual rescaling weight given to the
+            weight (Tensor): A manual rescaling weight given to the
                 loss of each batch element. If given, has to be a Tensor of size
                 "nbatch". Defaults to ``None``.
-            reduction (str, optional): Specifies the reduction to apply to the
+            reduction (str): Specifies the reduction to apply to the
                 output: ``'none'`` | ``'mean'`` | ``'sum``'. ``'none'``: no reduction will be applied,
                 ``'mean'``: the sum of the output will be divided by the number of
                 elements in the output, ``'sum'``: the output will be summed. Defaults
                 to ``'mean'``.
-            label_smoothing (float, optional): The label smoothing factor. Defaults
+            label_smoothing (float): The label smoothing factor. Defaults
                 to ``0.0``.
         """
         super().__init__(weight=weight, reduction=reduction)

--- a/src/torch_uncertainty/losses/regression.py
+++ b/src/torch_uncertainty/losses/regression.py
@@ -12,7 +12,7 @@ class DistributionNLLLoss(nn.Module):
         """Negative Log-Likelihood loss using given distributions as inputs.
 
         Args:
-            reduction (str, optional): specifies the reduction to apply to the
+            reduction (str): specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``. Defaults to "mean".
         """
         super().__init__()
@@ -29,7 +29,7 @@ class DistributionNLLLoss(nn.Module):
         Args:
             dist (Distribution): The predicted distributions
             targets (Tensor): The target values
-            padding_mask (Tensor, optional): The padding mask. Defaults to ``None.``
+            padding_mask (Tensor): The padding mask. Defaults to ``None.``
                 Sets the loss to ``0`` for padded values.
         """
         loss = -dist.log_prob(targets)
@@ -52,7 +52,7 @@ class DERLoss(DistributionNLLLoss):
 
         Args:
             reg_weight (float): The weight of the regularization term.
-            reduction (str, optional): specifies the reduction to apply to the
+            reduction (str): specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:
@@ -109,7 +109,7 @@ class BetaNLL(nn.Module):
             beta (float): Parameter from range [0, 1] controlling relative
                 weighting between data points, where `0` corresponds to
                 high weight on low error points and `1` to an equal weighting.
-            reduction (str, optional): specifies the reduction to apply to the
+            reduction (str): specifies the reduction to apply to the
                 output:``'none'`` | ``'mean'`` | ``'sum'``.
 
         References:

--- a/src/torch_uncertainty/methods/batch_ensemble.py
+++ b/src/torch_uncertainty/methods/batch_ensemble.py
@@ -133,10 +133,10 @@ def batch_ensemble(
     Args:
         core_model (nn.Module): model to wrap
         num_estimators (int): number of ensemble members
-        repeat_training_inputs (bool, optional): whether to repeat the input batch during training.
+        repeat_training_inputs (bool): whether to repeat the input batch during training.
             If ``True``, the input batch is repeated during both training and evaluation. If ``False``,
             the input batch is repeated only during evaluation. Default is ``False``.
-        convert_layers (bool, optional): whether to convert the model's layers to BatchEnsemble layers.
+        convert_layers (bool): whether to convert the model's layers to BatchEnsemble layers.
             If ``True``, the wrapper will convert all ``nn.Linear`` and ``nn.Conv2d`` layers to their
             BatchEnsemble counterparts. Default is ``False``.
 

--- a/src/torch_uncertainty/methods/mc_dropout.py
+++ b/src/torch_uncertainty/methods/mc_dropout.py
@@ -54,7 +54,7 @@ class _MCDropout(nn.Module):
         selected dropout modules.
 
         Args:
-            mode (bool, optional): whether to set the module to training
+            mode (bool): whether to set the module to training
                 mode. Defaults to True.
         """
         if not isinstance(mode, bool):
@@ -158,9 +158,9 @@ def mc_dropout(
 
     Args:
         core_model (nn.Module): model to wrap
-        num_estimators (int): number of estimators to use last_layer (bool, optional): whether to apply dropout to the last layer only. Defaults to ``False``.
+        num_estimators (int): number of estimators to use last_layer (bool): whether to apply dropout to the last layer only. Defaults to ``False``.
         on_batch (bool): Increase the batch_size to perform MC-Dropout. Otherwise in a for loop to reduce memory footprint. Defaults to ``True``.
-        last_layer (bool, optional): whether to apply dropout to the last layer only. Defaults to ``False``.
+        last_layer (bool): whether to apply dropout to the last layer only. Defaults to ``False``.
         task (Literal[``"classification"``, ``"regression"``, ``"segmentation"``, ``"pixel_regression"``]): The model task. Defaults to ``"classification"``.
         probabilistic (bool): Whether the regression model is probabilistic.
 

--- a/src/torch_uncertainty/methods/swag.py
+++ b/src/torch_uncertainty/methods/swag.py
@@ -39,11 +39,11 @@ class SWAG(SWA):
             core_model (nn.Module): PyTorch model to be trained.
             cycle_start (int): Begininning of the first SWAG averaging cycle.
             cycle_length (int): Number of epochs between SWAG updates. The first update occurs at :attr:`cycle_start` + :attr:`cycle_length`.
-            scale (float, optional): Scale of the Gaussian. Defaults to ``1.0``.
-            diag_covariance (bool, optional): Whether to use a diagonal covariance. Defaults to ``False``.
-            max_num_models (int, optional): Maximum number of models to store. Defaults to ``0``.
-            var_clamp (float, optional): Minimum variance. Defaults to ``1e-30``.
-            num_estimators (int, optional): Number of posterior estimates to use. Defaults to ``16``.
+            scale (float): Scale of the Gaussian. Defaults to ``1.0``.
+            diag_covariance (bool): Whether to use a diagonal covariance. Defaults to ``False``.
+            max_num_models (int): Maximum number of models to store. Defaults to ``0``.
+            var_clamp (float): Minimum variance. Defaults to ``1e-30``.
+            num_estimators (int): Number of posterior estimates to use. Defaults to ``16``.
 
         References:
             [1] `A simple baseline for bayesian uncertainty in deep learning. In NeurIPS 2019
@@ -160,11 +160,11 @@ class SWAG(SWA):
 
         Args:
             scale (float): Rescale coefficient of the Gaussian.
-            diag_covariance (bool, optional): Whether to use a diagonal
+            diag_covariance (bool): Whether to use a diagonal
                 covariance. Defaults to None.
-            block (bool, optional): Whether to sample a block diagonal
+            block (bool): Whether to sample a block diagonal
                 covariance. Defaults to False.
-            seed (int, optional): Random seed. Defaults to None.
+            seed (int): Random seed. Defaults to None.
 
         Returns:
             nn.Module: Sampled model.

--- a/src/torch_uncertainty/metrics/classification/brier_score.py
+++ b/src/torch_uncertainty/metrics/classification/brier_score.py
@@ -31,9 +31,9 @@ class BrierScore(Metric):
 
         Args:
             num_classes (int): Number of classes.
-            top_class (bool, optional): If True, computes the Brier score for the
+            top_class (bool): If True, computes the Brier score for the
                 top predicted class only. Defaults to ``False``.
-            reduction (str, optional): Determines how to reduce the score across the
+            reduction (str): Determines how to reduce the score across the
                 batch dimension:
 
                 - ``'mean'`` [default]: Averages the score across samples.

--- a/src/torch_uncertainty/metrics/classification/calibration/adaptive_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/adaptive_calibration_error.py
@@ -199,11 +199,11 @@ class AdaptiveCalibrationError:
 
         Args:
             task (str): Specifies the task type, either ``"binary"`` or ``"multiclass"``.
-            num_bins (int, optional): Number of bins to divide the probability space. Defaults to ``10``.
-            norm (str, optional): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``. Defaults to ``"l1"``.
-            num_classes (int, optional): Number of classes for ``"multiclass"`` tasks. Required when task is ``"multiclass"``.
-            ignore_index (int, optional): Index to ignore during calculations. Defaults to ``None``.
-            validate_args (bool, optional): Whether to validate input arguments. Defaults to ``True``.
+            num_bins (int): Number of bins to divide the probability space. Defaults to ``10``.
+            norm (str): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``. Defaults to ``"l1"``.
+            num_classes (int): Number of classes for ``"multiclass"`` tasks. Required when task is ``"multiclass"``.
+            ignore_index (int): Index to ignore during calculations. Defaults to ``None``.
+            validate_args (bool): Whether to validate input arguments. Defaults to ``True``.
             **kwargs (Any): Additional keyword arguments passed to the metric.
 
         Example:

--- a/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
@@ -300,14 +300,14 @@ class CalibrationError:
 
         Args:
             task (str): Specifies the task type, either ``"binary"`` or ``"multiclass"``.
-            adaptive (bool, optional): Whether to use adaptive binning. Defaults to ``False``.
-            num_bins (int, optional): Number of bins to divide the probability space. Defaults to ``10``.
-            norm (str, optional): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
+            adaptive (bool): Whether to use adaptive binning. Defaults to ``False``.
+            num_bins (int): Number of bins to divide the probability space. Defaults to ``10``.
+            norm (str): Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
                 Defaults to ``"l1"``.
-            num_classes (int, optional): Number of classes for ``"multiclass"`` tasks. Required when task
+            num_classes (int): Number of classes for ``"multiclass"`` tasks. Required when task
                 is ``"multiclass"``.
-            ignore_index (int, optional): Index to ignore during calculations. Defaults to ``None``.
-            validate_args (bool, optional): Whether to validate input arguments. Defaults to ``True``.
+            ignore_index (int): Index to ignore during calculations. Defaults to ``None``.
+            validate_args (bool): Whether to validate input arguments. Defaults to ``True``.
             **kwargs: Additional keyword arguments for the metric.
 
         Example:

--- a/src/torch_uncertainty/metrics/classification/calibration/classwise_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/classwise_calibration_error.py
@@ -34,7 +34,7 @@ class ClasswiseCalibrationError(Metric):
 
         Args:
             num_classes (int): Number of classes.
-            num_bins (int, optional): Number of calibration bins. Defaults to ``15``.
+            num_bins (int): Number of calibration bins. Defaults to ``15``.
             norm (Literal["l1", "l2", "max"]): Norm used to compute the ECE (e.g., ``'l1'``,
                 ``'l2'``, ``'max'``). Defaults to ``'l1'``.
             reduction (Literal["mean", "sum", "none"] | None): Determines how to reduce the score across the

--- a/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/smooth_calibration_error.py
@@ -36,22 +36,22 @@ class SmoothCalibrationError(Metric):
         bandwidth selection strategy. Computed on the top label.
 
         Args:
-            kernel_type (str, optional): The kernel to use. Choose between:
+            kernel_type (str): The kernel to use. Choose between:
                 - ``'logit'``: Applies a Gaussian kernel in log-odds space. This
                     effectively uses an adaptive bandwidth that is narrower near 1.0,
                     making it ideal for modern overconfident models. (Default)
                 - ``'reflected'``: Applies a Gaussian kernel in probability space
                     with reflections at 0 and 1 to prevent boundary bias.
                 Note that relplot's original implementation has ``'reflected'`` as default.
-            bandwidth (Literal[auto] | float, optional): The kernel bandwidth $h$. If set to
+            bandwidth (Literal[auto] | float): The kernel bandwidth $h$. If set to
                 ``'auto'``, it uses a fixed-point binary search to find a bandwidth
                 consistent with the error level. Defaults to ``'auto'``.
-            eps (float, optional): The tolerance for the binary search when
+            eps (float): The tolerance for the binary search when
                 bandwidth is ``'auto'``. Defaults to ``0.001``.
-            mesh_pts (int, optional): The base number of points for the grid
+            mesh_pts (int): The base number of points for the grid
                 discretization. The actual number may be higher depending on the
                 bandwidth. Defaults to ``200``.
-            refine_steps (int, optional): Number of binary search iterations for
+            refine_steps (int): Number of binary search iterations for
                 the ``'auto'`` bandwidth. Defaults to ``10``.
             **kwargs: Additional arguments for the :class:`torchmetrics.Metric` base.
 

--- a/src/torch_uncertainty/metrics/classification/categorical_nll.py
+++ b/src/torch_uncertainty/metrics/classification/categorical_nll.py
@@ -34,7 +34,7 @@ class CategoricalNLL(Metric):
         of sample :math:`i`.
 
         Args:
-            reduction (str, optional): Determines how to reduce the computed loss over
+            reduction (str): Determines how to reduce the computed loss over
                 the batch dimension:
 
                 - ``'mean'`` [default]: Averages the loss across samples in the batch.

--- a/src/torch_uncertainty/metrics/classification/coverage_rate.py
+++ b/src/torch_uncertainty/metrics/classification/coverage_rate.py
@@ -23,15 +23,15 @@ class CoverageRate(Metric):
         """Empirical coverage rate metric.
 
         Args:
-            num_classes (int | None, optional): Number of classes. Defaults to ``None``.
-            average (str, optional): Defines the reduction that is applied over labels. Should be
+            num_classes (int | None): Number of classes. Defaults to ``None``.
+            average (str): Defines the reduction that is applied over labels. Should be
                 one of the following:
 
                 - ``'macro'`` (default): Compute the metric for each class separately and find their
                   unweighted mean. This does not take label imbalance into account.
                 - ``'micro'``: Sum statistics across over all labels.
 
-            validate_args (bool, optional): Whether to validate the arguments. Defaults to ``True``.
+            validate_args (bool): Whether to validate the arguments. Defaults to ``True``.
             kwargs: Additional keyword arguments, see `Advanced metric settings
                 <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
 

--- a/src/torch_uncertainty/metrics/classification/disagreement.py
+++ b/src/torch_uncertainty/metrics/classification/disagreement.py
@@ -26,7 +26,7 @@ class Disagreement(Metric):
         estimators.
 
         Args:
-            reduction (str, optional): Determines how to reduce over the :math:`B`/batch dimension:
+            reduction (str): Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples

--- a/src/torch_uncertainty/metrics/classification/entropy.py
+++ b/src/torch_uncertainty/metrics/classification/entropy.py
@@ -23,7 +23,7 @@ class Entropy(Metric):
         or the mean confidence across estimators.
 
         Args:
-            reduction (str, optional): Determines how to reduce over the
+            reduction (str): Determines how to reduce over the
                 :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples

--- a/src/torch_uncertainty/metrics/classification/mutual_information.py
+++ b/src/torch_uncertainty/metrics/classification/mutual_information.py
@@ -25,7 +25,7 @@ class MutualInformation(Metric):
         ensemble of estimators.
 
         Args:
-            reduction (str, optional): Determines how to reduce over the :math:`B`/batch dimension:
+            reduction (str): Determines how to reduce over the :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples

--- a/src/torch_uncertainty/metrics/classification/risk_coverage.py
+++ b/src/torch_uncertainty/metrics/classification/risk_coverage.py
@@ -113,11 +113,11 @@ class AURC(Metric):
         ``update``.
 
         Args:
-            ax (Axes | None, optional): An matplotlib axis object. If provided
+            ax (Axes | None): An matplotlib axis object. If provided
                 will add plot to this axis. Defaults to None.
-            plot_value (bool, optional): Whether to print the AURC value on the
+            plot_value (bool): Whether to print the AURC value on the
                 plot. Defaults to True.
-            name (str | None, optional): Name of the model. Defaults to None.
+            name (str | None): Name of the model. Defaults to None.
 
         Returns:
             tuple[[Figure | None], Axes]: Figure object and Axes object
@@ -237,11 +237,11 @@ class AUGRC(AURC):
         ``update``.
 
         Args:
-            ax (Axes | None, optional): An matplotlib axis object. If provided
+            ax (Axes | None): An matplotlib axis object. If provided
                 will add plot to this axis. Defaults to None.
-            plot_value (bool, optional): Whether to print the AURC value on the
+            plot_value (bool): Whether to print the AURC value on the
                 plot. Defaults to True.
-            name (str | None, optional): Name of the model. Defaults to None.
+            name (str | None): Name of the model. Defaults to None.
 
         Returns:
             tuple[[Figure | None], Axes]: Figure object and Axes object

--- a/src/torch_uncertainty/metrics/classification/set_size.py
+++ b/src/torch_uncertainty/metrics/classification/set_size.py
@@ -23,7 +23,7 @@ class SetSize(Metric):
         """Set size to compute the efficiency of conformal prediction methods.
 
         Args:
-            reduction (str, optional): Determines how to reduce over the
+            reduction (str): Determines how to reduce over the
                 :math:`B`/batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples

--- a/src/torch_uncertainty/metrics/classification/variation_ratio.py
+++ b/src/torch_uncertainty/metrics/classification/variation_ratio.py
@@ -27,8 +27,8 @@ class VariationRatio(Metric):
         predicted class labels that are not the chosen (most frequent) class.
 
         Args:
-            probabilistic (bool, optional): Whether to use probabilistic predictions. Defaults to True.
-            reduction (Literal["mean", "sum", "none", None], optional): Determines how to reduce over the batch dimension:
+            probabilistic (bool): Whether to use probabilistic predictions. Defaults to True.
+            reduction (Literal["mean", "sum", "none", None]): Determines how to reduce over the batch dimension:
 
                 - ``'mean'`` [default]: Averages score across samples
                 - ``'sum'``: Sum score across samples

--- a/src/torch_uncertainty/metrics/regression/nll.py
+++ b/src/torch_uncertainty/metrics/regression/nll.py
@@ -16,7 +16,7 @@ class DistributionNLL(CategoricalNLL):
         Args:
             dist (torch.distributions.Distribution): Predicted distributions.
             target (Tensor): Ground truth labels.
-            padding_mask (Tensor, optional): The padding mask. Defaults to None.
+            padding_mask (Tensor): The padding mask. Defaults to None.
                 Sets the loss to 0 for padded values.
         """
         nlog_prob = -dist.log_prob(target)

--- a/src/torch_uncertainty/metrics/regression/quantile_calibration.py
+++ b/src/torch_uncertainty/metrics/regression/quantile_calibration.py
@@ -34,10 +34,10 @@ class QuantileCalibrationError(BinaryCalibrationError):
         against the ground truth values.
 
         Args:
-            num_bins (int, optional): Number of bins to use for calibration. Defaults to `15`.
-            norm (str, optional): Norm to use for calibration error computation. Defaults to `"l1"`.
-            ignore_index (int, optional): Index to ignore during calibration. Defaults to `None`.
-            validate_args (bool, optional): Whether to validate the input arguments. Defaults to `True`.
+            num_bins (int): Number of bins to use for calibration. Defaults to `15`.
+            norm (str): Norm to use for calibration error computation. Defaults to `"l1"`.
+            ignore_index (int): Index to ignore during calibration. Defaults to `None`.
+            validate_args (bool): Whether to validate the input arguments. Defaults to `True`.
             kwargs: Additional keyword arguments, see `Advanced metric settings
               <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
         """
@@ -55,7 +55,7 @@ class QuantileCalibrationError(BinaryCalibrationError):
         Args:
             dist (Distribution): The predicted distribution.
             target (Tensor): The ground truth values.
-            padding_mask (Tensor | None, optional): A mask to ignore certain values. Defaults to `None`.
+            padding_mask (Tensor | None): A mask to ignore certain values. Defaults to `None`.
         """
         reduce_event_dims = False
         if isinstance(dist, Independent):

--- a/src/torch_uncertainty/metrics/segmentation/mean_iou.py
+++ b/src/torch_uncertainty/metrics/segmentation/mean_iou.py
@@ -20,12 +20,12 @@ class MeanIntersectionOverUnion(MulticlassStatScores):
 
         Args:
             num_classes (int): Integer specifying the number of classes.
-            top_k (int, optional): Number of highest probability or logit score predictions
+            top_k (int): Number of highest probability or logit score predictions
                 considered to find the correct label. Only works when ``preds`` contain
                 probabilities/logits. Defaults to ``1``.
-            ignore_index (int | None, optional): Specifies a target value that is ignored and does
+            ignore_index (int | None): Specifies a target value that is ignored and does
                 not contribute to the metric calculation. Defaults to ``None``.
-            validate_args (bool, optional): Bool indicating if input arguments and tensors should
+            validate_args (bool): Bool indicating if input arguments and tensors should
                 be validated for correctness. Set to ``False`` for faster computations. Defaults to
                 ``True``.
             **kwargs: kwargs: Additional keyword arguments, see

--- a/src/torch_uncertainty/metrics/sparsification.py
+++ b/src/torch_uncertainty/metrics/sparsification.py
@@ -93,11 +93,11 @@ class AUSE(Metric):
         ``update``, and the oracle sparsification curve.
 
         Args:
-            ax (Axes | None, optional): An matplotlib axis object. If provided
+            ax (Axes | None): An matplotlib axis object. If provided
                 will add plot to this axis. Defaults to None.
-            plot_oracle (bool, optional): Whether to plot the oracle
+            plot_oracle (bool): Whether to plot the oracle
                 sparsification curve. Defaults to True.
-            plot_value (bool, optional): Whether to plot the AUSE value.
+            plot_value (bool): Whether to plot the AUSE value.
                 Defaults to True.
 
         Returns:

--- a/src/torch_uncertainty/models/classification/inception_time/batched.py
+++ b/src/torch_uncertainty/models/classification/inception_time/batched.py
@@ -159,7 +159,7 @@ def batched_inception_time(
         num_blocks (int): Number of inception blocks. Default is ``6``.
         dropout (float): Dropout rate. Default is ``0.0``.
         residual (bool): Whether to use residual connections. Default is ``True``.
-        repeat_strategy ("legacy"|"paper", optional): The repeat
+        repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training

--- a/src/torch_uncertainty/models/classification/resnet/batched.py
+++ b/src/torch_uncertainty/models/classification/resnet/batched.py
@@ -331,8 +331,8 @@ def batched_resnet(
         groups (int): Number of groups within each estimator.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module, optional): Normalization layer.
-        repeat_strategy (Literal["legacy", "paper"], optional): The repeatrepeat_strategy ("legacy"|"paper", optional): The repeat
+        normalization_layer (nn.Module): Normalization layer.
+        repeat_strategy (Literal["legacy", "paper"]): The repeatrepeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training

--- a/src/torch_uncertainty/models/classification/resnet/masked.py
+++ b/src/torch_uncertainty/models/classification/resnet/masked.py
@@ -351,8 +351,8 @@ def masked_resnet(
         dropout_rate (float): Dropout rate. Defaults to ``0``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module, optional): Normalization layer.
-        repeat_strategy ("legacy"|"paper", optional): The repeat
+        normalization_layer (nn.Module): Normalization layer.
+        repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training

--- a/src/torch_uncertainty/models/classification/resnet/mimo.py
+++ b/src/torch_uncertainty/models/classification/resnet/mimo.py
@@ -69,13 +69,13 @@ def mimo_resnet(
         num_classes (int): Number of classes to predict.
         arch (int): The architecture of the ResNet.
         num_estimators (int): Number of estimators in the ensemble.
-        conv_bias (bool, optional): Whether to use bias in convolutional layers. Defaults to ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
-        width_multiplier (float, optional): Width multiplier. Defaults to ``1.0``.
-        groups (int, optional): Number of groups for grouped convolution. Defaults to ``1``.
+        conv_bias (bool): Whether to use bias in convolutional layers. Defaults to ``True``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
+        width_multiplier (float): Width multiplier. Defaults to ``1.0``.
+        groups (int): Number of groups for grouped convolution. Defaults to ``1``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/resnet/packed.py
+++ b/src/torch_uncertainty/models/classification/resnet/packed.py
@@ -412,9 +412,9 @@ def packed_resnet(
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
         normalization_layer (nn.Module): Normalization layer. Defaults to ``nn.BatchNorm2d``.
-        pretrained (bool, optional): Whether to load pretrained weights.
+        pretrained (bool): Whether to load pretrained weights.
             Defaults to ``False``.
-        linear_implementation (str, optional): Implementation of the
+        linear_implementation (str): Implementation of the
             packed linear layer. Defaults to ``"conv1d"``.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/resnet/std.py
+++ b/src/torch_uncertainty/models/classification/resnet/std.py
@@ -367,9 +367,9 @@ def resnet(
         groups (int): Number of groups in convolutions. Defaults to 1.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/wideresnet/batched.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/batched.py
@@ -251,16 +251,16 @@ def batched_wideresnet28x10(
         num_estimators (int): Number of estimators in the ensemble.
         conv_bias (bool): Whether to use bias in convolutions. Defaults to
             ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.3``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
         num_classes (int): Number of classes to predict.
         groups (int): Number of groups in the convolutions. Defaults to ``1``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
-        repeat_strategy ("legacy"|"paper", optional): The repeat
+        repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both training

--- a/src/torch_uncertainty/models/classification/wideresnet/masked.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/masked.py
@@ -259,16 +259,16 @@ def masked_wideresnet28x10(
         scale (float): Expansion factor affecting the width of the estimators.
         conv_bias (bool): Whether to use bias in convolutions. Defaults to
             ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.3``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
         groups (int): Number of groups within each estimator. Defaults to
             ``1``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
-        repeat_strategy ("legacy"|"paper", optional): The repeat
+        repeat_strategy ("legacy"|"paper"): The repeat
             strategy to use during training:
 
             - "legacy": Repeat inputs for each estimator during both

--- a/src/torch_uncertainty/models/classification/wideresnet/mimo.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/mimo.py
@@ -70,12 +70,12 @@ def mimo_wideresnet28x10(
         groups (int): Number of subgroups in the convolutions.
         conv_bias (bool): Whether to use bias in convolutions. Defaults to
             ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.3``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/wideresnet/packed.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/packed.py
@@ -275,12 +275,12 @@ def packed_wideresnet28x10(
         groups (int): Number of subgroups in the convolutions.
         conv_bias (bool): Whether to use bias in convolutions. Defaults to
             ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.3``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:

--- a/src/torch_uncertainty/models/classification/wideresnet/std.py
+++ b/src/torch_uncertainty/models/classification/wideresnet/std.py
@@ -224,16 +224,16 @@ def wideresnet28x10(
     Args:
         in_channels (int): Number of input channels
         num_classes (int): Number of classes to predict.
-        groups (int, optional): Number of groups in convolutions. Defaults to
+        groups (int): Number of groups in convolutions. Defaults to
             ``1``.
         conv_bias (bool): Whether to use bias in convolutions. Defaults to
             ``True``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.3``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.3``.
         style (ResNetStyle | Literal["imagenet", "cifar"]): Whether to use the ImageNet or CIFAR
             structure. Defaults to ``ResNetStyle.IMAGENET``.
-        activation_fn (Callable, optional): Activation function. Defaults to
+        activation_fn (Callable): Activation function. Defaults to
             ``torch.nn.functional.relu``.
-        normalization_layer (nn.Module, optional): Normalization layer.
+        normalization_layer (nn.Module): Normalization layer.
             Defaults to ``torch.nn.BatchNorm2d``.
 
     Returns:

--- a/src/torch_uncertainty/models/depth/bts.py
+++ b/src/torch_uncertainty/models/depth/bts.py
@@ -322,7 +322,7 @@ class BTSDecoder(nn.Module):
             max_depth (float): The maximum predicted depth.
             feat_out_channels (list[int]): The number of output channels from the backbone.
             num_features (int): The number of features to use in the decoder.
-            dist_family (str | None, optional): The distribution family name. ``None`` means point-wise
+            dist_family (str | None): The distribution family name. ``None`` means point-wise
             prediction. Defaults to ``None``.
         """
         super().__init__()

--- a/src/torch_uncertainty/models/mlp.py
+++ b/src/torch_uncertainty/models/mlp.py
@@ -36,10 +36,10 @@ class _MLP(nn.Module):
             activation (Callable): Activation function.
             layer_args (Dict): Arguments for the layer class.
             dropout_rate (float): Dropout probability.
-            dist_family (str, optional): Distribution family name. ``None`` means point-wise
+            dist_family (str): Distribution family name. ``None`` means point-wise
                 prediction.
-            dist_args (Dict, optional): Arguments for the distribution layer class.
-            flatten_start_dim (int, optional): Dimension to start flattening the input.
+            dist_args (Dict): Arguments for the distribution layer class.
+            flatten_start_dim (int): Dimension to start flattening the input.
         """
         super().__init__()
         self.activation = activation
@@ -197,13 +197,13 @@ def mlp(
         in_features (int): Number of input features.
         num_outputs (int): Number of output features.
         hidden_dims (list[int]): Number of features in each hidden layer.
-        activation (Callable, optional): Activation function. Defaults to
+        activation (Callable): Activation function. Defaults to
             ``F.relu``.
-        dropout_rate (float, optional): Dropout probability. Defaults to ``0.0``.
-        dist_family (str, optional): Distribution family. Defaults to ``None``.
-        dist_args (Dict, optional): Arguments for the distribution layer class. Defaults
+        dropout_rate (float): Dropout probability. Defaults to ``0.0``.
+        dist_family (str): Distribution family. Defaults to ``None``.
+        dist_args (Dict): Arguments for the distribution layer class. Defaults
             to ``None``.
-        flatten_start_dim (int, optional): Dimension to start flattening the input.
+        flatten_start_dim (int): Dimension to start flattening the input.
             Defaults to ``-1``.
 
     Returns:

--- a/src/torch_uncertainty/models/segmentation/deeplab.py
+++ b/src/torch_uncertainty/models/segmentation/deeplab.py
@@ -27,10 +27,10 @@ class SeparableConv2d(nn.Module):
             in_channels (int): Number of input channels.
             out_channels (int): Number of output channels.
             kernel_size (_size_2_t): Kernel size.
-            stride (_size_2_t, optional): Stride. Defaults to 1.
-            padding (_size_2_t, optional): Padding. Defaults to 0.
-            dilation (_size_2_t, optional): Dilation. Defaults to 1.
-            bias (bool, optional): Use biases. Defaults to True.
+            stride (_size_2_t): Stride. Defaults to 1.
+            padding (_size_2_t): Padding. Defaults to 0.
+            dilation (_size_2_t): Dilation. Defaults to 1.
+            bias (bool): Use biases. Defaults to True.
         """
         super().__init__()
         self.separable = nn.Conv2d(
@@ -205,10 +205,10 @@ class DeepLabV3Decoder(nn.Module):
     Args:
         in_channels (int): Number of channels of the input latent space.
         num_classes (int): Number of classes.
-        aspp_dilate (list[int], optional): Atrous rates for the ASPP module.
-        separable (bool, optional): Use separable convolutions to reduce the number
+        aspp_dilate (list[int]): Atrous rates for the ASPP module.
+        separable (bool): Use separable convolutions to reduce the number
             of parameters. Defaults to False.
-        dropout_rate (float, optional): Dropout rate of the ASPP. Defaults to 0.1.
+        dropout_rate (float): Dropout rate of the ASPP. Defaults to 0.1.
     """
 
     conv: nn.Module
@@ -256,7 +256,7 @@ class DeepLabV3PlusDecoder(nn.Module):
             aspp_dilate (list[int]): Atrous rates for the ASPP module.
             separable (bool): Use separable convolutions to reduce the number
                 of parameters.
-            dropout_rate (float, optional): Dropout rate of the ASPP. Defaults
+            dropout_rate (float): Dropout rate of the ASPP. Defaults
                 to 0.1.
         """
         super().__init__()
@@ -305,12 +305,12 @@ class _DeepLabV3(nn.Module):
             backbone_name (Literal["resnet50", "resnet101"]): Backbone name.
             style (Literal["v3", "v3+"]):  Whether to use a DeepLab V3 or
                 V3+ model.
-            output_stride (int, optional): Output stride. Defaults to 16.
-            separable (bool, optional): Use separable convolutions. Defaults
+            output_stride (int): Output stride. Defaults to 16.
+            separable (bool): Use separable convolutions. Defaults
                 to False.
-            pretrained_backbone (bool, optional): Use pretrained backbone.
+            pretrained_backbone (bool): Use pretrained backbone.
                 Defaults to True.
-            norm_momentum (float, optional): BatchNorm momentum. Defaults to
+            norm_momentum (float): BatchNorm momentum. Defaults to
                 0.01.
 
         References:
@@ -372,10 +372,10 @@ def deep_lab_v3_resnet(
         num_classes (int): Number of classes.
         arch (int): Number of layers of the underlying ResNet model: 50 or 101.
         style (Literal["v3", "v3+"]): Whether to use a DeepLab V3 or V3+ model.
-        output_stride (int, optional): Output stride. Defaults to 16.
-        separable (bool, optional): Use separable convolutions. Defaults to
+        output_stride (int): Output stride. Defaults to 16.
+        separable (bool): Use separable convolutions. Defaults to
             False.
-        pretrained_backbone (bool, optional): Use pretrained backbone. Defaults
+        pretrained_backbone (bool): Use pretrained backbone. Defaults
             to True.
     """
     return _DeepLabV3(

--- a/src/torch_uncertainty/models/segmentation/unet/batched.py
+++ b/src/torch_uncertainty/models/segmentation/unet/batched.py
@@ -22,7 +22,7 @@ class _DoubleConv(nn.Module):
             in_channels (int): Number of input channels.
             out_channels (int): Number of output channels.
             num_estimators (int): Number of estimators.
-            mid_channels (int | None, optional): Number of intermediate channels.
+            mid_channels (int | None): Number of intermediate channels.
                 If ``None``, defaults to :attr:`out_channels`. Defaults to ``None``.
         """
         super().__init__()
@@ -118,9 +118,9 @@ class _BatchedUNet(nn.Module):
             num_classes (int): Number of output classes.
             num_blocks (list[int]): Number of channels in each layer of the U-Net.
             num_estimators (int): Number of estimators.
-            bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+            bilinear (bool): If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. Defaults to ``False``.
-            dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+            dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
@@ -191,9 +191,9 @@ def _batched_unet(
         num_classes (int): Number of output classes.
         num_blocks (list[int]): Number of channels in each layer of the U-Net.
         num_estimators (int): Number of estimators.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Batched U-Net model.
@@ -221,9 +221,9 @@ def batched_small_unet(
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
         num_estimators (int): Number of estimators.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Small Batched U-Net model.
@@ -252,9 +252,9 @@ def batched_unet(
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
         num_estimators (int): Number of estimators.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _BatchedUNet: Batched U-Net model.

--- a/src/torch_uncertainty/models/segmentation/unet/masked.py
+++ b/src/torch_uncertainty/models/segmentation/unet/masked.py
@@ -24,7 +24,7 @@ class _DoubleConv(nn.Module):
             out_channels (int): Number of output channels.
             num_estimators (int): Number of estimators.
             scale (float): Scale for the MaskedConv2d layer.
-            mid_channels (int | None, optional): Number of intermediate channels.
+            mid_channels (int | None): Number of intermediate channels.
                 If ``None``, defaults to :attr:`out_channels`. Defaults to ``None``.
         """
         super().__init__()
@@ -130,9 +130,9 @@ class _MaskedUNet(nn.Module):
             num_blocks (list[int]): Number of channels in each layer of the U-Net.
             num_estimators (int): Number of estimators.
             scale (float): Scale for the MaskedConv2d layer.
-            bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+            bilinear (bool): If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. Defaults to ``False``.
-            dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+            dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
@@ -233,9 +233,9 @@ def _masked_unet(
         num_blocks (list[int]): Number of channels in each layer of the U-Net.
         num_estimators (int): Number of estimators.
         scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Masked U-Net model.
@@ -266,9 +266,9 @@ def masked_small_unet(
         num_classes (int): Number of output classes.
         num_estimators (int): Number of estimators.
         scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Small Masked U-Net model.
@@ -300,9 +300,9 @@ def masked_unet(
         num_classes (int): Number of output classes.
         num_estimators (int): Number of estimators.
         scale (float): Scale for the MaskedConv2d layer.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate. Defaults to ``0.0``.
+        dropout_rate (float): Dropout rate. Defaults to ``0.0``.
 
     Returns:
         _MaskedUNet: Masked U-Net model.

--- a/src/torch_uncertainty/models/segmentation/unet/standard.py
+++ b/src/torch_uncertainty/models/segmentation/unet/standard.py
@@ -133,10 +133,10 @@ class _UNet(nn.Module):
             in_channels (int): Number of input channels.
             num_classes (int): Number of output classes.
             num_blocks (list[int]): Number of channels in each layer of the U-Net.
-            bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+            bilinear (bool): If ``True``, use bilinear interpolation instead of
                 transposed convolutions for upsampling. This can help to reduce the number
                 of parameters and improve the performance of the model. Defaults to ``False``.
-            dropout_rate (float, optional): Dropout rate for the model. Defaults to 0.0.
+            dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
         """
         check_unet_parameters(in_channels, num_classes, num_blocks, bilinear)
         super().__init__()
@@ -194,10 +194,10 @@ def _unet(
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
         num_blocks (list[int]): Number of channels in each layer of the U-Net.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
 
     Returns:
         _UNet: U-Net model.
@@ -222,10 +222,10 @@ def small_unet(
     Args:
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
 
     Returns:
         _SmallUNet: Small U-Net model.
@@ -251,10 +251,10 @@ def unet(
     Args:
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
-        bilinear (bool, optional): If ``True``, use bilinear interpolation instead of
+        bilinear (bool): If ``True``, use bilinear interpolation instead of
             transposed convolutions for upsampling. This can help to reduce the number
             of parameters and improve the performance of the model. Defaults to ``False``.
-        dropout_rate (float, optional): Dropout rate for the model. Defaults to 0.0.
+        dropout_rate (float): Dropout rate for the model. Defaults to 0.0.
 
     Returns:
         _UNet: U-Net model.

--- a/src/torch_uncertainty/optim/sghmc.py
+++ b/src/torch_uncertainty/optim/sghmc.py
@@ -25,10 +25,10 @@ class SGHMC(Optimizer):
                 groups should be named.
             lr (float): Learning rate :math:`\epsilon`. Defaults to ``1e-2``.
             burn_in_steps (int): Number of discarded steps used to update the state. Defaults to ``200``.
-            friction (float, optional): The friction term :math:`C`. Defaults to ``0.05``.
+            friction (float): The friction term :math:`C`. Defaults to ``0.05``.
             noise_factor (float): A factor to reduce the amount of noise and stabilize the training.
                 This parameter was not proposed in the original paper. Defaults to ``1e-2``.
-            weight_decay (float, optional): Weight decay (L2 penalty). Defaults to ``0``.
+            weight_decay (float): Weight decay (L2 penalty). Defaults to ``0``.
 
         Reference:
             - [1] `Stochastic Gradient Hamiltonian Monte Carlo <https://arxiv.org/pdf/1402.4102>`_.

--- a/src/torch_uncertainty/optim/sgld.py
+++ b/src/torch_uncertainty/optim/sgld.py
@@ -21,10 +21,10 @@ class SGLD(Optimizer):
             params (ParamsT): Iterable of parameters or named_parameters to optimize or iterable of
                 dicts defining parameter groups. When using named_parameters, all parameters in all
                 groups should be named.
-            lr (float, optional): Learning rate for the optimization. Defaults to ``1e-3``.
-            noise_factor (float, optional): A factor to reduce the amount of noise and stabilize the training.
+            lr (float): Learning rate for the optimization. Defaults to ``1e-3``.
+            noise_factor (float): A factor to reduce the amount of noise and stabilize the training.
                 This parameter was not proposed in the original paper. Defaults to ``1e-2``.
-            weight_decay (float, optional): Weight decay (L2 penalty). Defaults to ``0``.
+            weight_decay (float): Weight decay (L2 penalty). Defaults to ``0``.
 
         Reference:
             - `Bayesian Learning via Stochastic Gradient Langevin Dynamics <https://www.stats.ox.ac.uk/~teh/research/compstats/WelTeh2011a.pdf>`_.

--- a/src/torch_uncertainty/optim_recipes.py
+++ b/src/torch_uncertainty/optim_recipes.py
@@ -203,7 +203,7 @@ def optim_imagenet_resnet50_a3(model: nn.Module, effective_batch_size: int | Non
 
     Args:
         model (nn.Module): The model to be optimized.
-        effective_batch_size (int, optional): The batch size of the model
+        effective_batch_size (int): The batch size of the model
             (taking multiple GPUs into account). Defaults to None.
 
     Returns:
@@ -377,8 +377,8 @@ def get_procedure(
     Args:
         arch_name (str): The name of the architecture.
         ds_name (str): The name of the dataset.
-        method (str, optional): The name of the method. Defaults to "".
-        imagenet_recipe (str, optional): The recipe to use for
+        method (str): The name of the method. Defaults to "".
+        imagenet_recipe (str): The recipe to use for
             ImageNet. Defaults to None.
 
     Returns:

--- a/src/torch_uncertainty/post_processing/abnn.py
+++ b/src/torch_uncertainty/post_processing/abnn.py
@@ -42,13 +42,13 @@ class ABNN(PostProcessing):
             num_samples (int): Number of samples per model.
             base_lr (float): Base learning rate.
             device (torch.device): Device to use.
-            max_epochs (int, optional): Number of training epochs. Defaults
+            max_epochs (int): Number of training epochs. Defaults
                 to ``5``.
-            use_original_model (bool, optional): Use original model during
+            use_original_model (bool): Use original model during
                 evaluation. Defaults to ``True``.
-            precision (str, optional): Machine precision for training & eval.
+            precision (str): Machine precision for training & eval.
                 Defaults to ``"32"``.
-            model (nn.Module | None, optional): Model to use. Defaults to ``None``.
+            model (nn.Module | None): Model to use. Defaults to ``None``.
         """
         super().__init__(model)
         _abnn_checks(

--- a/src/torch_uncertainty/post_processing/calibration/bbq.py
+++ b/src/torch_uncertainty/post_processing/calibration/bbq.py
@@ -81,7 +81,7 @@ class BBQScaler(PostProcessing):
 
         Args:
             dataloader (DataLoader): Dataloader providing the calibration data.
-            progress (bool, optional): Whether to show a progress bar.
+            progress (bool): Whether to show a progress bar.
                 Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):

--- a/src/torch_uncertainty/post_processing/calibration/dirichlet_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/dirichlet_scaler.py
@@ -29,18 +29,18 @@ class DirichletScaler(MatrixScaler):
         Args:
             num_classes (int): Number of classes.
             model (nn.Module | None): Model to calibrate. Defaults to ``None``.
-            init_weight_temperature (float, optional): Initial value for the weight matrix. Defaults to ``1``.
-            init_bias_temperature (float | None, optional): Initial value for the bias. The inverse bias will be
+            init_weight_temperature (float): Initial value for the weight matrix. Defaults to ``1``.
+            init_bias_temperature (float | None): Initial value for the bias. The inverse bias will be
                 set to the ``0`` vector if set to ``None``. Defaults to ``None``.
-            lr (float, optional): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int, optional): Maximum number of iterations for the optimizer. Defaults to ``200``.
-            lambda_reg (float | None, optional): Regularization coefficient applied to the
+            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``200``.
+            lambda_reg (float | None): Regularization coefficient applied to the
                 off-diagonal elements of the weight matrix. Used to mitigate overfitting.
                 Defaults to ``None``.
-            mu_reg (float | None, optional): Regularization coefficient applied to the
+            mu_reg (float | None): Regularization coefficient applied to the
                 bias vector. Defaults to ``None``.
             eps (float): Small value for numerical stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for optimization.
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization.
                 Defaults to ``None``.
 
         References:
@@ -79,9 +79,9 @@ class DirichletScaler(MatrixScaler):
         Args:
             dataloader (DataLoader): Dataloader with the calibration data. If there is no model,
                 the dataloader should include the confidence score directly and not the logits.
-            save_logits (bool, optional): Whether to save the logits and
+            save_logits (bool): Whether to save the logits and
                 labels in memory. Defaults to ``False``.
-            progress (bool, optional): Whether to show a progress bar.
+            progress (bool): Whether to show a progress bar.
                 Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):

--- a/src/torch_uncertainty/post_processing/calibration/histogram_binning.py
+++ b/src/torch_uncertainty/post_processing/calibration/histogram_binning.py
@@ -34,7 +34,7 @@ class HistogramBinningScaler(PostProcessing):
             num_bins (int): Number of equal-width bins to use. Defaults to ``15``.
             eps (float): Small value for stability when converting probs back to logits.
                 Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for
                 tensor operations. Defaults to ``None``.
 
         References:
@@ -60,7 +60,7 @@ class HistogramBinningScaler(PostProcessing):
 
         Args:
             dataloader (DataLoader): Dataloader providing the calibration data.
-            progress (bool, optional): Whether to show a progress bar.
+            progress (bool): Whether to show a progress bar.
                 Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):  # coverage: ignore

--- a/src/torch_uncertainty/post_processing/calibration/isotonic_regression.py
+++ b/src/torch_uncertainty/post_processing/calibration/isotonic_regression.py
@@ -40,7 +40,7 @@ class IsotonicRegressionScaler(PostProcessing):
             model (nn.Module): Model to calibrate. Defaults to ``None``.
             eps (float): Small value for stability when converting probs back to logits.
                 Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for
                 tensor operations. Defaults to ``None``.
 
         References:
@@ -82,7 +82,7 @@ class IsotonicRegressionScaler(PostProcessing):
         Args:
             dataloader (DataLoader): Dataloader providing the calibration data
                 (logits and targets).
-            progress (bool, optional): Whether to show a progress bar during
+            progress (bool): Whether to show a progress bar during
                 data extraction. Defaults to ``True``.
         """
         if self.model is None or isinstance(self.model, nn.Identity):  # coverage: ignore

--- a/src/torch_uncertainty/post_processing/calibration/matrix_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/matrix_scaler.py
@@ -25,13 +25,13 @@ class MatrixScaler(Scaler):
         Args:
             num_classes (int): Number of classes.
             model (nn.Module | None): Model to calibrate. Defaults to ``None``.
-            init_weight_temperature (float | Tensor , optional): Initial value for the weights. Defaults to ``1``.
-            init_bias_temperature (float | Tensor | None, optional): Initial value for the bias. The inverse bias will be
+            init_weight_temperature (float | Tensor ): Initial value for the weights. Defaults to ``1``.
+            init_bias_temperature (float | Tensor | None): Initial value for the bias. The inverse bias will be
                 set to the ``0`` vector if set to ``None``. Defaults to ``None``.
-            lr (float, optional): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int, optional): Maximum number of iterations for the optimizer. Defaults to ``100``.
+            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
             eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for optimization. Defaults to ``None``.
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017

--- a/src/torch_uncertainty/post_processing/calibration/scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/scaler.py
@@ -29,10 +29,10 @@ class Scaler(PostProcessing):
 
         Args:
             model (nn.Module): Model to calibrate. Defaults to ``None``.
-            lr (float, optional): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int, optional): Maximum number of iterations for the optimizer. Defaults to ``100``.
+            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
             eps (float): Small value for stability. Defaults to ``1e-6``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for optimization. Defaults to ``None``.
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017
@@ -67,9 +67,9 @@ class Scaler(PostProcessing):
 
         Args:
             dataloader (DataLoader): Dataloader with the logits and target of the calibration data.
-            save_logits (bool, optional): Whether to save the logits and
+            save_logits (bool): Whether to save the logits and
                 labels in memory. Defaults to ``False``.
-            progress (bool, optional): Whether to show a progress bar.
+            progress (bool): Whether to show a progress bar.
                 Defaults to ``True``.
 
         Warning:

--- a/src/torch_uncertainty/post_processing/calibration/temperature_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/temperature_scaler.py
@@ -22,11 +22,11 @@ class TemperatureScaler(Scaler):
 
         Args:
             model (nn.Module): Model to calibrate.
-            init_temperature (float | Tensor, optional): Initial value for the temperature. Defaults to ``1``.
-            lr (float, optional): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int, optional): Maximum number of iterations for the optimizer. Defaults to ``100``.
+            init_temperature (float | Tensor): Initial value for the temperature. Defaults to ``1``.
+            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
             eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for optimization. Defaults to ``None``.
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017

--- a/src/torch_uncertainty/post_processing/calibration/utils.py
+++ b/src/torch_uncertainty/post_processing/calibration/utils.py
@@ -25,7 +25,7 @@ def _extract_data(
     Args:
         dataloader (DataLoader): The calibration dataloader.
         model (nn.Module): Model to calibrate.
-        device (Optional[Literal["cpu", "cuda"]], optional): Device to use for
+        device (Optional[Literal["cpu", "cuda"]]): Device to use for
             tensor operations.
         progress (bool): Whether to show the progress bar.
 

--- a/src/torch_uncertainty/post_processing/calibration/vector_scaler.py
+++ b/src/torch_uncertainty/post_processing/calibration/vector_scaler.py
@@ -23,11 +23,11 @@ class VectorScaler(Scaler):
         Args:
             model (nn.Module): Model to calibrate.
             num_classes (int): Number of classes.
-            init_temperature (float | Tensor, optional): Initial value for the weights. Defaults to ``1``.
-            lr (float, optional): Learning rate for the optimizer. Defaults to ``0.1``.
-            max_iter (int, optional): Maximum number of iterations for the optimizer. Defaults to ``100``.
+            init_temperature (float | Tensor): Initial value for the weights. Defaults to ``1``.
+            lr (float): Learning rate for the optimizer. Defaults to ``0.1``.
+            max_iter (int): Maximum number of iterations for the optimizer. Defaults to ``100``.
             eps (float): Small value for stability. Defaults to ``1e-8``.
-            device (Optional[Literal["cpu", "cuda"]], optional): Device to use for optimization. Defaults to ``None``.
+            device (Optional[Literal["cpu", "cuda"]]): Device to use for optimization. Defaults to ``None``.
 
         References:
             [1] `On calibration of modern neural networks. In ICML 2017

--- a/src/torch_uncertainty/post_processing/conformal/aps.py
+++ b/src/torch_uncertainty/post_processing/conformal/aps.py
@@ -25,13 +25,13 @@ class ConformalClsAPS(Conformal):
             alpha (float): The confidence level meaning we allow :math:`1-\alpha` error.
             model (nn.Module | None): Trained classification model. Defaults to ``None``.
             randomized (bool): Whether to use randomized smoothing in APS. Defaults to ``True``.
-            ts_init_val (float, optional): Initial value for the temperature.
+            ts_init_val (float): Initial value for the temperature.
                 Defaults to ``1.0``.
-            ts_lr (float, optional): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int, optional): Maximum number of iterations for the temperature scaling
+            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter (int): Maximum number of iterations for the temperature scaling
                 optimizer. Defaults to ``100``.
             enable_ts (bool): Whether to scale the logits. Defaults to ``False``.
-            device (Literal["cpu", "cuda"] | torch.device | None, optional): device.
+            device (Literal["cpu", "cuda"] | torch.device | None): device.
                 Defaults to ``None``.
 
         Warning:

--- a/src/torch_uncertainty/post_processing/conformal/raps.py
+++ b/src/torch_uncertainty/post_processing/conformal/raps.py
@@ -28,13 +28,13 @@ class ConformalClsRAPS(ConformalClsAPS):
             randomized (bool): Whether to use randomized smoothing in RAPS. Defaults to ``True``.
             penalty (float): Regularization weight. Defaults to ``0.1``.
             regularization_rank (int): Rank threshold for regularization. Defaults to ``1``.
-            ts_init_val (float, optional): Initial value for the temperature.
+            ts_init_val (float): Initial value for the temperature.
                 Defaults to ``1.0``.
-            ts_lr (float, optional): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int, optional): Maximum number of iterations for the temperature scaling
+            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter (int): Maximum number of iterations for the temperature scaling
                 optimizer. Defaults to ``100``.
             enable_ts (bool): Whether to scale the logits. Defaults to ``False``.
-            device (Literal["cpu", "cuda"] | torch.device | None, optional): device.
+            device (Literal["cpu", "cuda"] | torch.device | None): device.
                 Defaults to ``None``.
 
         Warning:

--- a/src/torch_uncertainty/post_processing/conformal/thr.py
+++ b/src/torch_uncertainty/post_processing/conformal/thr.py
@@ -22,14 +22,14 @@ class ConformalClsTHR(Conformal):
 
         Args:
             alpha (float): The confidence level, meaning we allow :math:`1-\alpha` error.
-            model (nn.Module | None, optional): Model to be calibrated. Defaults to ``None``.
-            ts_init_val (float, optional): Initial value for the temperature.
+            model (nn.Module | None): Model to be calibrated. Defaults to ``None``.
+            ts_init_val (float): Initial value for the temperature.
                 Defaults to ``1.0``.
-            ts_lr (float, optional): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
-            ts_max_iter (int, optional): Maximum number of iterations for the temperature scaling
+            ts_lr (float): Learning rate for the temperature scaling optimizer. Defaults to ``0.1``.
+            ts_max_iter (int): Maximum number of iterations for the temperature scaling
                 optimizer. Defaults to ``100``.
             enable_ts (bool): Whether to scale the logits. Defaults to ``True``.
-            device (Literal["cpu", "cuda"] | torch.device | None, optional): device.
+            device (Literal["cpu", "cuda"] | torch.device | None): device.
                 Defaults to ``None``.
 
         Warning:

--- a/src/torch_uncertainty/post_processing/laplace.py
+++ b/src/torch_uncertainty/post_processing/laplace.py
@@ -36,12 +36,12 @@ class LaplaceApprox(PostProcessing):
                 "last_layer".
             hessian_struct (str): structure of the Hessian matrix. Defaults to
                 "kron".
-            pred_type (Literal["glm", "nn"], optional): type of posterior predictive,
+            pred_type (Literal["glm", "nn"]): type of posterior predictive,
                 See the Laplace library for more details. Defaults to "glm".
-            link_approx (Literal["mc", "probit", "bridge", "bridge_norm"], optional):
+            link_approx (Literal["mc", "probit", "bridge", "bridge_norm"]):
                 how to approximate the classification link function for the `'glm'`.
                 See the Laplace library for more details. Defaults to "probit".
-            optimize_prior_precision (bool, optional): whether to optimize the prior
+            optimize_prior_precision (bool): whether to optimize the prior
                 precision. Defaults to True.
 
         References:

--- a/src/torch_uncertainty/post_processing/mc_batch_norm.py
+++ b/src/torch_uncertainty/post_processing/mc_batch_norm.py
@@ -28,9 +28,9 @@ class MCBatchNorm(PostProcessing):
             model (nn.Module): model to be converted.
             num_estimators (int): number of estimators.
             convert (bool): whether to convert the model. Defaults to ``True``.
-            mc_batch_size (int, optional): Monte Carlo batch size. The smaller the more variability
+            mc_batch_size (int): Monte Carlo batch size. The smaller the more variability
                 in the predictions. Defaults to ``32``.
-            device (Literal["cpu", "cuda"] | torch.device | None, optional): device.
+            device (Literal["cpu", "cuda"] | torch.device | None): device.
                 Defaults to ``None``.
 
         Warning:

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -82,36 +82,36 @@ class ClassificationRoutine(LightningModule):
             num_classes (int): Number of classes.
             loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
                 Defaults to ``None``.
-            is_ensemble (bool, optional): Indicates whether the model is an
+            is_ensemble (bool): Indicates whether the model is an
                 ensemble at test time or not. Defaults to ``False``.
             num_tta (int): Number of test-time augmentations (TTA). If ``1``: no TTA.
                 Defaults to ``1``.
-            format_batch_fn (torch.nn.Module, optional): Function to format the batch.
+            format_batch_fn (torch.nn.Module): Function to format the batch.
                 Defaults to ``None``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler, optional): The optimizer and
+            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
                 optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            mixup_params (dict, optional): Mixup parameters. Can include mixup type,
+            mixup_params (dict): Mixup parameters. Can include mixup type,
                 mixup mode, distance similarity, kernel tau max, kernel tau std,
                 mixup alpha, and cutmix alpha. If None, no mixup augmentations.
                 Defaults to ``None``.
-            eval_ood (bool, optional): Indicates whether to evaluate the OOD
+            eval_ood (bool): Indicates whether to evaluate the OOD
                 detection performance. Defaults to ``False``.
-            eval_shift (bool, optional): Indicates whether to evaluate the Distribution
+            eval_shift (bool): Indicates whether to evaluate the Distribution
                 shift performance. Defaults to ``False``.
-            eval_grouping_loss (bool, optional): Indicates whether to evaluate the
+            eval_grouping_loss (bool): Indicates whether to evaluate the
                 grouping loss or not. Defaults to ``False``.
-            ood_criterion (TUOODCriterion | str, optional): Criterion for the binary OOD detection
+            ood_criterion (TUOODCriterion | str): Criterion for the binary OOD detection
                 task. Defaults to ``msp``, the Maximum Softmax Probability score.
-            post_processing (PostProcessing, optional): Post-processing method
+            post_processing (PostProcessing): Post-processing method
                 to train on the calibration set. No post-processing if None.
                 Defaults to ``None``.
-            num_bins_calibration_error (int, optional): Number of bins to compute calibration
+            num_bins_calibration_error (int): Number of bins to compute calibration
                 error metrics. Defaults to ``15``.
-            log_plots (bool, optional): Indicates whether to log plots from
+            log_plots (bool): Indicates whether to log plots from
                 metrics. Defaults to ``False``.
-            save_in_csv (bool, optional): Save the results in csv. Defaults to
+            save_in_csv (bool): Save the results in csv. Defaults to
                 ``False``.
-            csv_filename (str, optional): Name of the csv file. Defaults to
+            csv_filename (str): Name of the csv file. Defaults to
                 ``"results.csv"``. Note that this is only used if
                 :attr:`save_in_csv` is ``True``.
 
@@ -372,7 +372,7 @@ class ClassificationRoutine(LightningModule):
 
         Args:
             inputs (Tensor): input tensor.
-            save_feats (bool, optional): whether to store the features or
+            save_feats (bool): whether to store the features or
                 not. Defaults to ``False``.
 
         Note:
@@ -665,7 +665,7 @@ def _classification_routine_checks(
         model (nn.Module): the model used to make classification predictions.
         num_classes (int): the number of classes in the dataset.
         is_ensemble (bool): whether the model is an ensemble or a single model.
-        ood_criterion (TUOODCriterion, optional): OOD criterion for the binary OOD detection task.
+        ood_criterion (TUOODCriterion): OOD criterion for the binary OOD detection task.
         eval_grouping_loss (bool): whether to evaluate the grouping loss.
         num_bins_calibration_error (int): the number of bins for the evaluation of the calibration.
         mixup_params (dict | None): the dictionary to setup the mixup augmentation.

--- a/src/torch_uncertainty/routines/pixel_regression.py
+++ b/src/torch_uncertainty/routines/pixel_regression.py
@@ -76,25 +76,25 @@ class PixelRegressionRoutine(LightningModule):
             output_dim (int): Number of outputs of the model.
             loss (nn.Module): Loss function to optimize the :attr:`model`.
                 Defaults to ``None``.
-            dist_family (str, optional): The distribution family to use for
+            dist_family (str): The distribution family to use for
                 probabilistic pixel regression. If ``None`` then point-wise regression.
                 Defaults to ``None``.
-            dist_estimate (str, optional): The estimate to use when computing the
+            dist_estimate (str): The estimate to use when computing the
                 point-wise metrics. Defaults to ``"mean"``.
-            is_ensemble (bool, optional): Whether the model is an ensemble.
+            is_ensemble (bool): Whether the model is an ensemble.
                 Defaults to ``False``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler, optional): The optimizer and
+            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
                 optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool, optional): Indicates whether to evaluate the Distribution
+            eval_shift (bool): Indicates whether to evaluate the Distribution
                 shift performance. Defaults to ``False``.
-            format_batch_fn (nn.Module, optional): The function to format the
+            format_batch_fn (nn.Module): The function to format the
                 batch. Defaults to ``None``.
-            num_image_plot (int, optional): Number of images to plot. Defaults to ``4``.
-            log_plots (bool, optional): Indicates whether to log plots from
+            num_image_plot (int): Number of images to plot. Defaults to ``4``.
+            log_plots (bool): Indicates whether to log plots from
                 metrics. Defaults to ``False``.
-            save_in_csv (bool, optional): Save the results in csv. Defaults to
+            save_in_csv (bool): Save the results in csv. Defaults to
                 ``False``.
-            csv_filename (str, optional): Name of the csv file. Defaults to
+            csv_filename (str): Name of the csv file. Defaults to
                 ``"results.csv"``. Note that this is only used if
                 :attr:`save_in_csv` is ``True``.
         """
@@ -429,9 +429,9 @@ def colorize(
 
     Args:
         value (Tensor): The tensor of depth values.
-        vmin (float, optional): The minimum depth value. Defaults to None.
-        vmax (float, optional): The maximum depth value. Defaults to None.
-        cmap (str, optional): The colormap to use. Defaults to 'magma'.
+        vmin (float): The minimum depth value. Defaults to None.
+        vmax (float): The maximum depth value. Defaults to None.
+        cmap (str): The colormap to use. Defaults to 'magma'.
     """
     vmin = value.min().item() if vmin is None else vmin
     vmax = value.max().item() if vmax is None else vmax

--- a/src/torch_uncertainty/routines/regression.py
+++ b/src/torch_uncertainty/routines/regression.py
@@ -61,18 +61,18 @@ class RegressionRoutine(LightningModule):
             output_dim (int): Number of outputs of the model.
             loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
                 Defaults to ``None``.
-            dist_family (str, optional): The distribution family to use for probabilistic regression. If ``None`` then point-wise regression. Defaults to ``None``.
-            dist_estimate (str | DistEstimate, optional): The estimate to use when computing the point-wise metrics. Defaults to ``"mean"``.
-            is_ensemble (bool, optional): Whether the model is an ensemble. Defaults to ``False``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler, optional): The optimizer and optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool, optional): Indicates whether to evaluate the Distribution shift performance. Defaults to ``False``.
-            format_batch_fn (torch.nn.Module, optional): The function to format the batch. Defaults to ``None``.
-            log_plots (bool, optional): Indicates whether to log figures in the logger.
+            dist_family (str): The distribution family to use for probabilistic regression. If ``None`` then point-wise regression. Defaults to ``None``.
+            dist_estimate (str | DistEstimate): The estimate to use when computing the point-wise metrics. Defaults to ``"mean"``.
+            is_ensemble (bool): Whether the model is an ensemble. Defaults to ``False``.
+            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
+            eval_shift (bool): Indicates whether to evaluate the Distribution shift performance. Defaults to ``False``.
+            format_batch_fn (torch.nn.Module): The function to format the batch. Defaults to ``None``.
+            log_plots (bool): Indicates whether to log figures in the logger.
                 Defaults to ``False``.
-            num_bins_calibration_error (int, optional): Number of bins to compute calibration
+            num_bins_calibration_error (int): Number of bins to compute calibration
                 error metrics. Defaults to ``15``.
-            save_in_csv (bool, optional): Save the results in csv. Defaults to ``False``.
-            csv_filename (str, optional): Name of the csv file. Defaults to ``"results.csv"``. Note that this is only used if
+            save_in_csv (bool): Save the results in csv. Defaults to ``False``.
+            csv_filename (str): Name of the csv file. Defaults to ``"results.csv"``. Note that this is only used if
                 :attr:`save_in_csv` is ``True``.
 
         Warning:

--- a/src/torch_uncertainty/routines/segmentation.py
+++ b/src/torch_uncertainty/routines/segmentation.py
@@ -74,31 +74,31 @@ class SegmentationRoutine(LightningModule):
             num_classes (int): Number of classes in the segmentation task.
             loss (torch.nn.Module): Loss function to optimize the :attr:`model`.
                 Defaults to ``None``.
-            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler, optional): The optimizer and
+            optim_recipe (Callable[[nn.Module], OptimizerLRScheduler] | OptimizerLRScheduler): The optimizer and
                 optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
-            eval_shift (bool, optional): Indicates whether to evaluate the Distribution
+            eval_shift (bool): Indicates whether to evaluate the Distribution
                 shift performance. Defaults to ``False``.
-            format_batch_fn (torch.nn.Module, optional): The function to format the
+            format_batch_fn (torch.nn.Module): The function to format the
                 batch. Defaults to ``None``.
-            metric_subsampling_rate (float, optional): The rate of subsampling for the
+            metric_subsampling_rate (float): The rate of subsampling for the
                 memory consuming metrics. Defaults to ``1e-2``.
-            eval_ood (bool, optional): Indicates whether to evaluate the OOD
+            eval_ood (bool): Indicates whether to evaluate the OOD
                 performance. Defaults to ``False``.
-            ood_criterion (TUOODCriterion, optional): Criterion for the binary OOD detection task.
+            ood_criterion (TUOODCriterion): Criterion for the binary OOD detection task.
                 Defaults to ``"msp"`` which amounts to the maximum softmax probability score (MSP).
-            post_processing (PostProcessing, optional): The post-processing
+            post_processing (PostProcessing): The post-processing
                 technique to use. Defaults to ``None``. Warning: There is no
                 post-processing technique implemented yet for segmentation tasks.
-            log_plots (bool, optional): Indicates whether to log figures in the logger.
+            log_plots (bool): Indicates whether to log figures in the logger.
                 Defaults to ``False``.
-            num_samples_to_plot (int, optional): Number of segmentation prediction and
+            num_samples_to_plot (int): Number of segmentation prediction and
                 target to plot in the logger. Note that this is only used if
                 :attr:`log_plots` is set to ``True``. Defaults to ``3``.
-            num_bins_calibration_error (int, optional): Number of bins to compute calibration
+            num_bins_calibration_error (int): Number of bins to compute calibration
                 error metrics. Defaults to ``15``.
-            save_in_csv (bool, optional): Save the results in csv. Defaults to
+            save_in_csv (bool): Save the results in csv. Defaults to
                 ``False``.
-            csv_filename (str, optional): The name of the csv file to save the results in.
+            csv_filename (str): The name of the csv file to save the results in.
                 Defaults to ``"results.csv"``.
 
         Warning:
@@ -317,7 +317,7 @@ class SegmentationRoutine(LightningModule):
         Args:
             batch (tuple[Tensor, Tensor]): the test images and their corresponding targets
             batch_idx (int): the index of the batch in the test dataloader.
-            dataloader_idx (int, optional): the index of the dataloader. Defaults to ``0``.
+            dataloader_idx (int): the index of the dataloader. Defaults to ``0``.
         """
         img, targets = batch
 

--- a/src/torch_uncertainty/transforms/image.py
+++ b/src/torch_uncertainty/transforms/image.py
@@ -268,12 +268,12 @@ class RandomRescale(Transform):
         Args:
             min_scale (int): Minimum scale for random sampling
             max_scale (int): Maximum scale for random sampling
-            interpolation (InterpolationMode, optional): Desired interpolation enum defined by
+            interpolation (InterpolationMode): Desired interpolation enum defined by
                 :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.
                 If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.NEAREST_EXACT``,
                 ``InterpolationMode.BILINEAR`` and ``InterpolationMode.BICUBIC`` are supported.
                 The corresponding Pillow integer constants, e.g. ``PIL.Image.BILINEAR`` are accepted as well.
-            antialias (bool, optional): Whether to apply antialiasing.
+            antialias (bool): Whether to apply antialiasing.
                 It only affects **tensors** with bilinear or bicubic modes and it is
                 ignored otherwise: on PIL images, antialiasing is always applied on
                 bilinear or bicubic modes; on other modes (for PIL images and

--- a/src/torch_uncertainty/transforms/mixup.py
+++ b/src/torch_uncertainty/transforms/mixup.py
@@ -109,9 +109,9 @@ class AbstractMixup(nn.Module, ABC):
         """Abstract Mixup class.
 
         Args:
-            alpha (float, optional): Mixup alpha.
+            alpha (float): Mixup alpha.
             num_classes (int): Number of classes.
-            isobatch (bool, optional): Whether to use a single coefficient for the whole batch
+            isobatch (bool): Whether to use a single coefficient for the whole batch
                 instead of for each pair. Defaults to ``False``.
             **kwargs (Any): Keyword arguments for compatibility.
         """
@@ -209,11 +209,11 @@ class MixupMP(AbstractMixup):
         inputs and targets, all concatenated.
 
         Args:
-            alpha (float, optional): Mixup alpha.
+            alpha (float): Mixup alpha.
             num_classes (int): Number of classes.
             mixup_ratio (float): Ratio of the number of mixup-ed pairs and normal pairs. Defaults
                 to ``1``. This parameter is named "r" in the paper.
-            isobatch (bool, optional): Whether to use a single coefficient for the whole batch
+            isobatch (bool): Whether to use a single coefficient for the whole batch
                 instead of for each pair. Defaults to ``False``.
             **kwargs (Any): Keyword arguments for compatibility.
 

--- a/src/torch_uncertainty/utils/checkpoints.py
+++ b/src/torch_uncertainty/utils/checkpoints.py
@@ -8,7 +8,7 @@ def get_version(root: str | Path, version: int, checkpoint: int | None = None) -
         root (Union[str, Path]): The root of the dataset containing the
             checkpoints.
         version (int): The version of the checkpoint.
-        checkpoint (int, optional): The number of the checkpoint. Defaults
+        checkpoint (int): The number of the checkpoint. Defaults
             to None.
 
     Raises:

--- a/src/torch_uncertainty/utils/cli.py
+++ b/src/torch_uncertainty/utils/cli.py
@@ -81,45 +81,45 @@ class TULightningCLI(LightningCLI):
         """Custom LightningCLI for torch-uncertainty.
 
         Args:
-            model_class (type[LightningModule] | Callable[..., LightningModule] | None, optional):
+            model_class (type[LightningModule] | Callable[..., LightningModule] | None):
                 An optional `LightningModule` class to train or a callable which returns a
                 ``LightningModule`` instance when called. If ``None``, you can pass a registered model
                 with ``--model=MyModel``. Defaults to ``None``.
-            datamodule_class (type[LightningDataModule] | Callable[..., LightningDataModule] | None, optional):
+            datamodule_class (type[LightningDataModule] | Callable[..., LightningDataModule] | None):
                 An optional ``LightningDataModule`` class or a callable which returns a ``LightningDataModule``
                 instance when called. If ``None``, you can pass a registered datamodule with ``--data=MyDataModule``.
                 Defaults to ``None``.
-            save_config_callback (type[SaveConfigCallback] | None, optional): A callback class to
+            save_config_callback (type[SaveConfigCallback] | None): A callback class to
                 save the config. Defaults to ``TUSaveConfigCallback``.
-            save_config_kwargs (dict[str, Any] | None, optional): Parameters that will be used to
+            save_config_kwargs (dict[str, Any] | None): Parameters that will be used to
                 instantiate the save_config_callback. Defaults to ``None``.
-            trainer_class (type[Trainer] | Callable[..., Trainer], optional): An optional subclass
+            trainer_class (type[Trainer] | Callable[..., Trainer]): An optional subclass
                 of the Trainer class or a callable which returns a ``Trainer`` instance when called.
                 Defaults to ``TUTrainer``.
-            trainer_defaults (dict[str, Any] | None, optional): Set to override Trainer defaults
+            trainer_defaults (dict[str, Any] | None): Set to override Trainer defaults
                 or add persistent callbacks. The callbacks added through this argument will not
                 be configurable from a configuration file and will always be present for this
                 particular CLI. Alternatively, configurable callbacks can be added as explained
                 in the CLI docs. Defaults to ``None``.
-            seed_everything_default (bool | int, optional): Number for the ``seed_everything()``
+            seed_everything_default (bool | int): Number for the ``seed_everything()``
                 seed value. Set to ``True`` to automatically choose a seed value. Setting it to ``False``
                 will avoid calling seed_everything. Defaults to ``True``.
-            parser_kwargs (dict[str, Any] | dict[str, dict[str, Any]] | None, optional): Additional
+            parser_kwargs (dict[str, Any] | dict[str, dict[str, Any]] | None): Additional
                 arguments to instantiate each ``LightningArgumentParser``. Defaults to
                 ``LightningArgumentParser``. Defaults to ``None``.
-            subclass_mode_model (bool, optional): Whether model can be any subclass of the given
+            subclass_mode_model (bool): Whether model can be any subclass of the given
                 class. Defaults to ``False``.
-            subclass_mode_data (bool, optional): Whether datamodule can be any subclass of the
+            subclass_mode_data (bool): Whether datamodule can be any subclass of the
                 given class. Defaults to ``False``.
-            args (ArgsType, optional): Arguments to parse. If `None` the arguments are taken from
+            args (ArgsType): Arguments to parse. If `None` the arguments are taken from
                 ``sys.argv``. Command line style arguments can be given in a ``list``. Alternatively,
                 structured config options can be given in a ``dict`` or ``jsonargparse.Namespace``.
                 Defaults to `None`.
-            run (bool, optional): Whether subcommands should be added to run a ``Trainer`` method. If
+            run (bool): Whether subcommands should be added to run a ``Trainer`` method. If
                 set to `False`, the trainer and model classes will be instantiated only. Defaults
                 to ``True``.
-            auto_configure_optimizers (bool, optional): Defaults to ``True``.
-            eval_after_fit_default (bool, optional): Store whether an evaluation should be performed
+            auto_configure_optimizers (bool): Defaults to ``True``.
+            eval_after_fit_default (bool): Store whether an evaluation should be performed
                 after the training. Defaults to ``False``.
             **kwargs: Additional keyword arguments to pass to the parent class added for
                 ``lightning>2.5.0``:

--- a/src/torch_uncertainty/utils/plotting.py
+++ b/src/torch_uncertainty/utils/plotting.py
@@ -31,9 +31,9 @@ def plot_hist(
 
     Args:
         conf (Any): The confidence values.
-        bins (int, optional): The number of bins. Defaults to ``20``.
-        title (str, optional): The title of the plot. Defaults to ``"Histogram with 'auto' bins"``.
-        dpi (int, optional): The dpi of the plot. Defaults to ``60``.
+        bins (int): The number of bins. Defaults to ``20``.
+        title (str): The title of the plot. Defaults to ``"Histogram with 'auto' bins"``.
+        dpi (int): The dpi of the plot. Defaults to ``60``.
 
     Returns:
         Tuple[Figure, Axes]: The figure and axes of the plot.

--- a/tests/_dummies/dataset.py
+++ b/tests/_dummies/dataset.py
@@ -14,17 +14,17 @@ class DummyClassificationDataset(Dataset):
 
     Args:
         root (string): Root directory containing the dataset (unused).
-        train (bool, optional): If True, creates dataset from training set,
+        train (bool): If True, creates dataset from training set,
             otherwise creates from test set (unused).
-        transform (callable, optional): A function/transform that takes in
+        transform (callable): A function/transform that takes in
             a PIL image and returns a transformed version. E.g,
             ``transforms.RandomCrop``
-        target_transform (callable, optional): A function/transform that
+        target_transform (callable): A function/transform that
             takes in the target and transforms it.
-        num_channels (int, optional): Number of channels in the images.
-        image_size (int, optional): Size of the images.
-        num_classes (int, optional): Number of classes in the dataset.
-        num_images (int, optional): Number of images in the dataset.
+        num_channels (int): Number of channels in the images.
+        image_size (int): Size of the images.
+        num_classes (int): Number of classes in the dataset.
+        num_images (int): Number of images in the dataset.
         kwargs (Any): Other arguments.
     """
 

--- a/tests/_dummies/model.py
+++ b/tests/_dummies/model.py
@@ -114,9 +114,9 @@ def dummy_model(
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
         num_estimators (int): Number of estimators in the ensemble.
-        dropout_rate (float, optional): Dropout rate. Defaults to 0.0.
-        with_feats (bool, optional): Whether to include features. Defaults to True.
-        dist_family (str, optional): Distribution family. Defaults to None.
+        dropout_rate (float): Dropout rate. Defaults to 0.0.
+        with_feats (bool): Whether to include features. Defaults to True.
+        dist_family (str): Distribution family. Defaults to None.
 
     Returns:
         _Dummy: Dummy model.
@@ -149,8 +149,8 @@ def dummy_segmentation_model(
         in_channels (int): Number of input channels.
         num_classes (int): Number of output classes.
         image_size (int): Size of the input image.
-        dropout_rate (float, optional): Dropout rate. Defaults to 0.0.
-        dist_family (str, optional): Distribution family. Defaults to None.
+        dropout_rate (float): Dropout rate. Defaults to 0.0.
+        dist_family (str): Distribution family. Defaults to None.
 
     Returns:
         nn.Module: Dummy segmentation model.


### PR DESCRIPTION
The first step to clean the docstrings and make them more readable. Can you just have a very quick look, @alafage? It was just a search-and-replace.