### PR TITLE
:bug:(Entropy)! fix OOD ensemble predictive entropy & compute shift entropy

### DIFF
--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -258,6 +258,7 @@ class ClassificationRoutine(LightningModule):
 
         if self.eval_shift:
             self.test_shift_metrics = cls_metrics.clone(prefix="shift/")
+            self.test_shift_entropy = Entropy()
 
         # metrics for ensembles only
         if self.is_ensemble:
@@ -512,6 +513,7 @@ class ClassificationRoutine(LightningModule):
                 self.post_cls_metrics.update(pp_probs, targets)
 
         if self.eval_ood and dataloader_idx == 1:
+            self.test_ood_entropy.update(probs)
             self.test_ood_metrics.update(ood_scores, torch.ones_like(targets))
 
             if self.is_ensemble:
@@ -521,7 +523,9 @@ class ClassificationRoutine(LightningModule):
                 self.ood_score_storage.append(ood_scores.detach().cpu())
 
         if self.eval_shift and dataloader_idx == (2 if self.eval_ood else 1):
+            self.test_shift_entropy.update(probs)
             self.test_shift_metrics.update(probs, targets)
+
             if self.is_ensemble:
                 self.test_shift_ens_metrics.update(probs_per_est)
 
@@ -570,6 +574,9 @@ class ClassificationRoutine(LightningModule):
         if self.eval_shift:
             result_dict |= self.test_shift_metrics.compute() | {
                 "shift/severity": self.trainer.datamodule.shift_severity,
+            }
+            result_dict |= self.test_ood_metrics.compute() | {
+                "shift/Entropy": self.test_shift_entropy.compute()
             }
 
             if self.is_ensemble:

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -503,7 +503,6 @@ class ClassificationRoutine(LightningModule):
                 self.test_id_ens_metrics.update(probs_per_est)
 
             if self.eval_ood:
-                self.test_ood_entropy.update(probs)
                 self.test_ood_metrics.update(ood_scores, torch.zeros_like(targets))
 
             if self.id_score_storage is not None:


### PR DESCRIPTION
As of now, ood/Entropy=cls/Entropy. OOD Entropy could probably be the average Entropy over both ID and OOD samples, or the entropy of the OOD samples only. I'm leaning towards the second solution. We also did not compute the shift Entropy.

Just give me your opinion on this, and we can merge this fast @alafage.

This makes issue #158 even more critical imo. I mixed the meaning of ens_entropy myself: it's actually the average over the samples of the average over the estimators of the entropy of their predictions, not the average over the samples of the entropy of the ensemble predictions.