### PR TITLE
:sparkles:(losses): add the quantile loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To date, the following deep-learning uncertainty quantification methods have bee
 - Stochastic Weight Averaging & Stochastic Weight Averaging Gaussian
 - [Deep Evidential Classification](https://torch-uncertainty.github.io/auto_tutorials/Classification/tutorial_evidential_classification.html) & [Regression](https://torch-uncertainty.github.io/auto_tutorials/Regression/tutorial_der_cubic.html)
 - Regression with Beta Gaussian NLL Loss
+- Quantile Regression with Pinball Loss
 - Test-time adaptation with Zero
 
 ### Augmentation methods

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -410,6 +410,7 @@ Losses
     ELBOLoss
     FocalLoss
     KLDiv
+    PinballLoss
 
 Post-Processing Methods
 -----------------------

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -30,6 +30,17 @@ For Beta NLL in Deep Regression, consider citing:
 * Paper: `ICLR 2022 <https://arxiv.org/abs/2203.09168>`__.
 
 
+Pinball / Quantile Regression
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For Pinball / Quantile Regression, consider citing:
+
+**Regression Quantiles**
+
+* Authors: *Roger Koenker and Gilbert Bassett Jr.*
+* Paper: `Econometrica 1978 <https://www.jstor.org/stable/1913643>`__.
+
+
 Deep Evidential Regression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/torch_uncertainty/losses/__init__.py
+++ b/src/torch_uncertainty/losses/__init__.py
@@ -9,4 +9,4 @@ from .classification import (
     FocalLoss,
     MixupMPLoss,
 )
-from .regression import BetaNLL, DERLoss, DistributionNLLLoss
+from .regression import BetaNLL, DERLoss, DistributionNLLLoss, PinballLoss

--- a/src/torch_uncertainty/losses/regression.py
+++ b/src/torch_uncertainty/losses/regression.py
@@ -7,6 +7,62 @@ from torch.distributions import Distribution, Independent
 from torch_uncertainty.utils.distributions import NormalInverseGamma
 
 
+class PinballLoss(nn.Module):
+    def __init__(self, quantile: float = 0.5, reduction: str | None = "mean") -> None:
+        r"""The Pinball loss for quantile regression.
+
+        Also known as the quantile loss or check loss, the pinball loss at
+        quantile level :math:`\tau \in (0, 1)` is:
+
+        .. math::
+            \mathcal{L}_\tau(y, \hat{y}) =
+            \max\!\left(\tau\,(y - \hat{y}),\,(\tau - 1)\,(y - \hat{y})\right)
+            = \begin{cases}
+                \tau\,(y - \hat{y}) & \text{if } y \geq \hat{y}, \\
+                (1 - \tau)\,(\hat{y} - y) & \text{if } y < \hat{y}.
+            \end{cases}
+
+        For :math:`\tau = 0.5` the loss coincides with the mean absolute error
+        (MAE) scaled by :math:`\tfrac{1}{2}`.
+
+        Args:
+            quantile: The quantile level :math:`\tau \in (0, 1)`. Defaults to
+                ``0.5``.
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``. Defaults
+                to ``"mean"``.
+
+        References:
+            [1] `Koenker, R., & Bassett Jr, G. (1978). Regression quantiles.
+            Econometrica, <https://www.jstor.org/stable/1913643>`_.
+        """
+        super().__init__()
+
+        if not 0 < quantile < 1:
+            raise ValueError(f"The quantile parameter should be in (0, 1), but got {quantile}.")
+        self.quantile = quantile
+
+        if reduction not in ("none", "mean", "sum"):
+            raise ValueError(f"{reduction} is not a valid value for reduction.")
+        self.reduction = reduction
+
+    def forward(self, predictions: Tensor, targets: Tensor) -> Tensor:
+        """Compute the pinball loss.
+
+        Args:
+            predictions: The predicted quantile values.
+            targets: The target values.
+        """
+        residual = targets - predictions
+        loss = torch.maximum(self.quantile * residual, (self.quantile - 1) * residual)
+
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss
+
+
 class DistributionNLLLoss(nn.Module):
     def __init__(self, reduction: Literal["mean", "sum"] | None = "mean") -> None:
         r"""Negative Log-Likelihood loss for probabilistic regression.

--- a/tests/losses/test_regression.py
+++ b/tests/losses/test_regression.py
@@ -8,6 +8,7 @@ from torch_uncertainty.losses import (
     BetaNLL,
     DERLoss,
     DistributionNLLLoss,
+    PinballLoss,
 )
 from torch_uncertainty.utils.distributions import NormalInverseGamma
 
@@ -111,3 +112,54 @@ class TestBetaNLL:
 
         with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
             BetaNLL(beta=1.0, reduction="median")
+
+
+class TestPinballLoss:
+    """Testing the PinballLoss class."""
+
+    def test_main(self) -> None:
+        # At τ=0.5 and perfect prediction the loss is zero.
+        loss = PinballLoss(quantile=0.5)
+        pred = torch.tensor([1.0])
+        target = torch.tensor([1.0])
+        assert loss(pred, target) == pytest.approx(0.0)
+
+        # tau 0.5 is MAE/2: underestimate and overestimate are symmetric.
+        pred_low = torch.tensor([0.0])
+        pred_high = torch.tensor([1.0])
+        target_one = torch.tensor([1.0])
+        target_zero = torch.tensor([0.0])
+        assert loss(pred_low, target_one) == pytest.approx(0.5)
+        assert loss(pred_high, target_zero) == pytest.approx(0.5)
+
+        # tau 0.9 penalises underestimation more heavily than overestimation.
+        loss_q90 = PinballLoss(quantile=0.9)
+        assert loss_q90(pred_low, target_one) == pytest.approx(0.9)
+        assert loss_q90(pred_high, target_zero) == pytest.approx(0.1)
+
+        # reduction "sum"
+        loss_sum = PinballLoss(quantile=0.5, reduction="sum")
+        preds = torch.tensor([0.0, 1.0])
+        targets = torch.tensor([1.0, 0.0])
+        assert loss_sum(preds, targets) == pytest.approx(1.0)
+
+        # reduction "none"
+        loss_none = PinballLoss(quantile=0.5, reduction="none")
+        result = loss_none(preds, targets)
+        assert result.tolist() == pytest.approx([0.5, 0.5])
+
+    def test_failures(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"The quantile parameter should be in \(0, 1\)",
+        ):
+            PinballLoss(quantile=0.0)
+
+        with pytest.raises(
+            ValueError,
+            match=r"The quantile parameter should be in \(0, 1\)",
+        ):
+            PinballLoss(quantile=1.0)
+
+        with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
+            PinballLoss(quantile=0.5, reduction="median")


### PR DESCRIPTION
## Description

Add the quantile/pinball loss to enhance the regression task support.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [x] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
