### PR TITLE
:sparkles: Add interval evaluation metrics (PICP, MPIW, Winkler score)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -344,10 +344,13 @@ Regression
     :template: class.rst
 
     DistributionNLL
+    IntervalCoverage
+    IntervalScore
     Log10
     MeanAbsoluteErrorInverse
     MeanGTRelativeAbsoluteError
     MeanGTRelativeSquaredError
+    MeanIntervalWidth
     MeanSquaredErrorInverse
     MeanSquaredLogError
     SILog

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -493,6 +493,17 @@ For the grouping loss, consider citing:
 * Paper: `ICLR 2023 <https://arxiv.org/pdf/2210.16315.pdf>`__.
 
 
+Interval (Winkler) Score
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For the interval (Winkler) score, consider citing:
+
+**Strictly Proper Scoring Rules, Prediction, and Estimation**
+
+* Authors: *Tilman Gneiting and Adrian E. Raftery*
+* Paper: `JASA 2007 <https://doi.org/10.1198/016214506000001437>`__.
+
+
 Datasets
 --------
 

--- a/src/torch_uncertainty/metrics/__init__.py
+++ b/src/torch_uncertainty/metrics/__init__.py
@@ -29,10 +29,13 @@ from .classification import (
 )
 from .regression import (
     DistributionNLL,
+    IntervalCoverage,
+    IntervalScore,
     Log10,
     MeanAbsoluteErrorInverse,
     MeanGTRelativeAbsoluteError,
     MeanGTRelativeSquaredError,
+    MeanIntervalWidth,
     MeanSquaredErrorInverse,
     MeanSquaredLogError,
     QuantileCalibrationError,

--- a/src/torch_uncertainty/metrics/regression/__init__.py
+++ b/src/torch_uncertainty/metrics/regression/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401
+from .interval import IntervalCoverage, IntervalScore, MeanIntervalWidth
 from .inverse import MeanAbsoluteErrorInverse, MeanSquaredErrorInverse
 from .log10 import Log10
 from .mse_log import MeanSquaredLogError

--- a/src/torch_uncertainty/metrics/regression/interval.py
+++ b/src/torch_uncertainty/metrics/regression/interval.py
@@ -3,20 +3,7 @@ from typing import Any
 import torch
 from torch import Tensor
 from torchmetrics import Metric
-
-
-def _check_interval_shapes(lower: Tensor, upper: Tensor, target: Tensor | None = None) -> None:
-    if lower.shape != upper.shape:
-        raise ValueError(
-            f"Expected `lower` and `upper` to have the same shape, got {lower.shape} and "
-            f"{upper.shape}."
-        )
-    if target is not None and target.shape != lower.shape:
-        raise ValueError(
-            f"Expected `target` to have the same shape as the interval bounds, got "
-            f"{target.shape} and {lower.shape}."
-        )
-
+from torch_uncertainty.utils import check_interval_shapes
 
 class IntervalCoverage(Metric):
     is_differentiable: bool = False
@@ -68,7 +55,7 @@ class IntervalCoverage(Metric):
             # tensor(0.7500)
         """
         super().__init__(**kwargs)
-        self.add_state("covered", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("covered", default=torch.tensor(0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
 
     def update(self, lower: Tensor, upper: Tensor, target: Tensor) -> None:
@@ -79,7 +66,7 @@ class IntervalCoverage(Metric):
             upper: The predicted upper bounds of the interval.
             target: The ground-truth targets.
         """
-        _check_interval_shapes(lower, upper, target)
+        check_interval_shapes(lower, upper, target)
         inside = (target >= lower) & (target <= upper)
         self.covered += inside.sum()
         self.total += target.numel()
@@ -90,7 +77,7 @@ class IntervalCoverage(Metric):
 
 
 class MeanIntervalWidth(Metric):
-    is_differentiable: bool = True
+    is_differentiable: bool = False
     higher_is_better: bool = False
     full_state_update: bool = False
     width_sum: Tensor
@@ -143,7 +130,7 @@ class MeanIntervalWidth(Metric):
             lower: The predicted lower bounds of the interval.
             upper: The predicted upper bounds of the interval.
         """
-        _check_interval_shapes(lower, upper)
+        check_interval_shapes(lower, upper)
         self.width_sum += (upper - lower).sum()
         self.total += lower.numel()
 
@@ -153,7 +140,7 @@ class MeanIntervalWidth(Metric):
 
 
 class IntervalScore(Metric):
-    is_differentiable: bool = True
+    is_differentiable: bool = False
     higher_is_better: bool = False
     full_state_update: bool = False
     score_sum: Tensor
@@ -224,7 +211,7 @@ class IntervalScore(Metric):
             upper: The predicted upper bounds of the interval.
             target: The ground-truth targets.
         """
-        _check_interval_shapes(lower, upper, target)
+        check_interval_shapes(lower, upper, target)
         width = upper - lower
         below = (lower - target).clamp(min=0)
         above = (target - upper).clamp(min=0)

--- a/src/torch_uncertainty/metrics/regression/interval.py
+++ b/src/torch_uncertainty/metrics/regression/interval.py
@@ -3,7 +3,9 @@ from typing import Any
 import torch
 from torch import Tensor
 from torchmetrics import Metric
+
 from torch_uncertainty.utils import check_interval_shapes
+
 
 class IntervalCoverage(Metric):
     is_differentiable: bool = False

--- a/src/torch_uncertainty/metrics/regression/interval.py
+++ b/src/torch_uncertainty/metrics/regression/interval.py
@@ -1,0 +1,237 @@
+from typing import Any
+
+import torch
+from torch import Tensor
+from torchmetrics import Metric
+
+
+def _check_interval_shapes(lower: Tensor, upper: Tensor, target: Tensor | None = None) -> None:
+    if lower.shape != upper.shape:
+        raise ValueError(
+            f"Expected `lower` and `upper` to have the same shape, got {lower.shape} and "
+            f"{upper.shape}."
+        )
+    if target is not None and target.shape != lower.shape:
+        raise ValueError(
+            f"Expected `target` to have the same shape as the interval bounds, got "
+            f"{target.shape} and {lower.shape}."
+        )
+
+
+class IntervalCoverage(Metric):
+    is_differentiable: bool = False
+    higher_is_better: bool | None = None
+    full_state_update: bool = False
+    covered: Tensor
+    total: Tensor
+
+    def __init__(self, **kwargs: Any) -> None:
+        r"""Prediction Interval Coverage Probability (PICP).
+
+        Given predicted lower and upper bounds :math:`\hat{l}_i` and :math:`\hat{u}_i` of a
+        central prediction interval, PICP is the empirical fraction of targets that fall
+        inside the interval:
+
+        .. math::
+            \text{PICP} = \frac{1}{N} \sum_{i=1}^{N}
+            \mathbf{1}\!\left[ \hat{l}_i \le y_i \le \hat{u}_i \right].
+
+        A well-calibrated interval built for a nominal coverage :math:`1 - \alpha` should
+        yield :math:`\text{PICP} \approx 1 - \alpha`. Coverage is **gameable on its own** —
+        an arbitrarily wide interval reaches :math:`\text{PICP} = 1` — so it should always be
+        reported together with an interval-width metric such as
+        :class:`~torch_uncertainty.metrics.regression.MeanIntervalWidth` or a proper interval
+        score such as :class:`~torch_uncertainty.metrics.regression.IntervalScore`.
+
+        Args:
+            kwargs: Additional keyword arguments, see `Advanced metric settings
+                <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
+
+        Note:
+            Inputs of any shape are accepted and flattened, so the metric returns the coverage
+            rate over all elements (e.g. batch and output dimensions pooled together).
+
+        Example:
+
+        .. code-block:: python
+
+            import torch
+            from torch_uncertainty.metrics.regression import IntervalCoverage
+
+            lower = torch.tensor([0.0, 1.0, 2.0, 3.0])
+            upper = torch.tensor([2.0, 3.0, 4.0, 5.0])
+            target = torch.tensor([1.0, 5.0, 3.0, 4.0])  # 3 of 4 inside
+
+            metric = IntervalCoverage()
+            metric.update(lower, upper, target)
+            print(metric.compute())
+            # tensor(0.7500)
+        """
+        super().__init__(**kwargs)
+        self.add_state("covered", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def update(self, lower: Tensor, upper: Tensor, target: Tensor) -> None:
+        """Update state with a batch of interval bounds and targets.
+
+        Args:
+            lower: The predicted lower bounds of the interval.
+            upper: The predicted upper bounds of the interval.
+            target: The ground-truth targets.
+        """
+        _check_interval_shapes(lower, upper, target)
+        inside = (target >= lower) & (target <= upper)
+        self.covered += inside.sum()
+        self.total += target.numel()
+
+    def compute(self) -> Tensor:
+        """Compute the prediction interval coverage probability."""
+        return self.covered.float() / self.total
+
+
+class MeanIntervalWidth(Metric):
+    is_differentiable: bool = True
+    higher_is_better: bool = False
+    full_state_update: bool = False
+    width_sum: Tensor
+    total: Tensor
+
+    def __init__(self, **kwargs: Any) -> None:
+        r"""Mean Prediction Interval Width (MPIW), a.k.a. sharpness.
+
+        The mean width of the predicted central prediction intervals:
+
+        .. math::
+            \text{MPIW} = \frac{1}{N} \sum_{i=1}^{N} \left( \hat{u}_i - \hat{l}_i \right).
+
+        MPIW measures the sharpness of the intervals. It is only meaningful **jointly** with a
+        coverage metric such as :class:`~torch_uncertainty.metrics.regression.IntervalCoverage`:
+        narrower is better *at equal coverage*, since width can be reduced trivially by
+        sacrificing coverage.
+
+        Args:
+            kwargs: Additional keyword arguments, see `Advanced metric settings
+                <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
+
+        Note:
+            Inputs of any shape are accepted and flattened, so the metric returns the mean width
+            over all elements.
+
+        Example:
+
+        .. code-block:: python
+
+            import torch
+            from torch_uncertainty.metrics.regression import MeanIntervalWidth
+
+            lower = torch.tensor([0.0, 1.0, 2.0])
+            upper = torch.tensor([2.0, 3.0, 5.0])  # widths 2, 2, 3
+
+            metric = MeanIntervalWidth()
+            metric.update(lower, upper)
+            print(metric.compute())
+            # tensor(2.3333)
+        """
+        super().__init__(**kwargs)
+        self.add_state("width_sum", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def update(self, lower: Tensor, upper: Tensor) -> None:
+        """Update state with a batch of interval bounds.
+
+        Args:
+            lower: The predicted lower bounds of the interval.
+            upper: The predicted upper bounds of the interval.
+        """
+        _check_interval_shapes(lower, upper)
+        self.width_sum += (upper - lower).sum()
+        self.total += lower.numel()
+
+    def compute(self) -> Tensor:
+        """Compute the mean interval width."""
+        return self.width_sum / self.total
+
+
+class IntervalScore(Metric):
+    is_differentiable: bool = True
+    higher_is_better: bool = False
+    full_state_update: bool = False
+    score_sum: Tensor
+    total: Tensor
+
+    def __init__(self, coverage: float, **kwargs: Any) -> None:
+        r"""Interval (Winkler) score for a central prediction interval.
+
+        A proper scoring rule that rewards sharp intervals while penalizing targets that fall
+        outside them. For a central prediction interval :math:`[\hat{l}_i, \hat{u}_i]` built for
+        a nominal coverage :math:`1 - \alpha` (so that :math:`\hat{l}_i` and :math:`\hat{u}_i`
+        are the :math:`\alpha/2` and :math:`1 - \alpha/2` predictive quantiles), the score is
+
+        .. math::
+            S_\alpha(\hat{l}_i, \hat{u}_i; y_i) = (\hat{u}_i - \hat{l}_i)
+            + \frac{2}{\alpha} (\hat{l}_i - y_i)\, \mathbf{1}\!\left[y_i < \hat{l}_i\right]
+            + \frac{2}{\alpha} (y_i - \hat{u}_i)\, \mathbf{1}\!\left[y_i > \hat{u}_i\right],
+
+        and the metric returns its mean over all elements. Lower is better. Unlike coverage and
+        width taken separately, the interval score penalizes width and miscoverage jointly, so a
+        trivially wide interval no longer scores well.
+
+        Args:
+            coverage: The nominal coverage :math:`1 - \alpha` of the interval, in :math:`(0, 1)`
+                (e.g. ``0.9`` for a 90% interval). Sets the miscoverage penalty factor
+                :math:`2 / \alpha`.
+            kwargs: Additional keyword arguments, see `Advanced metric settings
+                <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
+
+        Note:
+            Inputs of any shape are accepted and flattened, so the metric returns the mean score
+            over all elements.
+
+        Reference:
+            [1] `Gneiting & Raftery, Strictly Proper Scoring Rules, Prediction, and Estimation,
+            JASA 2007 <https://doi.org/10.1198/016214506000001437>`_ (Eq. 43).
+
+        Example:
+
+        .. code-block:: python
+
+            import torch
+            from torch_uncertainty.metrics.regression import IntervalScore
+
+            lower = torch.tensor([0.0, 1.0])
+            upper = torch.tensor([2.0, 3.0])
+            target = torch.tensor([1.0, 5.0])  # 2nd target misses the upper bound by 2
+
+            metric = IntervalScore(coverage=0.9)
+            metric.update(lower, upper, target)
+            print(metric.compute())
+            # width mean = 2; penalty on 2nd = (2/0.1)*2 = 40; mean = (2 + 42)/2 = 22
+            # tensor(22.)
+        """
+        super().__init__(**kwargs)
+        if not 0.0 < coverage < 1.0:
+            raise ValueError(f"coverage must be in the open interval (0, 1), got {coverage}.")
+        self.coverage = coverage
+        self.alpha = 1.0 - coverage
+        self.add_state("score_sum", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def update(self, lower: Tensor, upper: Tensor, target: Tensor) -> None:
+        """Update state with a batch of interval bounds and targets.
+
+        Args:
+            lower: The predicted lower bounds of the interval.
+            upper: The predicted upper bounds of the interval.
+            target: The ground-truth targets.
+        """
+        _check_interval_shapes(lower, upper, target)
+        width = upper - lower
+        below = (lower - target).clamp(min=0)
+        above = (target - upper).clamp(min=0)
+        score = width + (2.0 / self.alpha) * (below + above)
+        self.score_sum += score.sum()
+        self.total += target.numel()
+
+    def compute(self) -> Tensor:
+        """Compute the mean interval (Winkler) score."""
+        return self.score_sum / self.total

--- a/src/torch_uncertainty/utils/__init__.py
+++ b/src/torch_uncertainty/utils/__init__.py
@@ -8,3 +8,4 @@ from .misc import csv_writer, get_logger_dir, log_figure, log_image_array
 from .plotting import plot_hist, show_segmentation_predictions
 from .trainer import TUTrainer
 from .transforms import interpolation_modes_from_str
+from .checks import check_interval_shapes

--- a/src/torch_uncertainty/utils/__init__.py
+++ b/src/torch_uncertainty/utils/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
 from .checkpoints import get_version
+from .checks import check_interval_shapes
 from .cli import TULightningCLI
 from .distributions import NormalInverseGamma, get_dist_class, get_dist_estimate
 from .evaluation_loop import TUEvaluationLoop
@@ -8,4 +9,3 @@ from .misc import csv_writer, get_logger_dir, log_figure, log_image_array
 from .plotting import plot_hist, show_segmentation_predictions
 from .trainer import TUTrainer
 from .transforms import interpolation_modes_from_str
-from .checks import check_interval_shapes

--- a/src/torch_uncertainty/utils/checks.py
+++ b/src/torch_uncertainty/utils/checks.py
@@ -1,0 +1,17 @@
+import torch 
+
+from torch import Tensor
+
+def check_interval_shapes(lower: Tensor, upper: Tensor, target: Tensor | None = None) -> None:
+    if lower.shape != upper.shape:
+        raise ValueError(
+            f"Expected `lower` and `upper` to have the same shape, got {lower.shape} and "
+            f"{upper.shape}."
+        )
+    if target is not None and target.shape != lower.shape:
+        raise ValueError(
+            f"Expected `target` to have the same shape as the interval bounds, got "
+            f"{target.shape} and {lower.shape}."
+        )
+    if torch.any(lower > upper):
+        raise ValueError("Expected `lower` to be less than or equal to `upper` elementwise.")

--- a/src/torch_uncertainty/utils/checks.py
+++ b/src/torch_uncertainty/utils/checks.py
@@ -1,6 +1,6 @@
-import torch 
-
+import torch
 from torch import Tensor
+
 
 def check_interval_shapes(lower: Tensor, upper: Tensor, target: Tensor | None = None) -> None:
     if lower.shape != upper.shape:

--- a/tests/metrics/regression/test_interval.py
+++ b/tests/metrics/regression/test_interval.py
@@ -68,6 +68,11 @@ class TestMeanIntervalWidth:
         )
         assert metric.compute() == pytest.approx(7 / 3)
 
+    def test_invalid_interval_order(self) -> None:
+        metric = MeanIntervalWidth()
+        with pytest.raises(ValueError, match="lower.*upper"):
+            metric.update(torch.tensor([1.0]), torch.tensor([0.0]))
+
     def test_shape_mismatch(self) -> None:
         metric = MeanIntervalWidth()
         with pytest.raises(ValueError, match="same shape"):

--- a/tests/metrics/regression/test_interval.py
+++ b/tests/metrics/regression/test_interval.py
@@ -70,7 +70,7 @@ class TestMeanIntervalWidth:
 
     def test_invalid_interval_order(self) -> None:
         metric = MeanIntervalWidth()
-        with pytest.raises(ValueError, match="lower.*upper"):
+        with pytest.raises(ValueError, match=r"lower.*upper"):
             metric.update(torch.tensor([1.0]), torch.tensor([0.0]))
 
     def test_shape_mismatch(self) -> None:

--- a/tests/metrics/regression/test_interval.py
+++ b/tests/metrics/regression/test_interval.py
@@ -1,0 +1,113 @@
+import pytest
+import torch
+
+from torch_uncertainty.metrics import (
+    IntervalCoverage,
+    IntervalScore,
+    MeanIntervalWidth,
+)
+
+
+class TestIntervalCoverage:
+    """Test the IntervalCoverage (PICP) metric."""
+
+    def test_main(self) -> None:
+        lower = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        upper = torch.tensor([2.0, 3.0, 4.0, 5.0])
+        target = torch.tensor([1.0, 5.0, 3.0, 4.0])  # inside: T, F, T, T
+        metric = IntervalCoverage()
+        metric.update(lower, upper, target)
+        assert metric.compute() == pytest.approx(0.75)
+
+    def test_boundaries_are_inclusive(self) -> None:
+        metric = IntervalCoverage()
+        metric.update(
+            torch.tensor([0.0, 1.0]),
+            torch.tensor([2.0, 3.0]),
+            torch.tensor([0.0, 3.0]),  # exactly on the lower / upper bound
+        )
+        assert metric.compute() == pytest.approx(1.0)
+
+    def test_accumulates_across_updates(self) -> None:
+        metric = IntervalCoverage()
+        metric.update(
+            torch.tensor([0.0, 1.0, 2.0, 3.0]),
+            torch.tensor([2.0, 3.0, 4.0, 5.0]),
+            torch.tensor([1.0, 5.0, 3.0, 4.0]),
+        )  # 3 / 4
+        metric.update(
+            torch.tensor([0.0, 10.0]),
+            torch.tensor([1.0, 11.0]),
+            torch.tensor([0.5, 0.0]),
+        )  # 1 / 2
+        assert metric.compute() == pytest.approx(4 / 6)
+
+    def test_multidim_is_flattened(self) -> None:
+        metric = IntervalCoverage()
+        metric.update(
+            torch.zeros(2, 2),
+            torch.ones(2, 2),
+            torch.tensor([[0.5, 0.5], [2.0, 0.5]]),  # inside: T, T, F, T
+        )
+        assert metric.compute() == pytest.approx(0.75)
+
+    def test_shape_mismatch(self) -> None:
+        metric = IntervalCoverage()
+        with pytest.raises(ValueError, match="same shape"):
+            metric.update(torch.zeros(3), torch.ones(2), torch.zeros(3))
+
+
+class TestMeanIntervalWidth:
+    """Test the MeanIntervalWidth (MPIW) metric."""
+
+    def test_main(self) -> None:
+        metric = MeanIntervalWidth()
+        metric.update(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([2.0, 3.0, 5.0]),  # widths 2, 2, 3
+        )
+        assert metric.compute() == pytest.approx(7 / 3)
+
+    def test_shape_mismatch(self) -> None:
+        metric = MeanIntervalWidth()
+        with pytest.raises(ValueError, match="same shape"):
+            metric.update(torch.zeros(3), torch.ones(2))
+
+
+class TestIntervalScore:
+    """Test the IntervalScore (Winkler) metric."""
+
+    def test_inside_equals_width(self) -> None:
+        # A target inside the interval is only charged the interval width.
+        metric = IntervalScore(coverage=0.8)
+        metric.update(torch.tensor([0.0]), torch.tensor([3.0]), torch.tensor([1.5]))
+        assert metric.compute() == pytest.approx(3.0)
+
+    def test_above_and_inside(self) -> None:
+        # coverage 0.9 -> alpha 0.1 -> penalty factor 2 / 0.1 = 20.
+        # pt1 [0, 2], y=1 inside -> 2
+        # pt2 [1, 3], y=5 above by 2 -> 2 + 20 * 2 = 42
+        # mean = (2 + 42) / 2 = 22
+        metric = IntervalScore(coverage=0.9)
+        metric.update(
+            torch.tensor([0.0, 1.0]),
+            torch.tensor([2.0, 3.0]),
+            torch.tensor([1.0, 5.0]),
+        )
+        assert metric.compute() == pytest.approx(22.0)
+
+    def test_below_bound(self) -> None:
+        # [2, 4], y=0 below by 2 -> width 2 + 20 * 2 = 42
+        metric = IntervalScore(coverage=0.9)
+        metric.update(torch.tensor([2.0]), torch.tensor([4.0]), torch.tensor([0.0]))
+        assert metric.compute() == pytest.approx(42.0)
+
+    @pytest.mark.parametrize("coverage", [0.0, 1.0, -0.1, 1.5])
+    def test_invalid_coverage(self, coverage: float) -> None:
+        with pytest.raises(ValueError, match="coverage must be in"):
+            IntervalScore(coverage=coverage)
+
+    def test_shape_mismatch(self) -> None:
+        metric = IntervalScore(coverage=0.9)
+        with pytest.raises(ValueError, match="same shape"):
+            metric.update(torch.zeros(3), torch.ones(3), torch.zeros(2))


### PR DESCRIPTION
## Description

A first pass at the interval-scoring part of #327 — the three metrics that share a `(lower, upper[, target])` signature and tell one story about a central prediction interval:

- **`IntervalCoverage`** (PICP) — empirical fraction of targets inside `[lower, upper]`. The docstring is explicit that coverage is gameable on its own (a wide-enough interval reaches 1.0), so it should always be read next to a width/score metric.
- **`MeanIntervalWidth`** (MPIW / sharpness) — mean `upper - lower`; only meaningful jointly with coverage (narrower is better *at equal coverage*).
- **`IntervalScore`** (Winkler / interval score) — the proper scoring rule `(u − l) + (2/α)(l − y)·1[y<l] + (2/α)(y − u)·1[y>u]` at nominal coverage `1 − α`, which penalizes width and miscoverage jointly, so a trivially wide interval no longer scores well. Ref: Gneiting & Raftery (2007), Eq. 43.

All three are `torchmetrics.Metric` subclasses following the `add_state` / `update` / `compute` pattern of the existing regression metrics, accept inputs of any shape (flattened, so batch and output dims pool into one scalar), and validate that `lower` / `upper` / `target` shapes agree.

I scoped this PR to the central-interval trio to keep it small and reviewable. The remaining items in #327 — mean pinball loss as a metric, CRPS over a τ-grid, and the coverage-from-quantiles variant of `QuantileCalibrationError` — operate on a set of quantiles + levels rather than a single interval, so they're a natural second PR. Happy to follow up with those, and happy to adjust naming/interface here (e.g. different class names, or taking stacked quantiles) before this lands.

Partially addresses #327 (the interval-metrics portion; deliberately not using a closing keyword since the pinball/CRPS/coverage-from-quantiles items remain).

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`pytest tests/metrics/regression/test_interval.py`)
- [x] Code is formatted (`ruff format && ruff check`)
- [x] Code coverage is not reduced too much (new code is covered by `tests/metrics/regression/test_interval.py`)
- [x] New functions/classes have type annotations and docstrings
- [x] Reference added to the References page (Gneiting & Raftery, 2007, for the interval/Winkler score)
- [x] Licensed code from external sources is explicitly attributed (n/a — original implementation)
