### PR TITLE
Scod fix

### DIFF
--- a/docs/source/evaluation.rst
+++ b/docs/source/evaluation.rst
@@ -206,12 +206,6 @@ datamodule). Three dense, segmentation-specific binary metrics are then computed
   :class:`~torch_uncertainty.metrics.segmentation.SegmentationBinaryAveragePrecision`.
 - ``ood/FPR95`` —
   :class:`~torch_uncertainty.metrics.segmentation.SegmentationFPR95`.
-- ``ood/SCOD_AURC`` — :class:`~torch_uncertainty.metrics.classification.SCODAURC`.
-- ``ood/SCOD_AUGRC`` — :class:`~torch_uncertainty.metrics.classification.SCODAUGRC`.
-- ``ood/SCOD_Cov_5Risk`` —
-  :class:`~torch_uncertainty.metrics.classification.SCODCovAt5Risk`.
-- ``ood/SCOD_Risk_80Cov`` —
-  :class:`~torch_uncertainty.metrics.classification.SCODRiskAt80Cov`.
 
 The OOD score is again controlled by ``ood_criterion``. See the
 :doc:`MUAD segmentation tutorial <auto_tutorials/Segmentation/tutorial_muad_seg>` for an

--- a/src/torch_uncertainty/metrics/classification/risk_coverage.py
+++ b/src/torch_uncertainty/metrics/classification/risk_coverage.py
@@ -398,14 +398,15 @@ class CovAtxRisk(Metric):
         if num_samples < 1:
             return torch.tensor([float("nan")], device=self.device)
         error_rates = _aurc_rejection_rate_compute(scores, errors)
-        admissible_risks = (error_rates > self.risk_threshold) * 1
-        max_cov_at_risk = admissible_risks.flip(0).argmin()
+        admissible = torch.nonzero(
+            error_rates <= self.risk_threshold,
+            as_tuple=False,
+        ).flatten()
 
-        # check if max_cov_at_risk is really admissible, if not return nan
-        risk = admissible_risks[max_cov_at_risk]
-        if risk > self.risk_threshold:
+        if admissible.numel() == 0:
             return torch.tensor([float("nan")], device=self.device)
-        return 1 - max_cov_at_risk / num_samples
+
+        return (admissible[-1] + 1) / num_samples
 
 
 class CovAt5Risk(CovAtxRisk):

--- a/src/torch_uncertainty/metrics/classification/scod_risk_coverage.py
+++ b/src/torch_uncertainty/metrics/classification/scod_risk_coverage.py
@@ -1,125 +1,490 @@
+import torch
 from torch import Tensor
 
 from .risk_coverage import AUGRC, AURC, CovAtxRisk, RiskAtxCov
 
 
-class SCODAURC(AURC):
-    r"""Area Under the SCOD Risk-Coverage curve.
+class _SCODRiskCoverageMixin:
+    scores: list[Tensor]
+    errors: list[Tensor]
 
-    This metric extends selective classification to a binary
-    in-distribution-vs-out-of-distribution (ID/OOD) decision problem.
+    def _set_ood_cost(self, ood_cost: float) -> None:
+        if not isinstance(ood_cost, float):
+            raise TypeError(f"Expected ood_cost to be of type float, but got {type(ood_cost)}")
+        if not 0 <= ood_cost <= 1:
+            raise ValueError(f"ood_cost should be in the range [0, 1], but got {ood_cost}.")
+        self.ood_cost = ood_cost
 
-    Let :math:`s_i` be an OOD score (higher means *more OOD*) and
-    :math:`e_i \in \{0,1\}` the SCOD error indicator with
-    :math:`e_i = 1` for OOD samples and :math:`e_i = 0` for ID samples.
-    Samples are sorted by decreasing ID acceptance confidence
-    :math:`-s_i`, and the risk at coverage :math:`\kappa = k/N` is:
+    def update(  # pyrefly: ignore[bad-override]
+        self,
+        ood_scores: Tensor,
+        classification_errors: Tensor,
+        is_ood: Tensor,
+    ) -> None:
+        """Store acceptance scores and their associated SCOD losses.
+
+        Args:
+            ood_scores: Scores for which larger values indicate more OOD-like inputs.
+            classification_errors: Boolean indicators of misclassified ID inputs.
+                Values corresponding to OOD inputs are ignored.
+            is_ood: Boolean indicators of OOD inputs.
+        """
+        ood_scores = ood_scores.reshape(-1)
+        classification_errors = classification_errors.reshape(-1)
+        is_ood = is_ood.reshape(-1)
+
+        if not (ood_scores.numel() == classification_errors.numel() == is_ood.numel()):
+            raise ValueError(
+                "ood_scores, classification_errors and is_ood must contain "
+                "the same number of elements."
+            )
+
+        classification_errors = classification_errors.to(dtype=ood_scores.dtype)
+        is_ood = is_ood.bool()
+
+        scod_losses = torch.where(
+            is_ood,
+            torch.full_like(classification_errors, self.ood_cost),
+            classification_errors * (1 - self.ood_cost),
+        )
+
+        # Risk-coverage metrics rank larger scores as more likely to be accepted.
+        self.scores.append(-ood_scores)
+        self.errors.append(scod_losses)
+
+
+class SCODAURC(_SCODRiskCoverageMixin, AURC):
+    r"""Calculate the Area Under the SCOD Risk-Coverage curve.
+
+    Selective Classification with Out-of-Distribution Detection (SCOD)
+    evaluates a classifier and a rejection rule jointly. Unlike ordinary OOD
+    detection, SCOD penalizes both accepted OOD samples and accepted,
+    misclassified in-distribution (ID) samples.
+
+    Let :math:`s_i` be an OOD score for sample :math:`i`, where larger values
+    indicate that a sample is more likely to be OOD. Let
+    :math:`o_i \in \{0, 1\}` indicate whether the sample is OOD and let
+    :math:`e_i \in \{0, 1\}` indicate whether an ID sample is misclassified.
+    For an OOD acceptance cost :math:`c_{\mathrm{OOD}} \in [0, 1]`, the
+    per-sample SCOD loss is
 
     .. math::
 
-        r\!\left(\tfrac{k}{N}\right) = \frac{1}{k}\sum_{i=1}^{k} e_{\sigma(i)}.
+        \ell_i =
+        \begin{cases}
+            0,
+            & o_i = 0,\ e_i = 0,\\
+            1 - c_{\mathrm{OOD}},
+            & o_i = 0,\ e_i = 1,\\
+            c_{\mathrm{OOD}},
+            & o_i = 1.
+        \end{cases}
 
-    The SCOD-AURC is then:
-
-    .. math::
-
-        \text{SCOD-AURC} = \int_0^1 r(\kappa)\,\mathrm{d}\kappa
-        \approx \frac{1}{N}\sum_{k=1}^{N} r\!\left(\tfrac{k}{N}\right).
-
-    As input to ``forward`` and ``update`` the metric accepts the following input:
-
-    - **ood_scores** (:class:`~torch.Tensor`): A float tensor of shape ``(N, ...)``
-      containing OOD scores.
-    - **targets** (:class:`~torch.Tensor`): A binary int tensor of shape ``(N, ...)``
-      with ``0`` for ID and ``1`` for OOD.
-    """
-
-    def update(self, ood_scores: Tensor, targets: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        """Store SCOD confidence scores and associated detection errors.
-
-        Args:
-            ood_scores: OOD scores where higher means more OOD-like.
-            targets: Binary labels, with 0 for ID and 1 for OOD.
-        """
-        self.scores.append(-ood_scores.reshape(-1))
-        self.errors.append(targets.reshape(-1).float())
-
-
-class SCODAUGRC(AUGRC):
-    r"""Area Under the SCOD Generalized Risk-Coverage curve.
-
-    Using the same notation as :class:`SCODAURC`, the generalized SCOD risk is:
+    Equivalently,
 
     .. math::
 
-        \text{SCOD-AUGRC} = \int_0^1 \kappa \cdot r(\kappa)\,\mathrm{d}\kappa
-        \approx \frac{1}{N}\sum_{k=1}^{N}\frac{k}{N}\cdot r\!\left(\tfrac{k}{N}\right).
+        \ell_i =
+        c_{\mathrm{OOD}} o_i
+        + (1 - c_{\mathrm{OOD}})(1-o_i)e_i.
+
+    This convention corresponds to the cost :math:`c_{\mathrm{fn}}` used by
+    Narasimhan et al. The parameter :math:`\beta` used by Xia and Bouganis
+    instead denotes the ID misclassification cost, and therefore satisfies
+
+    .. math::
+
+        \beta = 1 - c_{\mathrm{OOD}}.
+
+    Let :math:`\sigma` be the permutation sorting the :math:`N` samples by
+    increasing OOD score,
+
+    .. math::
+
+        s_{\sigma(1)} \leq \cdots \leq s_{\sigma(N)},
+
+    so that samples most likely to be accepted appear first. At empirical
+    coverage :math:`\kappa_k = k/N`, the SCOD selective risk is
+
+    .. math::
+
+        r(\kappa_k)
+        = \frac{1}{k}\sum_{j=1}^{k}\ell_{\sigma(j)}.
+
+    The SCOD-AURC is the area under this joint risk-coverage curve:
+
+    .. math::
+
+        \operatorname{SCOD\text{-}AURC}
+        = \int_0^1 r(\kappa)\,\mathrm{d}\kappa.
+
+    The discrete integration and finite-sample normalization follow
+    :class:`~torch_uncertainty.metrics.classification.AURC`.
+
+    As input to ``forward`` and ``update``, the metric accepts:
+
+    - **ood_scores** (:class:`~torch.Tensor`): Float tensor containing one OOD
+      score per sample. Larger values must indicate more OOD-like samples.
+    - **classification_errors** (:class:`~torch.Tensor`): Boolean or binary
+      tensor indicating misclassified ID samples. Values corresponding to OOD
+      samples are ignored.
+    - **is_ood** (:class:`~torch.Tensor`): Boolean or binary tensor indicating
+      which samples are OOD.
+
+    As output to ``forward`` and ``compute``, the metric returns:
+
+    - **scod_aurc** (:class:`~torch.Tensor`): Scalar tensor containing the area
+      under the SCOD risk-coverage curve. Lower values are better.
+
+    Args:
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    Note:
+        The empirical ratio of ID to OOD samples determines the mixture
+        proportion evaluated by this metric. Results obtained with different
+        ID/OOD ratios are therefore not directly comparable unless the mixture
+        proportions are controlled.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+        [3] `Geifman & El-Yaniv. Selective Classification for Deep Neural
+        Networks. NeurIPS, 2017.
+        <https://papers.nips.cc/paper_files/paper/2017/file/4a8423d5e91fda00bb7e46540e2b0cf1-Paper.pdf>`_.
     """
 
-    def update(self, ood_scores: Tensor, targets: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        """Store SCOD confidence scores and associated detection errors.
-
-        Args:
-            ood_scores: OOD scores where higher means more OOD-like.
-            targets: Binary labels, with 0 for ID and 1 for OOD.
-        """
-        self.scores.append(-ood_scores.reshape(-1))
-        self.errors.append(targets.reshape(-1).float())
+    def __init__(self, ood_cost: float = 0.5, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._set_ood_cost(ood_cost)
 
 
-class SCODCovAtxRisk(CovAtxRisk):
-    r"""Coverage at x SCOD risk.
+class SCODAUGRC(_SCODRiskCoverageMixin, AUGRC):
+    r"""Calculate the Area Under the Generalized SCOD Risk-Coverage curve.
 
-    This metric returns the maximum selective coverage for which the SCOD risk
-    remains below a target threshold.
+    This metric applies the generalized risk-coverage construction of
+    :class:`~torch_uncertainty.metrics.classification.AUGRC` to the joint SCOD
+    loss defined by
+    :class:`~torch_uncertainty.metrics.classification.SCODAURC`.
+
+    Let :math:`r(\kappa)` denote the SCOD selective risk at coverage
+    :math:`\kappa`. The generalized SCOD risk is
+    :math:`\kappa r(\kappa)`, and its area is
+
+    .. math::
+
+        \operatorname{SCOD\text{-}AUGRC}
+        = \int_0^1 \kappa r(\kappa)\,\mathrm{d}\kappa.
+
+    At empirical coverage :math:`\kappa_k=k/N`, this uses
+
+    .. math::
+
+        \kappa_k r(\kappa_k)
+        = \frac{1}{N}\sum_{j=1}^{k}\ell_{\sigma(j)},
+
+    where :math:`\ell_i` is the SCOD loss and :math:`\sigma` orders samples
+    from lowest to highest OOD score.
+
+    As input to ``forward`` and ``update``, the metric accepts:
+
+    - **ood_scores** (:class:`~torch.Tensor`): Float tensor containing OOD
+      scores, where larger values indicate more OOD-like samples.
+    - **classification_errors** (:class:`~torch.Tensor`): Boolean or binary
+      tensor indicating misclassified ID samples.
+    - **is_ood** (:class:`~torch.Tensor`): Boolean or binary tensor indicating
+      OOD samples.
+
+    As output to ``forward`` and ``compute``, the metric returns:
+
+    - **scod_augrc** (:class:`~torch.Tensor`): Scalar tensor containing the area
+      under the generalized SCOD risk-coverage curve. Lower values are better.
+
+    Args:
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    Note:
+        SCOD-AUGRC is the Torch-Uncertainty generalized risk-coverage metric
+        applied to the SCOD loss. It is a natural SCOD extension of AUGRC, but
+        it is not introduced under this name in the original SCOD papers.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+        [3] `Traub et al. Overcoming Common Flaws in the Evaluation of
+        Selective Classification Systems.
+        <https://arxiv.org/abs/2407.01032>`_.
+
+    See Also:
+        :class:`~torch_uncertainty.metrics.classification.SCODAURC`:
+            Definition of the SCOD loss and selective risk.
+        :class:`~torch_uncertainty.metrics.classification.AUGRC`:
+            Original generalized risk-coverage metric.
     """
 
-    def update(self, ood_scores: Tensor, targets: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        """Store SCOD confidence scores and associated detection errors.
+    def __init__(self, ood_cost: float = 0.5, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._set_ood_cost(ood_cost)
 
-        Args:
-            ood_scores: OOD scores where higher means more OOD-like.
-            targets: Binary labels, with 0 for ID and 1 for OOD.
-        """
-        self.scores.append(-ood_scores.reshape(-1))
-        self.errors.append(targets.reshape(-1).float())
+
+class SCODCovAtxRisk(_SCODRiskCoverageMixin, CovAtxRisk):
+    r"""Calculate the maximum coverage at a specified SCOD risk.
+
+    This metric applies
+    :class:`~torch_uncertainty.metrics.classification.CovAtxRisk` to the joint
+    SCOD loss defined by
+    :class:`~torch_uncertainty.metrics.classification.SCODAURC`.
+
+    Let :math:`r(\kappa_k)` denote the empirical SCOD selective risk at
+    coverage :math:`\kappa_k=k/N`. For a risk threshold
+    :math:`\tau\in[0,1]`, coverage at SCOD risk :math:`\tau` is
+
+    .. math::
+
+        \operatorname{SCOD\text{-}Cov@Risk}(\tau)
+        =
+        \max\left\{
+            \kappa_k :
+            r(\kappa_k)\leq\tau,\quad k\in\{1,\ldots,N\}
+        \right\}.
+
+    If no positive coverage satisfies the risk constraint, the metric returns
+    ``nan``. Because empirical selective risk need not be monotonic in
+    coverage, the metric considers every available coverage and returns the
+    largest admissible one.
+
+    As input to ``forward`` and ``update``, the metric accepts:
+
+    - **ood_scores** (:class:`~torch.Tensor`): Float tensor containing OOD
+      scores, where larger values indicate more OOD-like samples.
+    - **classification_errors** (:class:`~torch.Tensor`): Boolean or binary
+      tensor indicating misclassified ID samples.
+    - **is_ood** (:class:`~torch.Tensor`): Boolean or binary tensor indicating
+      OOD samples.
+
+    As output to ``forward`` and ``compute``, the metric returns:
+
+    - **scod_coverage** (:class:`~torch.Tensor`): Scalar tensor containing the
+      maximum coverage satisfying the SCOD risk constraint. Higher values are
+      better.
+
+    Args:
+        risk_threshold: Maximum admissible SCOD risk :math:`\tau`.
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+    See Also:
+        :class:`~torch_uncertainty.metrics.classification.SCODAURC`:
+            Definition of the SCOD loss and selective risk.
+        :class:`~torch_uncertainty.metrics.classification.CovAtxRisk`:
+            Corresponding selective-classification metric.
+    """
+
+    def __init__(
+        self,
+        risk_threshold: float,
+        ood_cost: float = 0.5,
+        **kwargs,
+    ) -> None:
+        super().__init__(risk_threshold=risk_threshold, **kwargs)
+        self._set_ood_cost(ood_cost)
 
 
 class SCODCovAt5Risk(SCODCovAtxRisk):
-    r"""Coverage at 5% SCOD risk.
+    r"""Calculate the maximum coverage at 5% SCOD risk.
 
-    This is a specific case of :class:`SCODCovAtxRisk` with
-    ``risk_threshold = 0.05``.
+    This is the fixed-threshold variant of
+    :class:`~torch_uncertainty.metrics.classification.SCODCovAtxRisk` with
+    :math:`\tau=0.05`:
+
+    .. math::
+
+        \operatorname{SCOD\text{-}Cov@5Risk}
+        =
+        \max\left\{
+            \kappa_k :
+            r(\kappa_k)\leq 0.05,\quad k\in\{1,\ldots,N\}
+        \right\}.
+
+    If no positive coverage has a SCOD risk at most 5%, the metric returns
+    ``nan``.
+
+    Args:
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+    See Also:
+        :class:`~torch_uncertainty.metrics.classification.SCODCovAtxRisk`:
+            General metric with a configurable risk threshold.
     """
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(risk_threshold=0.05, **kwargs)
+    def __init__(self, ood_cost: float = 0.5, **kwargs) -> None:
+        super().__init__(
+            risk_threshold=0.05,
+            ood_cost=ood_cost,
+            **kwargs,
+        )
 
 
-class SCODRiskAtxCov(RiskAtxCov):
-    r"""SCOD risk at x coverage.
+class SCODRiskAtxCov(_SCODRiskCoverageMixin, RiskAtxCov):
+    r"""Calculate the SCOD risk at a specified coverage.
 
-    This metric returns the SCOD error rate measured at a fixed selective
-    coverage level.
+    This metric applies
+    :class:`~torch_uncertainty.metrics.classification.RiskAtxCov` to the joint
+    SCOD loss defined by
+    :class:`~torch_uncertainty.metrics.classification.SCODAURC`.
+
+    For a target coverage :math:`\gamma\in[0,1]`, let
+
+    .. math::
+
+        k_\gamma = \left\lceil \gamma N \right\rceil.
+
+    Samples are ordered from lowest to highest OOD score, and the reported
+    SCOD risk is
+
+    .. math::
+
+        \operatorname{SCOD\text{-}Risk@Cov}(\gamma)
+        =
+        r\left(\frac{k_\gamma}{N}\right)
+        =
+        \frac{1}{k_\gamma}
+        \sum_{j=1}^{k_\gamma}\ell_{\sigma(j)}.
+
+    As input to ``forward`` and ``update``, the metric accepts:
+
+    - **ood_scores** (:class:`~torch.Tensor`): Float tensor containing OOD
+      scores, where larger values indicate more OOD-like samples.
+    - **classification_errors** (:class:`~torch.Tensor`): Boolean or binary
+      tensor indicating misclassified ID samples.
+    - **is_ood** (:class:`~torch.Tensor`): Boolean or binary tensor indicating
+      OOD samples.
+
+    As output to ``forward`` and ``compute``, the metric returns:
+
+    - **scod_risk** (:class:`~torch.Tensor`): Scalar tensor containing the SCOD
+      risk at the requested coverage. Lower values are better.
+
+    Args:
+        cov_threshold: Target coverage :math:`\gamma`.
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+    See Also:
+        :class:`~torch_uncertainty.metrics.classification.SCODAURC`:
+            Definition of the SCOD loss and selective risk.
+        :class:`~torch_uncertainty.metrics.classification.RiskAtxCov`:
+            Corresponding selective-classification metric.
     """
 
-    def update(self, ood_scores: Tensor, targets: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        """Store SCOD confidence scores and associated detection errors.
-
-        Args:
-            ood_scores: OOD scores where higher means more OOD-like.
-            targets: Binary labels, with 0 for ID and 1 for OOD.
-        """
-        self.scores.append(-ood_scores.reshape(-1))
-        self.errors.append(targets.reshape(-1).float())
+    def __init__(
+        self,
+        cov_threshold: float,
+        ood_cost: float = 0.5,
+        **kwargs,
+    ) -> None:
+        super().__init__(cov_threshold=cov_threshold, **kwargs)
+        self._set_ood_cost(ood_cost)
 
 
 class SCODRiskAt80Cov(SCODRiskAtxCov):
-    r"""SCOD risk at 80% coverage.
+    r"""Calculate the SCOD risk at 80% coverage.
 
-    This is a specific case of :class:`SCODRiskAtxCov` with
-    ``cov_threshold = 0.8``.
+    This is the fixed-coverage variant of
+    :class:`~torch_uncertainty.metrics.classification.SCODRiskAtxCov` with
+    :math:`\gamma=0.8`. For :math:`N` samples, it reports
+
+    .. math::
+
+        \operatorname{SCOD\text{-}Risk@80Cov}
+        =
+        r\left(
+            \frac{\lceil 0.8N\rceil}{N}
+        \right).
+
+    Samples are ordered from lowest to highest OOD score before the risk is
+    evaluated.
+
+    Args:
+        ood_cost: Relative cost :math:`c_{\mathrm{OOD}}` of accepting an OOD
+            sample. The cost of accepting a misclassified ID sample is
+            ``1 - ood_cost``. Defaults to ``0.5``.
+        kwargs: Additional keyword arguments passed to
+            :class:`torchmetrics.Metric`.
+
+    References:
+        [1] `Xia & Bouganis. Augmenting Softmax Information for Selective
+        Classification with Out-of-Distribution Data. ACCV, 2022.
+        <https://openaccess.thecvf.com/content/ACCV2022/papers/Xia_Augmenting_Softmax_Information_for_Selective_Classification_with_Out-of-Distribution_Data_ACCV_2022_paper.pdf>`_.
+
+        [2] `Narasimhan et al. Plugin Estimators for Selective Classification
+        with Out-of-Distribution Detection.
+        <https://arxiv.org/abs/2301.12386>`_.
+
+    See Also:
+        :class:`~torch_uncertainty.metrics.classification.SCODRiskAtxCov`:
+            General metric with configurable coverage.
     """
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(cov_threshold=0.8, **kwargs)
+    def __init__(self, ood_cost: float = 0.5, **kwargs) -> None:
+        super().__init__(
+            cov_threshold=0.8,
+            ood_cost=ood_cost,
+            **kwargs,
+        )

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -279,7 +279,7 @@ class ClassificationRoutine(LightningModule):
                 compute_groups=[
                     ["SCOD_AURC", "SCOD_AUGRC", "SCOD_Cov_5Risk", "SCOD_Risk_80Cov"],
                 ],
-            ).clone(prefix="ood/SCOD_")
+            ).clone(prefix="ood/")
 
             self.test_ood_entropy = Entropy()
 

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -73,6 +73,7 @@ class ClassificationRoutine(LightningModule):
         eval_grouping_loss: bool = False,
         ood_criterion: TUOODCriterion | str = "msp",
         post_processing: PostProcessing | None = None,
+        scod_ood_cost: float = 0.5,
         num_bins_calibration_error: int = 15,
         log_plots: bool = False,
         save_to_csv: bool = False,
@@ -103,6 +104,10 @@ class ClassificationRoutine(LightningModule):
                 Probability score.
             post_processing: Post-processing method to train on the calibration set. No post-processing if None.
                 Defaults to ``None``.
+            scod_ood_cost: Relative cost of accepting an out-of-distribution sample
+                when computing SCOD metrics. The cost of accepting a misclassified
+                in-distribution sample is ``1 - scod_ood_cost``. Must be between
+                ``0`` and ``1``. Defaults to ``0.5``.
             num_bins_calibration_error: Number of bins to compute calibration error metrics.
                 Defaults to ``15``.
             log_plots: Indicates whether to log plots from metrics. Defaults to ``False``.
@@ -143,6 +148,7 @@ class ClassificationRoutine(LightningModule):
             num_bins_calibration_error=num_bins_calibration_error,
             mixup_params=mixup_params,
             post_processing=post_processing,
+            scod_ood_cost=scod_ood_cost,
             format_batch_fn=format_batch_fn,
         )
 
@@ -172,6 +178,7 @@ class ClassificationRoutine(LightningModule):
         if self.post_processing is not None:
             self.post_processing.set_model(self.model)
 
+        self.scod_ood_cost = scod_ood_cost
         self._init_metrics()
         self.mixup = self._init_mixup(mixup_params)
 
@@ -250,23 +257,30 @@ class ClassificationRoutine(LightningModule):
         self.test_id_entropy = Entropy()
 
         if self.eval_ood:
-            ood_metrics = MetricCollection(
+            self.test_ood_metrics = MetricCollection(
                 {
                     "AUROC": BinaryAUROC(),
                     "AUPR": BinaryAveragePrecision(),
                     "FPR95": FPR95(pos_label=1),
-                    "SCOD_AURC": SCODAURC(),
-                    "SCOD_AUGRC": SCODAUGRC(),
-                    "SCOD_Cov_5Risk": SCODCovAt5Risk(),
-                    "SCOD_Risk_80Cov": SCODRiskAt80Cov(),
                 },
                 compute_groups=[
                     ["AUROC", "AUPR"],
                     ["FPR95"],
+                ],
+            ).clone(prefix="ood/")
+
+            self.test_scod_metrics = MetricCollection(
+                {
+                    "SCOD_AURC": SCODAURC(ood_cost=self.scod_ood_cost),
+                    "SCOD_AUGRC": SCODAUGRC(ood_cost=self.scod_ood_cost),
+                    "SCOD_Cov_5Risk": SCODCovAt5Risk(ood_cost=self.scod_ood_cost),
+                    "SCOD_Risk_80Cov": SCODRiskAt80Cov(ood_cost=self.scod_ood_cost),
+                },
+                compute_groups=[
                     ["SCOD_AURC", "SCOD_AUGRC", "SCOD_Cov_5Risk", "SCOD_Risk_80Cov"],
                 ],
-            )
-            self.test_ood_metrics = ood_metrics.clone(prefix="ood/")
+            ).clone(prefix="ood/SCOD_")
+
             self.test_ood_entropy = Entropy()
 
         if self.eval_shift:
@@ -528,6 +542,18 @@ class ClassificationRoutine(LightningModule):
             if self.eval_ood:
                 self.test_ood_metrics.update(ood_scores, torch.zeros_like(targets))
 
+                if self.binary_cls:
+                    id_preds = (probs.squeeze(-1) >= 0.5).long()
+                else:
+                    id_preds = probs.argmax(dim=-1)
+
+                classification_errors = id_preds.ne(targets)
+                self.test_scod_metrics.update(
+                    ood_scores,
+                    classification_errors=classification_errors,
+                    is_ood=torch.zeros_like(classification_errors),
+                )
+
             if self.id_score_storage is not None:
                 self.id_score_storage.append(ood_scores.detach().cpu())
 
@@ -537,6 +563,13 @@ class ClassificationRoutine(LightningModule):
         if self.eval_ood and dataloader_idx == 1:
             self.test_ood_entropy.update(probs)
             self.test_ood_metrics.update(ood_scores, torch.ones_like(targets))
+
+            is_ood = torch.ones_like(targets, dtype=torch.bool)
+            self.test_scod_metrics.update(
+                ood_scores,
+                classification_errors=torch.zeros_like(is_ood),
+                is_ood=is_ood,
+            )
 
             if self.is_ensemble:
                 self.test_ood_ens_metrics.update(probs_per_est)
@@ -587,9 +620,11 @@ class ClassificationRoutine(LightningModule):
             result_dict |= self.test_id_ens_metrics.compute()
 
         if self.eval_ood:
-            result_dict |= self.test_ood_metrics.compute() | {
-                "ood/Entropy": self.test_ood_entropy.compute()
-            }
+            result_dict |= (
+                self.test_ood_metrics.compute()
+                | self.test_scod_metrics.compute()
+                | {"ood/Entropy": self.test_ood_entropy.compute()}
+            )
             if self.is_ensemble:
                 result_dict |= self.test_ood_ens_metrics.compute()
 
@@ -618,6 +653,7 @@ class ClassificationRoutine(LightningModule):
             self.test_id_ens_metrics.reset()
         if self.eval_ood:
             self.test_ood_metrics.reset()
+            self.test_scod_metrics.reset()
             self.test_ood_entropy.reset()
             if self.is_ensemble:
                 self.test_ood_ens_metrics.reset()
@@ -671,6 +707,7 @@ def _classification_routine_checks(
     num_bins_calibration_error: int,
     mixup_params: dict | None,
     post_processing: PostProcessing | None,
+    scod_ood_cost: float,
     format_batch_fn: nn.Module | None,
 ) -> None:
     """Check the domains of the arguments of the classification routine.
@@ -684,6 +721,8 @@ def _classification_routine_checks(
         num_bins_calibration_error: the number of bins for the evaluation of the calibration.
         mixup_params: the dictionary to setup the mixup augmentation.
         post_processing: the post-processing module.
+        scod_ood_cost: Cost of accepting an OOD sample in SCOD metrics.
+            Misclassified ID samples cost ``1 - scod_ood_cost``.
         format_batch_fn: the function for formatting the batch for ensembles.
     """
     ood_criterion = get_ood_criterion(ood_criterion)
@@ -709,7 +748,7 @@ def _classification_routine_checks(
 
     if num_classes < 1:
         raise ValueError(
-            f"The number of classes must be a positive integer >= 1. Got {num_classes}."
+            f"The number of classes must be a positive integer >= 1. Got {num_classes=}."
         )
 
     if eval_grouping_loss and not hasattr(model, "feats_forward"):
@@ -727,7 +766,7 @@ def _classification_routine_checks(
 
     if num_bins_calibration_error < 2:
         raise ValueError(
-            f"num_bins_calibration_error must be at least 2, got {num_bins_calibration_error}."
+            f"num_bins_calibration_error must be at least 2, got {num_bins_calibration_error=}."
         )
 
     if mixup_params is not None and isinstance(format_batch_fn, RepeatTarget):
@@ -739,3 +778,10 @@ def _classification_routine_checks(
         raise ValueError(
             "Ensembles and post-processing methods cannot be used together. Raise an issue if needed."
         )
+
+    if not isinstance(scod_ood_cost, float):
+        raise TypeError(
+            f"Expected scod_ood_cost to be of type float, but got {type(scod_ood_cost)=}"
+        )
+    if not 0 <= scod_ood_cost <= 1:
+        raise ValueError(f"scod_ood_cost should be in the range [0, 1], but got {scod_ood_cost=}.")

--- a/src/torch_uncertainty/routines/segmentation.py
+++ b/src/torch_uncertainty/routines/segmentation.py
@@ -20,8 +20,6 @@ from torch_uncertainty.methods import (
 from torch_uncertainty.metrics import (
     AUGRC,
     AURC,
-    SCODAUGRC,
-    SCODAURC,
     BrierScore,
     CalibrationError,
     CategoricalNLL,
@@ -29,8 +27,6 @@ from torch_uncertainty.metrics import (
     MeanIntersectionOverUnion,
     PAvPU,
     RiskAt80Cov,
-    SCODCovAt5Risk,
-    SCODRiskAt80Cov,
     SegmentationBinaryAUROC,
     SegmentationBinaryAveragePrecision,
     SegmentationFPR95,
@@ -228,10 +224,6 @@ class SegmentationRoutine(LightningModule):
                     "AUROC": SegmentationBinaryAUROC(),
                     "AUPR": SegmentationBinaryAveragePrecision(),
                     "FPR95": SegmentationFPR95(pos_label=1),
-                    "SCOD_AURC": SCODAURC(),
-                    "SCOD_AUGRC": SCODAUGRC(),
-                    "SCOD_Cov_5Risk": SCODCovAt5Risk(),
-                    "SCOD_Risk_80Cov": SCODRiskAt80Cov(),
                 }
             )
             self.test_ood_metrics = ood_metrics.clone(prefix="ood/")

--- a/tests/metrics/classification/test_scod_risk_coverage.py
+++ b/tests/metrics/classification/test_scod_risk_coverage.py
@@ -1,52 +1,269 @@
 import pytest
 import torch
+from torch import Tensor
 
 from torch_uncertainty.metrics.classification import (
     SCODAUGRC,
     SCODAURC,
     SCODCovAt5Risk,
+    SCODCovAtxRisk,
     SCODRiskAt80Cov,
+    SCODRiskAtxCov,
 )
 
 
+@pytest.fixture
+def scod_inputs() -> tuple[Tensor, Tensor, Tensor]:
+    """Return scores yielding SCOD losses [0, 0.25, 0.75, 0].
+
+    With ``ood_cost=0.75``:
+
+    - correct ID costs 0,
+    - misclassified ID costs 0.25,
+    - OOD costs 0.75.
+
+    The OOD scores are already ordered from most to least acceptable.
+    """
+    ood_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
+    classification_errors = torch.tensor([False, True, False, False])
+    is_ood = torch.tensor([False, False, True, False])
+    return ood_scores, classification_errors, is_ood
+
+
 class TestSCODAURC:
-    def test_compute_binary_extremes(self) -> None:
-        ood_scores = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.2])
-        labels = torch.zeros(5)
-        metric = SCODAURC()
-        assert metric(ood_scores, labels).item() == pytest.approx(0)
+    def test_compute_joint_scod_risk(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODAURC(ood_cost=0.75)
 
-        labels = torch.ones(5)
-        metric = SCODAURC()
-        assert metric(ood_scores, labels).item() == pytest.approx(1)
+        metric.update(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        # Accepted losses are [0, 0.25, 0.75, 0], giving cumulative
+        # risks [0, 0.125, 1 / 3, 0.25].
+        assert torch.allclose(
+            metric.partial_compute(),
+            torch.tensor([0.0, 0.125, 1 / 3, 0.25]),
+        )
+        assert metric.compute().item() == pytest.approx(7 / 36)
+
+    def test_compute_across_separate_id_and_ood_updates(self) -> None:
+        metric = SCODAURC(ood_cost=0.75)
+
+        metric.update(
+            ood_scores=torch.tensor([0.1, 0.2, 0.4]),
+            classification_errors=torch.tensor([False, True, False]),
+            is_ood=torch.zeros(3, dtype=torch.bool),
+        )
+        metric.update(
+            ood_scores=torch.tensor([0.3]),
+            classification_errors=torch.tensor([False]),
+            is_ood=torch.ones(1, dtype=torch.bool),
+        )
+
+        assert torch.allclose(
+            metric.partial_compute(),
+            torch.tensor([0.0, 0.125, 1 / 3, 0.25]),
+        )
+        assert metric.compute().item() == pytest.approx(7 / 36)
+
+    def test_default_cost_extremes(self) -> None:
+        ood_scores = torch.tensor([0.1, 0.2, 0.3, 0.4])
+        is_id = torch.zeros(4, dtype=torch.bool)
 
         metric = SCODAURC()
-        assert metric(torch.tensor([0.0]), torch.tensor([1.0])).isnan()
+        result = metric(
+            ood_scores,
+            torch.zeros(4, dtype=torch.bool),
+            is_id,
+        )
+        assert result.item() == pytest.approx(0.0)
+
+        metric = SCODAURC()
+        result = metric(
+            ood_scores,
+            torch.ones(4, dtype=torch.bool),
+            is_id,
+        )
+        assert result.item() == pytest.approx(0.5)
+
+        metric = SCODAURC()
+        result = metric(
+            ood_scores,
+            torch.zeros(4, dtype=torch.bool),
+            torch.ones(4, dtype=torch.bool),
+        )
+        assert result.item() == pytest.approx(0.5)
+
+    def test_classification_error_is_ignored_for_ood(self) -> None:
+        metric = SCODAURC(ood_cost=0.75)
+        metric.update(
+            ood_scores=torch.tensor([0.1, 0.2]),
+            classification_errors=torch.tensor([True, True]),
+            is_ood=torch.tensor([True, True]),
+        )
+
+        assert torch.allclose(
+            metric.partial_compute(),
+            torch.tensor([0.75, 0.75]),
+        )
+        assert metric.compute().item() == pytest.approx(0.75)
+
+    def test_single_sample_returns_nan(self) -> None:
+        metric = SCODAURC()
+        result = metric(
+            torch.tensor([0.0]),
+            torch.tensor([True]),
+            torch.tensor([False]),
+        )
+
+        assert result.isnan().all()
 
 
 class TestSCODAUGRC:
-    def test_compute_binary_extremes(self) -> None:
-        ood_scores = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.2])
-        labels = torch.zeros(5)
+    def test_compute_joint_scod_risk(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODAUGRC(ood_cost=0.75)
+
+        result = metric(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        assert result.item() == pytest.approx(7 / 48)
+
+    def test_constant_ood_risk(self) -> None:
         metric = SCODAUGRC()
-        assert metric(ood_scores, labels).item() == pytest.approx(0)
+        result = metric(
+            ood_scores=torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5]),
+            classification_errors=torch.zeros(5, dtype=torch.bool),
+            is_ood=torch.ones(5, dtype=torch.bool),
+        )
 
-        labels = torch.ones(5)
-        metric = SCODAUGRC()
-        assert metric(ood_scores, labels).item() == pytest.approx(0.6)
-
-
-class TestSCODCovAt5Risk:
-    def test_compute(self) -> None:
-        ood_scores = torch.tensor([0.05, 0.1, 0.2, 0.3, 0.4])
-        labels = torch.zeros(5)
-        metric = SCODCovAt5Risk()
-        assert metric(ood_scores, labels) == 1
+        # Constant SCOD risk 0.5 multiplied by coverage before integration.
+        assert result.item() == pytest.approx(0.3)
 
 
-class TestSCODRiskAt80Cov:
-    def test_compute(self) -> None:
-        ood_scores = torch.tensor([0.05, 0.1, 0.8, 0.9, 0.95])
-        labels = torch.tensor([0, 0, 1, 1, 1])
-        metric = SCODRiskAt80Cov()
-        assert metric(ood_scores, labels) == 0.5
+class TestSCODCovAtxRisk:
+    def test_compute_maximum_admissible_coverage(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODCovAtxRisk(
+            risk_threshold=0.13,
+            ood_cost=0.75,
+        )
+
+        result = metric(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        # Risks are [0, 0.125, 1 / 3, 0.25], so the largest
+        # admissible coverage is 2 / 4.
+        assert result.item() == pytest.approx(0.5)
+
+    def test_compute_fixed_five_percent_risk(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODCovAt5Risk(ood_cost=0.75)
+
+        result = metric(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        assert result.item() == pytest.approx(0.25)
+
+    def test_no_admissible_coverage_returns_nan(self) -> None:
+        metric = SCODCovAtxRisk(
+            risk_threshold=0.5,
+            ood_cost=0.75,
+        )
+        result = metric(
+            ood_scores=torch.tensor([0.1, 0.2, 0.3]),
+            classification_errors=torch.zeros(3, dtype=torch.bool),
+            is_ood=torch.ones(3, dtype=torch.bool),
+        )
+
+        assert result.isnan().all()
+
+
+class TestSCODRiskAtxCov:
+    def test_compute_risk_at_coverage(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODRiskAtxCov(
+            cov_threshold=0.5,
+            ood_cost=0.75,
+        )
+
+        result = metric(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        assert result.item() == pytest.approx(0.125)
+
+    def test_compute_fixed_eighty_percent_coverage(
+        self,
+        scod_inputs: tuple[Tensor, Tensor, Tensor],
+    ) -> None:
+        ood_scores, classification_errors, is_ood = scod_inputs
+        metric = SCODRiskAt80Cov(ood_cost=0.75)
+
+        result = metric(
+            ood_scores,
+            classification_errors,
+            is_ood,
+        )
+
+        # ceil(4 * 0.8) = 4 accepted samples.
+        assert result.item() == pytest.approx(0.25)
+
+
+class TestSCODRiskCoverageValidation:
+    @pytest.mark.parametrize("metric_cls", [SCODAURC, SCODAUGRC])
+    def test_invalid_ood_cost_type(self, metric_cls: type) -> None:
+        with pytest.raises(TypeError, match=r"Expected ood_cost to be of type float"):
+            metric_cls(ood_cost=1)
+
+    @pytest.mark.parametrize("ood_cost", [-0.1, 1.1])
+    @pytest.mark.parametrize("metric_cls", [SCODAURC, SCODAUGRC])
+    def test_invalid_ood_cost_value(
+        self,
+        metric_cls: type,
+        ood_cost: float,
+    ) -> None:
+        with pytest.raises(ValueError, match=r"ood_cost should be in the range"):
+            metric_cls(ood_cost=ood_cost)
+
+    def test_mismatched_input_sizes(self) -> None:
+        metric = SCODAURC()
+
+        with pytest.raises(
+            ValueError,
+            match=r"must contain the same number of elements",
+        ):
+            metric.update(
+                ood_scores=torch.tensor([0.1, 0.2]),
+                classification_errors=torch.tensor([False]),
+                is_ood=torch.tensor([False, True]),
+            )

--- a/tests/routines/test_classification.py
+++ b/tests/routines/test_classification.py
@@ -465,10 +465,10 @@ class TestClassification:
             eval_ood=True,
         )
         assert routine.test_ood_metrics.prefix == "ood/"
-        assert "SCOD_AURC" in routine.test_ood_metrics
-        assert "SCOD_AUGRC" in routine.test_ood_metrics
-        assert "SCOD_Cov_5Risk" in routine.test_ood_metrics
-        assert "SCOD_Risk_80Cov" in routine.test_ood_metrics
+        assert "SCOD_AURC" in routine.test_scod_metrics
+        assert "SCOD_AUGRC" in routine.test_scod_metrics
+        assert "SCOD_Cov_5Risk" in routine.test_scod_metrics
+        assert "SCOD_Risk_80Cov" in routine.test_scod_metrics
 
         # num_classes
         with pytest.raises(ValueError):

--- a/tests/routines/test_segmentation.py
+++ b/tests/routines/test_segmentation.py
@@ -137,10 +137,6 @@ class TestSegmentation:
             eval_ood=True,
         )
         assert routine.test_ood_metrics.prefix == "ood/"
-        assert "SCOD_AURC" in routine.test_ood_metrics
-        assert "SCOD_AUGRC" in routine.test_ood_metrics
-        assert "SCOD_Cov_5Risk" in routine.test_ood_metrics
-        assert "SCOD_Risk_80Cov" in routine.test_ood_metrics
 
         with pytest.raises(ValueError, match=r"num_classes must be at least 2, got"):
             SegmentationRoutine(model=nn.Identity(), num_classes=1, loss=nn.CrossEntropyLoss())


### PR DESCRIPTION
## Description

Fix the computation of the SCOD metrics that didn't take ID mistakes into account until now.

Fixes #333 

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [ ] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
