### PR TITLE
:recycle: overall metrics fxies, robustification, & improvements

### DIFF
--- a/src/torch_uncertainty/metrics/classification/brier_score.py
+++ b/src/torch_uncertainty/metrics/classification/brier_score.py
@@ -63,8 +63,9 @@ class BrierScore(Metric):
                 <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
 
         Inputs:
-            - :attr:`probs`: :math:`(B, C)` or :math:`(B, N, C)`
-                Predicted probabilities for each class.
+            - :attr:`probs`: :math:`(B, C)` or :math:`(B, N, C)` for multiclass
+                predictions. For binary predictions (``num_classes=1``), :math:`(B)`,
+                :math:`(B, 1)`, or :math:`(B, N, 1)`.
             - :attr:`target`: :math:`(B)` or :math:`(B, C)`
                 Ground truth class labels or one-hot encoded targets.
 
@@ -121,15 +122,30 @@ class BrierScore(Metric):
         self.num_classes = num_classes
         self.top_class = top_class
         self.reduction = reduction
-        self.num_estimators = 1
 
         if self.reduction in ["mean", "sum"]:
-            self.add_state("values", default=torch.tensor(0.0), dist_reduce_fx="sum")
+            self.add_state(
+                "values",
+                default=torch.tensor(0.0),
+                dist_reduce_fx="sum",
+            )
         else:
-            self.add_state("values", default=[], dist_reduce_fx="cat")
-        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+            self.add_state(
+                "values",
+                default=[],
+                dist_reduce_fx="cat",
+            )
+        self.add_state(
+            "total",
+            default=torch.tensor(0),
+            dist_reduce_fx="sum",
+        )
 
-    def update(self, probs: Tensor, target: Tensor) -> None:  # pyrefly: ignore[bad-override]
+    def update(
+        self,
+        probs: Tensor,
+        target: Tensor,
+    ) -> None:  # pyrefly: ignore[bad-override]
         """Update the current Brier score with a new tensor of probabilities.
 
         Args:
@@ -139,29 +155,26 @@ class BrierScore(Metric):
             target: A tensor of ground truth labels of shape
                 (batch, num_classes) or (batch)
         """
-        if target.ndim == 2 and target.shape[-1] == 1:
-            target = target.squeeze(-1)
-        if target.ndim == 1 and self.num_classes > 1:
-            target = F.one_hot(target, self.num_classes)
-
-        if probs.ndim <= 2:
-            batch_size = probs.size(0)
-        elif probs.ndim == 3:
-            batch_size = probs.size(0)
-            self.num_estimators = probs.size(1)
-            target = target.unsqueeze(1).repeat(1, self.num_estimators, 1)
-        else:
-            raise ValueError(
-                f"Expected `probs` to be of shape (batch, num_classes) or "
-                f"(batch, num_estimators, num_classes) but got {probs.shape}"
-            )
+        probs, target = self._format_inputs(probs, target)
 
         if self.top_class:
-            probs, indices = probs.max(dim=-1)
-            target = target.gather(-1, indices.unsqueeze(-1)).squeeze(-1)
-            brier_score = F.mse_loss(probs, target, reduction="none")
+            if self.num_classes == 1:
+                probs = torch.cat((1 - probs, probs), dim=-1)
+                target = torch.cat((1 - target, target), dim=-1)
+
+            confidence, indices = probs.max(dim=-1)
+            correct = target.expand(-1, probs.size(1), -1).gather(
+                dim=-1,
+                index=indices.unsqueeze(-1),
+            )
+            brier_score = (confidence - correct.squeeze(-1)).square()
         else:
-            brier_score = F.mse_loss(probs, target, reduction="none").sum(dim=-1)
+            brier_score = (probs - target).square().sum(dim=-1)
+
+        # Average over estimators immediately so every sample has the same
+        # weight, independently of the number of estimators in each update.
+        brier_score = brier_score.mean(dim=1)
+        batch_size = brier_score.size(0)
 
         if self.reduction is None or self.reduction == "none":
             self.values.append(brier_score)
@@ -169,15 +182,61 @@ class BrierScore(Metric):
             self.values += brier_score.sum()
             self.total += batch_size
 
+    def _format_inputs(
+        self,
+        probs: Tensor,
+        target: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Normalize inputs to (batch, estimators, classes)."""
+        if probs.ndim == 1:
+            if self.num_classes != 1:
+                raise ValueError("One-dimensional `probs` are only supported for binary tasks.")
+            probs = probs[:, None, None]
+        elif probs.ndim == 2:
+            probs = probs.unsqueeze(1)
+        elif probs.ndim != 3:
+            raise ValueError(
+                "Expected `probs` to have shape (batch, num_classes) or "
+                f"(batch, num_estimators, num_classes), but got {probs.shape}."
+            )
+
+        if probs.shape[-1] != self.num_classes:
+            raise ValueError(f"Expected {self.num_classes} classes, but got {probs.shape[-1]}.")
+
+        if target.ndim == 2 and target.shape[-1] == 1:
+            target = target.squeeze(-1)
+
+        if target.ndim == 1:
+            target = (
+                target.unsqueeze(-1)
+                if self.num_classes == 1
+                else F.one_hot(target, self.num_classes)
+            )
+        elif target.ndim != 2 or target.shape[-1] != self.num_classes:
+            raise ValueError(
+                "Expected `target` to have shape (batch) or "
+                f"(batch, num_classes), but got {target.shape}."
+            )
+
+        if probs.shape[0] != target.shape[0]:
+            raise ValueError("Expected `probs` and `target` to have the same batch size.")
+
+        target = target.to(
+            device=probs.device,
+            dtype=probs.dtype,
+        ).unsqueeze(1)
+
+        return probs, target
+
     def compute(self) -> Tensor:
         """Compute the final Brier score based on inputs passed to ``update``.
 
         Returns:
-            Tensor: The final value(s) for the Brier score
+            Tensor: The final value(s) for the Brier score.
         """
         values = dim_zero_cat(self.values)
         if self.reduction == "sum":
-            return values.sum(dim=-1) / self.num_estimators
+            return values.sum()
         if self.reduction == "mean":
-            return values.sum(dim=-1) / self.total / self.num_estimators
+            return values.sum() / self.total
         return values

--- a/src/torch_uncertainty/metrics/classification/fpr.py
+++ b/src/torch_uncertainty/metrics/classification/fpr.py
@@ -26,7 +26,7 @@ class FPRx(Metric):
         equals the target recall level :math:`x`:
 
         .. math::
-            \tau_x = \inf \left\{ \tau \;\middle|\;
+            \tau_x = \sup \left\{ \tau \;\middle|\;
             \frac{|\{i : s_i \geq \tau,\, y_i = 1\}|}{|\{i : y_i = 1\}|} \geq x \right\},
 
         where :math:`s_i` is the confidence score assigned to sample :math:`i` and
@@ -96,53 +96,53 @@ class FPRx(Metric):
             Tensor: The value of the FPRx.
         """
         confidences = dim_zero_cat(self.confidences)
-        targets = dim_zero_cat(self.targets) == self.pos_label
-
-        # map examples and labels to OOD first
-        indx = torch.argsort(targets, descending=True)
-        examples = confidences[indx]
-        labels = torch.zeros_like(targets, dtype=torch.bool, device=self.device)
-        labels[: torch.count_nonzero(targets)] = True
-
-        # sort examples and labels by decreasing confidence
-        desc_scores_indx = torch.argsort(examples, descending=True)
-        examples = examples[desc_scores_indx]
-        labels = labels[desc_scores_indx]
-
-        # Get the indices of the distinct values
-        distinct_value_indices = torch.where(torch.diff(examples))[0]
-        threshold_idxs = torch.cat(
-            [
-                distinct_value_indices,
-                torch.tensor([labels.shape[0] - 1], dtype=torch.long, device=self.device),
-            ]
+        targets = dim_zero_cat(self.targets)
+        return _fprx_compute(
+            confidences,
+            targets,
+            recall_level=self.recall_level,
+            pos_label=self.pos_label,
         )
 
-        # accumulate the true positives with decreasing threshold
-        true_pos = torch.cumsum(labels, dim=0)[threshold_idxs]
-        false_pos = 1 + threshold_idxs - true_pos  # add one because of zero-based indexing
 
-        # check that there is at least one OOD example
-        if true_pos[-1] == 0:
-            return torch.tensor([torch.nan], device=self.device)
+def _fprx_compute(
+    confidences: Tensor,
+    target: Tensor,
+    recall_level: float,
+    pos_label: int,
+) -> Tensor:
+    """Compute a tie-aware FPR at a minimum requested recall."""
+    confidences = confidences.flatten()
+    labels = target.flatten() == pos_label
+    if confidences.shape != labels.shape:
+        raise ValueError("Expected `confidences` and `target` to have the same shape.")
 
-        recall = true_pos / true_pos[-1]
+    num_positive = labels.sum()
+    num_negative = (~labels).sum()
+    if num_positive == 0 or num_negative == 0:
+        dtype = confidences.dtype if confidences.is_floating_point() else torch.float32
+        return torch.tensor(torch.nan, device=confidences.device, dtype=dtype)
+    if recall_level == 0:
+        return confidences.new_tensor(0.0, dtype=torch.float32)
 
-        last_ind = torch.searchsorted(true_pos, true_pos[-1])
-        recall = torch.cat(
-            [
-                recall[: last_ind + 1].flip(0),
-                torch.tensor([1.0], device=self.device),
-            ]
+    order = confidences.argsort(descending=True)
+    sorted_scores = confidences[order]
+    sorted_labels = labels[order]
+
+    # Evaluate thresholds only after complete groups of tied scores. Splitting a
+    # tie could claim a recall/FPR pair that no score threshold can achieve.
+    threshold_idxs = torch.cat(
+        (
+            torch.where(sorted_scores[1:] != sorted_scores[:-1])[0],
+            torch.tensor([labels.numel() - 1], device=labels.device),
         )
-        false_pos = torch.cat(
-            [
-                false_pos[: last_ind + 1].flip(0),
-                torch.tensor([0.0], device=self.device),
-            ]
-        )
-        cutoff = torch.argmin(torch.abs(recall - self.recall_level))
-        return false_pos[cutoff] / (~labels).sum()
+    )
+    true_positive = sorted_labels.cumsum(dim=0)[threshold_idxs]
+    false_positive = threshold_idxs + 1 - true_positive
+    recall = true_positive / num_positive
+
+    cutoff = torch.where(recall >= recall_level)[0][0]
+    return false_positive[cutoff] / num_negative
 
 
 class FPR95(FPRx):

--- a/src/torch_uncertainty/metrics/classification/scod_risk_coverage.py
+++ b/src/torch_uncertainty/metrics/classification/scod_risk_coverage.py
@@ -39,12 +39,23 @@ class _SCODRiskCoverageMixin:
                 "the same number of elements."
             )
 
-        classification_errors = classification_errors.to(dtype=ood_scores.dtype)
-        is_ood = is_ood.bool()
+        if ood_scores.is_floating_point() and not torch.isfinite(ood_scores).all():
+            raise ValueError("ood_scores must contain only finite values.")
+
+        # SCOD losses are fractional even when the ranking scores are integral.
+        # Promote half precision as well, since the parent risk-coverage metrics
+        # perform cumulative sums over the losses.
+        dtype = torch.promote_types(ood_scores.dtype, torch.float32)
+        ood_scores = ood_scores.to(dtype=dtype)
+        classification_errors = classification_errors.to(
+            device=ood_scores.device,
+            dtype=dtype,
+        )
+        is_ood = is_ood.to(device=ood_scores.device, dtype=torch.bool)
 
         scod_losses = torch.where(
             is_ood,
-            torch.full_like(classification_errors, self.ood_cost),
+            torch.full_like(classification_errors, self.ood_cost, dtype=dtype),
             classification_errors * (1 - self.ood_cost),
         )
 

--- a/src/torch_uncertainty/metrics/regression/quantile_calibration.py
+++ b/src/torch_uncertainty/metrics/regression/quantile_calibration.py
@@ -1,31 +1,29 @@
 import warnings
-from typing import Literal, cast
+from typing import Literal
 
+import matplotlib.pyplot as plt
 import torch
 from torch import Tensor
 from torch.distributions import Distribution, Independent
-from torchmetrics.classification import BinaryCalibrationError
-from torchmetrics.functional.classification.calibration_error import (
-    _binning_bucketize,
-)
-from torchmetrics.utilities.data import dim_zero_cat
+from torchmetrics import Metric
 from torchmetrics.utilities.plot import _PLOT_OUT_TYPE
 
-from torch_uncertainty.metrics.classification.calibration.calibration_error import reliability_chart
 
+class QuantileCalibrationError(Metric):
+    is_differentiable = False
+    higher_is_better = False
+    full_state_update = False
 
-class QuantileCalibrationError(BinaryCalibrationError):
-    is_differentiable: bool = False
-    higher_is_better: bool = False
-    full_state_update: bool = False
-    not_implemented_error: bool = False
+    covered: Tensor
+    total: Tensor
+    unsupported: Tensor
 
     def __init__(
         self,
         num_bins: int = 15,
         norm: Literal["l1", "l2", "max"] = "l1",
-        ignore_index=None,
-        validate_args=True,
+        ignore_index: int | None = None,
+        validate_args: bool = True,
         **kwargs,
     ) -> None:
         r"""Quantile Calibration Error for regression tasks.
@@ -40,24 +38,54 @@ class QuantileCalibrationError(BinaryCalibrationError):
             \mathbf{1}\!\left[ y_i \in
             \left[ F^{-1}_{\theta, x_i}\!\left(\tfrac{1 - \alpha}{2}\right),
                    F^{-1}_{\theta, x_i}\!\left(\tfrac{1 + \alpha}{2}\right) \right]
-            \right],
+            \right].
 
-        where :math:`F^{-1}_{\theta, x_i}` is the predictive inverse CDF (computed via
-        the distribution's ``icdf`` method). The Quantile Calibration Error then
-        aggregates the gap :math:`|\hat{c}(\alpha) - \alpha|` over a regular grid of
-        :attr:`num_bins` confidence levels using the chosen :attr:`norm` — the regression
-        counterpart of the :class:`~torch_uncertainty.metrics.classification.CalibrationError`.
+        The metric evaluates this coverage on :attr:`num_bins` confidence levels
+        :math:`\alpha_k` regularly spaced between ``0.05`` and ``0.95``. It returns
+
+        .. math::
+            \operatorname{QCE}_{L_1}
+            = \frac{1}{K}\sum_{k=1}^{K}
+            \left|\hat{c}(\alpha_k)-\alpha_k\right|,
+
+        with analogous root-mean-square and maximum variants for ``norm="l2"``
+        and ``norm="max"``.
+
+        For :class:`~torch.distributions.Independent` distributions, calibration is
+        evaluated marginally: every scalar event component contributes one coverage
+        observation.
 
         Args:
-            num_bins: Number of bins to use for calibration. Defaults to ``15``.
-            norm: Norm to use for calibration error computation. Defaults to ``"l1"``.
-            ignore_index: Index to ignore during calibration. Defaults to ``None``.
-            validate_args: Whether to validate the input arguments. Defaults to ``True``.
+            num_bins: Number of confidence levels. Defaults to ``15``.
+            norm: Norm used to aggregate the calibration gaps. One of ``"l1"``,
+                ``"l2"``, or ``"max"``. Defaults to ``"l1"``.
+            ignore_index: Optional target value to ignore. Defaults to ``None``.
+            validate_args: Whether to validate input shapes. Defaults to ``True``.
             kwargs: Additional keyword arguments, see `Advanced metric settings
-              <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
+                <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
         """
-        super().__init__(num_bins, norm, ignore_index, validate_args, **kwargs)
-        self.conf_intervals = torch.linspace(0.05, 0.95, self.n_bins + 1)
+        super().__init__(**kwargs)
+        if num_bins < 1:
+            raise ValueError(f"Expected `num_bins` to be at least 1, but got {num_bins}.")
+        if norm not in ("l1", "l2", "max"):
+            raise ValueError(f"Expected `norm` to be one of ('l1', 'l2', 'max'), but got {norm}.")
+
+        self.n_bins = num_bins
+        self.norm = norm
+        self.ignore_index = ignore_index
+        self.validate_args = validate_args
+        self.register_buffer("conf_intervals", torch.linspace(0.05, 0.95, num_bins))
+        self.add_state(
+            "covered",
+            default=torch.zeros(num_bins, dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+        self.add_state("total", default=torch.tensor(0, dtype=torch.long), dist_reduce_fx="sum")
+        self.add_state(
+            "unsupported",
+            default=torch.tensor(0, dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
 
     def update(  # pyrefly: ignore[bad-override]
         self,
@@ -65,107 +93,96 @@ class QuantileCalibrationError(BinaryCalibrationError):
         target: Tensor,
         ignore_mask: Tensor | None = None,
     ) -> None:
-        """Update the metric with new predictions and targets.
+        """Update the metric with predictive distributions and targets.
 
         Args:
-            dist: The predicted distribution.
-            target: The ground truth values.
-            ignore_mask: A mask to ignore certain values. Defaults to ``None``.
+            dist: Predicted distribution. It must implement ``icdf``.
+            target: Ground-truth values, with one value per predictive distribution.
+            ignore_mask: Boolean mask of targets to ignore. A mask over only the batch
+                dimensions is expanded over trailing event dimensions. Defaults to ``None``.
         """
-        reduce_event_dims = False
-        if isinstance(dist, Independent):
-            iid_dist = dist.base_dist
-            reduce_event_dims = True
-        else:
-            iid_dist = dist
+        expected_shape = dist.batch_shape + dist.event_shape
+        if self.validate_args and target.shape != expected_shape:
+            raise ValueError(
+                "Expected `target` to have shape equal to the distribution batch and "
+                f"event shapes ({expected_shape}), but got {target.shape}."
+            )
+
+        marginal_dist = dist.base_dist if isinstance(dist, Independent) else dist
+        levels = self.conf_intervals.to(target.device)
 
         try:
-            iid_dist.icdf((1 - self.conf_intervals[0]) / 2)
-
+            intervals = [
+                (
+                    marginal_dist.icdf((1 - level) / 2),
+                    marginal_dist.icdf((1 + level) / 2),
+                )
+                for level in levels
+            ]
         except NotImplementedError:
             warnings.warn(
                 "The distribution does not support the `icdf()` method. "
-                "This metric will therefore return `nan` values. "
-                "Please use a distribution that implements `icdf()`.",
+                "This metric will therefore return `nan`. Please use a "
+                "distribution that implements `icdf()`.",
                 UserWarning,
                 stacklevel=2,
             )
-            self.not_implemented_error = True
+            self.unsupported += 1
             return
 
-        confidences = self.conf_intervals.expand(*dist.batch_shape, -1)
-        correct_mask = torch.empty_like(confidences)
-
-        for i, conf in enumerate(self.conf_intervals):
-            b_min = iid_dist.icdf((1 - conf) / 2)
-            bound_log_prob = iid_dist.log_prob(b_min)
-            target_log_prob = dist.log_prob(target)
-            if reduce_event_dims:
-                indep_dist = cast("Independent", dist)
-                bound_log_prob = bound_log_prob.sum(
-                    dim=list(range(-indep_dist.reinterpreted_batch_ndims, 0))
-                )
-
-            correct_mask[..., i] = (bound_log_prob <= target_log_prob).float()
-
+        valid = torch.ones_like(target, dtype=torch.bool)
+        if self.ignore_index is not None:
+            valid &= target != self.ignore_index
         if ignore_mask is not None:
-            confidences = confidences[~ignore_mask]
-            correct_mask = correct_mask[~ignore_mask]
+            ignore_mask = ignore_mask.bool()
+            while ignore_mask.ndim < target.ndim:
+                ignore_mask = ignore_mask.unsqueeze(-1)
+            try:
+                ignore_mask = torch.broadcast_to(ignore_mask, target.shape)
+            except RuntimeError as err:
+                raise ValueError(
+                    f"Expected `ignore_mask` to be broadcastable to {target.shape}, "
+                    f"but got {ignore_mask.shape}."
+                ) from err
+            valid &= ~ignore_mask
 
-        super().update(confidences.flatten(), correct_mask.flatten())
+        inside = torch.stack(
+            [(target >= lower) & (target <= upper) & valid for lower, upper in intervals]
+        )
+        self.covered += inside.reshape(self.n_bins, -1).sum(dim=1)
+        self.total += valid.sum()
 
     def compute(self) -> Tensor:
-        """Compute the quantile calibration error.
+        """Compute the Quantile Calibration Error."""
+        if self.unsupported > 0 or self.total == 0:
+            return torch.tensor(torch.nan, device=self.covered.device)
 
-        Returns:
-            Tensor: The quantile calibration error.
-
-        Warning:
-            If the distribution does not support ``icdf()``, this returns ``nan`` values.
-        """
-        if self.not_implemented_error:
-            return torch.tensor(float("nan"))
-        return super().compute()
+        empirical_coverage = self.covered / self.total
+        calibration_gap = (empirical_coverage - self.conf_intervals).abs()
+        if self.norm == "l1":
+            return calibration_gap.mean()
+        if self.norm == "l2":
+            return calibration_gap.square().mean().sqrt()
+        return calibration_gap.max()
 
     def plot(self) -> _PLOT_OUT_TYPE:  # pyrefly: ignore[bad-override]
-        """Plot the quantile calibration reliability diagram.
-
-        Raises:
-            NotImplementedError: If the distribution does not support ``icdf()``.
-        """
-        if self.not_implemented_error:
+        """Plot empirical coverage against nominal coverage."""
+        if self.unsupported > 0:
             raise NotImplementedError(
                 "The distribution does not support the `icdf()` method. "
-                "This metric will therefore return `nan` values. "
                 "Please use a distribution that implements `icdf()`."
             )
+        if self.total == 0:
+            raise RuntimeError("QuantileCalibrationError requires at least one valid target.")
 
-        confidences = dim_zero_cat(self.confidences)
-        accuracies = dim_zero_cat(self.accuracies)
-
-        bin_boundaries = torch.linspace(
-            0,
-            1,
-            self.n_bins + 1,
-            dtype=torch.float,
-            device=confidences.device,
-        )
-
-        with torch.no_grad():
-            acc_bin, conf_bin, prop_bin = _binning_bucketize(
-                confidences, accuracies, bin_boundaries
-            )
-
-        np_acc_bin = acc_bin.cpu().numpy()
-        np_conf_bin = conf_bin.cpu().numpy()
-        np_prop_bin = prop_bin.cpu().numpy()
-        np_bin_boundaries = bin_boundaries.cpu().numpy()
-
-        return reliability_chart(
-            accuracies=accuracies.cpu().numpy(),
-            confidences=confidences.cpu().numpy(),
-            bin_accuracies=np_acc_bin,
-            bin_confidences=np_conf_bin,
-            bin_sizes=np_prop_bin,
-            bins=np_bin_boundaries,
-        )
+        nominal = self.conf_intervals.detach().cpu() * 100
+        empirical = (self.covered / self.total).detach().cpu() * 100
+        fig, ax = plt.subplots()
+        ax.plot(nominal, empirical, marker="o", label="Model")
+        ax.plot([0, 100], [0, 100], linestyle="--", color="black", label="Ideal")
+        ax.set_xlabel("Nominal Coverage (%)")
+        ax.set_ylabel("Empirical Coverage (%)")
+        ax.set_xlim(0, 100)
+        ax.set_ylim(0, 100)
+        ax.legend()
+        return fig, ax

--- a/src/torch_uncertainty/metrics/segmentation/_binary.py
+++ b/src/torch_uncertainty/metrics/segmentation/_binary.py
@@ -1,0 +1,44 @@
+from collections.abc import Iterator
+
+import torch
+from torch import Tensor
+
+
+def binary_images(preds: Tensor, target: Tensor) -> Iterator[tuple[Tensor, Tensor]]:
+    """Yield flattened prediction/target pairs, one image at a time."""
+    if preds.shape != target.shape:
+        raise ValueError(
+            "Expected `preds` and `target` to have the same shape, but got "
+            f"{preds.shape} and {target.shape}."
+        )
+    if preds.ndim == 0:
+        raise ValueError("Expected `preds` and `target` to have at least one dimension.")
+
+    if preds.ndim == 1:
+        preds = preds.unsqueeze(0)
+        target = target.unsqueeze(0)
+    else:
+        preds = preds.flatten(start_dim=1)
+        target = target.flatten(start_dim=1)
+
+    yield from zip(preds, target, strict=True)
+
+
+def binary_target_has_classes(
+    target: Tensor,
+    *,
+    pos_label: int = 1,
+    ignore_index: int | None = None,
+    require_negative: bool = True,
+) -> bool:
+    """Check whether an image contains the classes required by a binary metric."""
+    if ignore_index is not None:
+        target = target[target != ignore_index]
+    if target.numel() == 0:
+        return False
+
+    positive = target == pos_label
+    has_positive = torch.any(positive).item()
+    if not require_negative:
+        return has_positive
+    return has_positive and torch.any(~positive).item()

--- a/src/torch_uncertainty/metrics/segmentation/seg_binary_auroc.py
+++ b/src/torch_uncertainty/metrics/segmentation/seg_binary_auroc.py
@@ -3,7 +3,9 @@ from typing import Any
 import torch
 from torch import Tensor
 from torchmetrics import Metric
-from torchmetrics.classification import BinaryAUROC
+from torchmetrics.functional.classification import binary_auroc
+
+from ._binary import binary_images, binary_target_has_classes
 
 
 class SegmentationBinaryAUROC(Metric):
@@ -40,6 +42,11 @@ class SegmentationBinaryAUROC(Metric):
         literature (e.g., MUAD) and behaves better than computing AUROC over the
         flattened set of all pixels when image sizes or OOD prevalences vary.
 
+        Images without both positive and negative pixels are excluded because their
+        AUROC is undefined. The metric returns ``nan`` if no valid image was observed.
+        A one-dimensional input is treated as one image; otherwise, the first dimension
+        is the image batch dimension.
+
         Args:
             max_fpr: If set, computes the partial AUROC up to this FPR value
                 (passed to :class:`~torchmetrics.classification.BinaryAUROC`).
@@ -50,23 +57,31 @@ class SegmentationBinaryAUROC(Metric):
                 <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
         """
         super().__init__(**kwargs)
-        self.auroc_metric = BinaryAUROC(
-            max_fpr=max_fpr,
-            thresholds=thresholds,
-            ignore_index=ignore_index,
-            validate_args=validate_args,
-            **kwargs,
-        )
+        self.max_fpr = max_fpr
+        self.thresholds = thresholds
+        self.ignore_index = ignore_index
+        self.validate_args = validate_args
         self.add_state("binary_auroc", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        batch_size = preds.size(0)
-        auroc = self.auroc_metric(preds, target)
-        self.binary_auroc += auroc * batch_size
-        self.total += batch_size
+        for image_preds, image_target in binary_images(preds, target):
+            if not binary_target_has_classes(image_target, ignore_index=self.ignore_index):
+                continue
+            thresholds = self.thresholds
+            if isinstance(thresholds, Tensor):
+                thresholds = thresholds.to(image_preds.device)
+            self.binary_auroc += binary_auroc(
+                image_preds,
+                image_target,
+                max_fpr=self.max_fpr,
+                thresholds=thresholds,
+                ignore_index=self.ignore_index,
+                validate_args=self.validate_args,
+            )
+            self.total += 1
 
     def compute(self) -> Tensor:
         if self.total == 0:
-            return torch.tensor(0.0, device=self.binary_auroc.device)
+            return torch.tensor(torch.nan, device=self.binary_auroc.device)
         return self.binary_auroc / self.total

--- a/src/torch_uncertainty/metrics/segmentation/seg_binary_average_precision.py
+++ b/src/torch_uncertainty/metrics/segmentation/seg_binary_average_precision.py
@@ -3,7 +3,9 @@ from typing import Any
 import torch
 from torch import Tensor
 from torchmetrics import Metric
-from torchmetrics.classification import BinaryAveragePrecision
+from torchmetrics.functional.classification import binary_average_precision
+
+from ._binary import binary_images, binary_target_has_classes
 
 
 class SegmentationBinaryAveragePrecision(Metric):
@@ -38,6 +40,11 @@ class SegmentationBinaryAveragePrecision(Metric):
         As for :class:`SegmentationBinaryAUROC`, image-wise averaging is the convention
         used in the dense OOD-detection literature.
 
+        Images without positive pixels are excluded because their Average Precision is
+        undefined. The metric returns ``nan`` if no valid image was observed. A
+        one-dimensional input is treated as one image; otherwise, the first dimension
+        is the image batch dimension.
+
         Args:
             thresholds: Optional explicit thresholds for the PR curve, see
                 :class:`~torchmetrics.classification.BinaryAveragePrecision`.
@@ -47,19 +54,33 @@ class SegmentationBinaryAveragePrecision(Metric):
                 <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
         """
         super().__init__(**kwargs)
-        self.aupr_metric = BinaryAveragePrecision(
-            thresholds=thresholds, ignore_index=ignore_index, validate_args=validate_args, **kwargs
-        )
+        self.thresholds = thresholds
+        self.ignore_index = ignore_index
+        self.validate_args = validate_args
         self.add_state("binary_aupr", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        batch_size = preds.size(0)
-        aupr = self.aupr_metric(preds, target)
-        self.binary_aupr += aupr * batch_size
-        self.total += batch_size
+        for image_preds, image_target in binary_images(preds, target):
+            if not binary_target_has_classes(
+                image_target,
+                ignore_index=self.ignore_index,
+                require_negative=False,
+            ):
+                continue
+            thresholds = self.thresholds
+            if isinstance(thresholds, Tensor):
+                thresholds = thresholds.to(image_preds.device)
+            self.binary_aupr += binary_average_precision(
+                image_preds,
+                image_target,
+                thresholds=thresholds,
+                ignore_index=self.ignore_index,
+                validate_args=self.validate_args,
+            )
+            self.total += 1
 
     def compute(self) -> Tensor:
         if self.total == 0:
-            return torch.tensor(0.0, device=self.binary_aupr.device)
+            return torch.tensor(torch.nan, device=self.binary_aupr.device)
         return self.binary_aupr / self.total

--- a/src/torch_uncertainty/metrics/segmentation/seg_fpr95.py
+++ b/src/torch_uncertainty/metrics/segmentation/seg_fpr95.py
@@ -2,7 +2,9 @@ import torch
 from torch import Tensor
 from torchmetrics import Metric
 
-from torch_uncertainty.metrics import FPR95
+from torch_uncertainty.metrics.classification.fpr import _fprx_compute
+
+from ._binary import binary_images, binary_target_has_classes
 
 
 class SegmentationFPR95(Metric):
@@ -13,7 +15,7 @@ class SegmentationFPR95(Metric):
     fpr95: Tensor
     total: Tensor
 
-    def __init__(self, pos_label: int, **kwargs) -> None:
+    def __init__(self, pos_label: int, ignore_index: int | None = None, **kwargs) -> None:
         r"""Image-averaged FPR@95 TPR for dense binary segmentation tasks.
 
         For each image, a per-pixel False Positive Rate at 95% True Positive Rate is
@@ -27,21 +29,39 @@ class SegmentationFPR95(Metric):
         Image-wise averaging is the convention used in the dense OOD-detection
         literature.
 
+        Images without both positive and negative pixels are excluded because FPR@95
+        is undefined. The metric returns ``nan`` if no valid image was observed. A
+        one-dimensional input is treated as one image; otherwise, the first dimension
+        is the image batch dimension.
+
         Args:
             pos_label: The positive label in the segmentation OOD detection task
                 (typically ``1`` for OOD pixels).
+            ignore_index: Optional label value to ignore.
             kwargs: Additional keyword arguments for the underlying
                 :class:`~torch_uncertainty.metrics.classification.FPR95` metric.
         """
         super().__init__(**kwargs)
-        self.fpr95_metric = FPR95(pos_label, **kwargs)
+        self.pos_label = pos_label
+        self.ignore_index = ignore_index
         self.add_state("fpr95", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # pyrefly: ignore[bad-override]
-        batch_size = preds.size(0)
-        self.fpr95 += self.fpr95_metric(preds, target) * batch_size
-        self.total += batch_size
+        for image_preds, image_target in binary_images(preds, target):
+            if self.ignore_index is not None:
+                keep = image_target != self.ignore_index
+                image_preds = image_preds[keep]
+                image_target = image_target[keep]
+            if not binary_target_has_classes(image_target, pos_label=self.pos_label):
+                continue
+            self.fpr95 += _fprx_compute(
+                image_preds,
+                image_target,
+                recall_level=0.95,
+                pos_label=self.pos_label,
+            )
+            self.total += 1
 
     def compute(self) -> Tensor:
         if self.total == 0:

--- a/src/torch_uncertainty/metrics/sparsification.py
+++ b/src/torch_uncertainty/metrics/sparsification.py
@@ -6,7 +6,6 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from torch import Tensor
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.compute import _auc_compute
 from torchmetrics.utilities.data import dim_zero_cat
 from torchmetrics.utilities.plot import _AX_TYPE
 
@@ -55,6 +54,18 @@ class AUSE(Metric):
             scores: uncertainty scores of shape :math:`(B,)`
             errors: errors of shape :math:`(B,)`
         """
+        if scores.ndim != 1 or errors.ndim != 1:
+            raise ValueError("Expected `scores` and `errors` to be one-dimensional tensors.")
+        if scores.shape != errors.shape:
+            raise ValueError(
+                "Expected `scores` and `errors` to have the same shape, but got "
+                f"{scores.shape} and {errors.shape}."
+            )
+        if errors.is_floating_point() and not torch.isfinite(errors).all():
+            raise ValueError("Expected `errors` to contain only finite values.")
+        if torch.any(errors < 0):
+            raise ValueError("Expected `errors` to contain only non-negative values.")
+
         self.scores.append(scores)
         self.errors.append(errors)
 
@@ -62,11 +73,11 @@ class AUSE(Metric):
         scores = dim_zero_cat(self.scores)
         errors = dim_zero_cat(self.errors)
         if scores.shape[0] < 2:
-            nan = torch.tensor([float("nan")], device=self.device)
+            nan = torch.tensor(float("nan"), device=self.device)
             return nan, nan
         error_rates = _ause_rejection_rate_compute(scores, errors)
         optimal_error_rates = _ause_rejection_rate_compute(errors, errors)
-        return error_rates.cpu(), optimal_error_rates.cpu()
+        return error_rates, optimal_error_rates
 
     def compute(self) -> Tensor:
         """Compute the Area Under the Sparsification Error curve (AUSE) based
@@ -76,12 +87,13 @@ class AUSE(Metric):
             Tensor: The AUSE.
         """
         error_rates, optimal_error_rates = self.partial_compute()
-        if torch.isnan(error_rates[0]).item():
-            return torch.tensor([float("nan")], device=self.device)
+        if error_rates.ndim == 0:
+            return error_rates
         num_samples = error_rates.size(0)
-        x = torch.arange(0, num_samples, device=self.device) / num_samples
+        x = torch.arange(num_samples, device=error_rates.device, dtype=error_rates.dtype)
+        x /= num_samples
         y = error_rates - optimal_error_rates
-        return torch.tensor([_auc_compute(x, y)])
+        return torch.trapezoid(y, x)
 
     def plot(  # pyrefly: ignore[bad-override]
         self,
@@ -106,23 +118,26 @@ class AUSE(Metric):
 
         # Computation of AUSEC
         error_rates, optimal_error_rates = self.partial_compute()
+        if error_rates.ndim == 0:
+            raise RuntimeError("AUSE requires at least two samples before plotting.")
         num_samples = error_rates.size(0)
-        x = torch.arange(num_samples) / num_samples
+        x = torch.arange(num_samples, device=error_rates.device, dtype=error_rates.dtype)
+        x /= num_samples
         y = error_rates - optimal_error_rates
 
-        ausec = _auc_compute(x, y).cpu().item()
+        ausec = torch.trapezoid(y, x).item()
 
-        rejection_rates = torch.arange(num_samples) / num_samples * 100
+        rejection_rates = x.cpu() * 100
 
         ax.plot(
             rejection_rates,
-            error_rates * 100,
+            error_rates.cpu() * 100,
             label="Model",
         )
         if plot_oracle:
             ax.plot(
                 rejection_rates,
-                optimal_error_rates * 100,
+                optimal_error_rates.cpu() * 100,
                 label="Oracle",
             )
 
@@ -158,10 +173,23 @@ def _ause_rejection_rate_compute(
     """
     num_samples = errors.size(0)
 
-    order = scores.argsort()
-    errors = errors[order]
+    dtype = errors.dtype if errors.is_floating_point() else torch.get_default_dtype()
+    ordered_errors = errors[scores.argsort()].to(dtype)
 
-    error_rates = torch.zeros(num_samples + 1)
-    error_rates[0] = errors.sum()
-    error_rates[1:] = errors.cumsum(dim=-1).flip(0)
-    return error_rates / error_rates[0]
+    # At rejection step k, the k samples with the highest uncertainty have
+    # been discarded. Since scores are sorted increasingly, the retained
+    # samples form the prefix ending at N-k.
+    remaining_sum = ordered_errors.cumsum(dim=0).flip(0)
+    remaining_count = torch.arange(
+        num_samples,
+        0,
+        -1,
+        device=errors.device,
+        dtype=dtype,
+    )
+    error_rates = remaining_sum / remaining_count
+
+    initial_error = ordered_errors.mean()
+    if initial_error == 0:
+        return torch.zeros_like(error_rates)
+    return error_rates / initial_error

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -456,16 +456,13 @@ class ClassificationRoutine(LightningModule):
         logits = self.forward(inputs, save_feats=self.eval_grouping_loss)
         logits = rearrange(logits, "(m b) c -> b m c", b=targets.size(0))
 
-        if self.binary_cls:
-            probs_per_est = torch.sigmoid(logits).squeeze(-1)
-        else:
-            probs_per_est = F.softmax(logits, dim=-1)
-
+        probs_per_est = torch.sigmoid(logits) if self.binary_cls else F.softmax(logits, dim=-1)
         probs = probs_per_est.mean(dim=1)
-        self.val_cls_metrics.update(probs, targets)
+        task_probs = probs.squeeze(-1) if self.binary_cls else probs
+        self.val_cls_metrics.update(task_probs, targets)
 
         if self.eval_grouping_loss:
-            self.val_grouping_loss.update(probs, targets, self.features)
+            self.val_grouping_loss.update(task_probs, targets, self.features)
 
     def test_step(
         self,
@@ -498,6 +495,13 @@ class ClassificationRoutine(LightningModule):
         logits = rearrange(logits, "(m b) c -> b m c", b=targets.size(0))
         probs_per_est = torch.sigmoid(logits) if self.binary_cls else F.softmax(logits, dim=-1)
         probs = probs_per_est.mean(dim=1)
+        task_probs = probs.squeeze(-1) if self.binary_cls else probs
+        categorical_probs_per_est = (
+            torch.cat((1 - probs_per_est, probs_per_est), dim=-1)
+            if self.binary_cls
+            else probs_per_est
+        )
+        categorical_probs = categorical_probs_per_est.mean(dim=1)
 
         pp_probs: Tensor | None = None
         pp_epistemic: Tensor | None = None
@@ -516,9 +520,9 @@ class ClassificationRoutine(LightningModule):
         if self.ood_criterion.input_type == OODCriterionInputType.LOGIT:
             ood_scores = self.ood_criterion(logits)
         elif self.ood_criterion.input_type == OODCriterionInputType.PROB:
-            ood_scores = self.ood_criterion(probs)
+            ood_scores = self.ood_criterion(categorical_probs)
         elif self.ood_criterion.input_type == OODCriterionInputType.ESTIMATOR_PROB:
-            ood_scores = self.ood_criterion(probs_per_est)
+            ood_scores = self.ood_criterion(categorical_probs_per_est)
         elif self.ood_criterion.input_type == OODCriterionInputType.POST_PROCESSING:
             if isinstance(self.post_processing, DEUP):
                 ood_scores = self.ood_criterion(pp_epistemic)
@@ -526,26 +530,19 @@ class ClassificationRoutine(LightningModule):
                 ood_scores = self.ood_criterion(pp_probs)
 
         if dataloader_idx == 0:
-            # squeeze if binary classification only for binary metrics
-            self.test_cls_metrics.update(
-                probs.squeeze(-1) if self.binary_cls else probs,
-                targets,
-            )
-            self.test_id_entropy.update(probs)
+            self.test_cls_metrics.update(task_probs, targets)
+            self.test_id_entropy.update(categorical_probs)
 
             if self.eval_grouping_loss:
-                self.test_grouping_loss.update(probs, targets, self.features)
+                self.test_grouping_loss.update(task_probs, targets, self.features)
 
             if self.is_ensemble:
-                self.test_id_ens_metrics.update(probs_per_est)
+                self.test_id_ens_metrics.update(categorical_probs_per_est)
 
             if self.eval_ood:
                 self.test_ood_metrics.update(ood_scores, torch.zeros_like(targets))
 
-                if self.binary_cls:
-                    id_preds = (probs.squeeze(-1) >= 0.5).long()
-                else:
-                    id_preds = probs.argmax(dim=-1)
+                id_preds = (task_probs >= 0.5).long() if self.binary_cls else probs.argmax(dim=-1)
 
                 classification_errors = id_preds.ne(targets)
                 self.test_scod_metrics.update(
@@ -561,7 +558,7 @@ class ClassificationRoutine(LightningModule):
                 self.post_cls_metrics.update(pp_probs, targets)
 
         if self.eval_ood and dataloader_idx == 1:
-            self.test_ood_entropy.update(probs)
+            self.test_ood_entropy.update(categorical_probs)
             self.test_ood_metrics.update(ood_scores, torch.ones_like(targets))
 
             is_ood = torch.ones_like(targets, dtype=torch.bool)
@@ -572,17 +569,17 @@ class ClassificationRoutine(LightningModule):
             )
 
             if self.is_ensemble:
-                self.test_ood_ens_metrics.update(probs_per_est)
+                self.test_ood_ens_metrics.update(categorical_probs_per_est)
 
             if self.ood_score_storage is not None:
                 self.ood_score_storage.append(ood_scores.detach().cpu())
 
         if self.eval_shift and dataloader_idx == (2 if self.eval_ood else 1):
-            self.test_shift_entropy.update(probs)
-            self.test_shift_metrics.update(probs, targets)
+            self.test_shift_entropy.update(categorical_probs)
+            self.test_shift_metrics.update(task_probs, targets)
 
             if self.is_ensemble:
-                self.test_shift_ens_metrics.update(probs_per_est)
+                self.test_shift_ens_metrics.update(categorical_probs_per_est)
 
     def on_validation_epoch_end(self) -> None:
         """Compute and log the values of the collected metrics in `validation_step`."""

--- a/src/torch_uncertainty/routines/segmentation.py
+++ b/src/torch_uncertainty/routines/segmentation.py
@@ -221,9 +221,9 @@ class SegmentationRoutine(LightningModule):
         if self.eval_ood:
             ood_metrics = MetricCollection(
                 {
-                    "AUROC": SegmentationBinaryAUROC(),
-                    "AUPR": SegmentationBinaryAveragePrecision(),
-                    "FPR95": SegmentationFPR95(pos_label=1),
+                    "AUROC": SegmentationBinaryAUROC(ignore_index=255),
+                    "AUPR": SegmentationBinaryAveragePrecision(ignore_index=255),
+                    "FPR95": SegmentationFPR95(pos_label=1, ignore_index=255),
                 }
             )
             self.test_ood_metrics = ood_metrics.clone(prefix="ood/")
@@ -378,13 +378,11 @@ class SegmentationRoutine(LightningModule):
 
         if self.eval_ood and dataloader_idx == 1:
             if self.ood_criterion.input_type == OODCriterionInputType.PROB:
-                ood_scores = self.ood_criterion(
-                    rearrange(probs, "b c h w -> b h w c")[~ignore_mask]
-                )
+                flat_probs = rearrange(probs, "b c h w -> (b h w) c")
+                ood_scores = self.ood_criterion(flat_probs).reshape_as(targets)
             elif self.ood_criterion.input_type == OODCriterionInputType.ESTIMATOR_PROB:
-                ood_scores = self.ood_criterion(
-                    rearrange(probs_per_est, "b m c h w -> b h w m c")[~ignore_mask]
-                )
+                flat_probs_per_est = rearrange(probs_per_est, "b m c h w -> (b h w) m c")
+                ood_scores = self.ood_criterion(flat_probs_per_est).reshape_as(targets)
             else:
                 raise ValueError(
                     f"Unsupported input type for OOD criterion: {self.ood_criterion.input_type}"
@@ -393,8 +391,9 @@ class SegmentationRoutine(LightningModule):
             labels = torch.zeros_like(targets)
             labels[id_mask] = 0  # ID examples
             labels[ood_mask] = 1  # OOD examples
+            labels[ignore_mask] = 255
 
-            self.test_ood_metrics.update(ood_scores, labels[~ignore_mask])
+            self.test_ood_metrics.update(ood_scores, labels)
 
     def on_validation_epoch_end(self) -> None:
         """Compute and log the values of the collected metrics in `validation_step`."""

--- a/tests/metrics/classification/test_brier_score.py
+++ b/tests/metrics/classification/test_brier_score.py
@@ -155,6 +155,40 @@ class TestBrierScore:
         metric.update(vec3d, vec3d_target)
         assert metric.compute() == 1
 
+    def test_mixed_2d_and_3d_updates(self) -> None:
+        metric = BrierScore(num_classes=2, reduction="mean")
+        metric.update(torch.tensor([[0.0, 1.0]]), torch.tensor([1]))
+        metric.update(
+            torch.tensor([[[1.0, 0.0], [1.0, 0.0]]]),
+            torch.tensor([1]),
+        )
+
+        # The first sample has score 0 and the second has estimator-mean score 2.
+        torch.testing.assert_close(metric.compute(), torch.tensor(1.0))
+
+    def test_none_reduction_averages_estimators_per_sample(self) -> None:
+        probs = torch.tensor(
+            [
+                [[0.0, 1.0], [1.0, 0.0]],
+                [[0.5, 0.5], [0.5, 0.5]],
+            ]
+        )
+        metric = BrierScore(num_classes=2, reduction="none")
+        metric.update(probs, torch.tensor([1, 0]))
+
+        assert metric.compute().shape == (2,)
+        torch.testing.assert_close(metric.compute(), torch.tensor([1.0, 0.5]))
+
+    def test_binary_brier_and_top_class(self) -> None:
+        probs = torch.tensor([0.1, 0.8])
+        target = torch.tensor([0, 1])
+
+        metric = BrierScore(num_classes=1)
+        top_metric = BrierScore(num_classes=1, top_class=True)
+
+        torch.testing.assert_close(metric(probs, target), torch.tensor(0.025))
+        torch.testing.assert_close(top_metric(probs, target), torch.tensor(0.025))
+
     def test_compute_3d_sum(self, vec3d: torch.Tensor, vec3d_target: torch.Tensor) -> None:
         metric = BrierScore(num_classes=2, reduction="sum")
         metric.update(vec3d, vec3d_target)

--- a/tests/metrics/classification/test_fpr95.py
+++ b/tests/metrics/classification/test_fpr95.py
@@ -37,3 +37,11 @@ class TestFPR95:
     def test_error(self) -> None:
         with pytest.raises(ValueError):
             FPRx(recall_level=1.2, pos_label=1)
+
+    def test_tied_scores_respect_minimum_recall(self) -> None:
+        scores = torch.tensor([0.9] * 16 + [0.1, 0.1])
+        target = torch.tensor([1] * 17 + [0])
+
+        # Reaching 95% recall requires accepting the complete score-0.1 tie,
+        # which also accepts the only negative example.
+        torch.testing.assert_close(FPR95(pos_label=1)(scores, target), torch.tensor(1.0))

--- a/tests/metrics/regression/test_quantile_calibration.py
+++ b/tests/metrics/regression/test_quantile_calibration.py
@@ -17,12 +17,8 @@ class TestQuantileCalibrationError:
         res = qce.compute()
         assert res.item() < 0.02
 
-        fig, ax = qce.plot()
+        fig, _ = qce.plot()
         assert isinstance(fig, plt.Figure)
-        assert ax[0].get_xlabel() == "Top-class Confidence (%)"
-        assert ax[0].get_ylabel() == "Success Rate (%)"
-        assert ax[1].get_xlabel() == "Top-class Confidence (%)"
-        assert ax[1].get_ylabel() == "Density (%)"
 
         qce2 = QuantileCalibrationError()
         qce2.update(dist, targets, ignore_mask=torch.zeros(1000, dtype=torch.bool))

--- a/tests/metrics/test_segmentation.py
+++ b/tests/metrics/test_segmentation.py
@@ -25,7 +25,19 @@ class TestSegmentationBinaryAUROC:
     def test_compute_zero_total(self) -> None:
         metric = SegmentationBinaryAUROC()
         result = metric.compute()
-        assert result == 0.0
+        assert torch.isnan(result)
+
+    def test_image_average_and_batch_partition_invariance(self) -> None:
+        preds, target = _image_averaging_example()
+
+        batched = SegmentationBinaryAUROC()
+        batched.update(preds, target)
+        split = SegmentationBinaryAUROC()
+        split.update(preds[0:1], target[0:1])
+        split.update(preds[1:2], target[1:2])
+
+        torch.testing.assert_close(batched.compute(), torch.tensor(0.5))
+        torch.testing.assert_close(split.compute(), batched.compute())
 
     def test_multiple_batches(self) -> None:
         metric = SegmentationBinaryAUROC()
@@ -49,7 +61,19 @@ class TestSegmentationBinaryAveragePrecision:
     def test_compute_zero_total(self) -> None:
         metric = SegmentationBinaryAveragePrecision()
         result = metric.compute()
-        assert result == 0.0
+        assert torch.isnan(result)
+
+    def test_image_average_and_batch_partition_invariance(self) -> None:
+        preds, target = _image_averaging_example()
+
+        batched = SegmentationBinaryAveragePrecision()
+        batched.update(preds, target)
+        split = SegmentationBinaryAveragePrecision()
+        split.update(preds[0:1], target[0:1])
+        split.update(preds[1:2], target[1:2])
+
+        torch.testing.assert_close(batched.compute(), torch.tensor(0.625))
+        torch.testing.assert_close(split.compute(), batched.compute())
 
     def test_multiple_batches(self) -> None:
         metric = SegmentationBinaryAveragePrecision()
@@ -84,6 +108,35 @@ class TestSegmentationFPR95:
             metric.update(preds, target)
         result = metric.compute()
         assert result.ndim == 0
+
+    def test_image_average_and_batch_partition_invariance(self) -> None:
+        preds, target = _image_averaging_example()
+
+        batched = SegmentationFPR95(pos_label=1)
+        batched.update(preds, target)
+        split = SegmentationFPR95(pos_label=1)
+        split.update(preds[0:1], target[0:1])
+        split.update(preds[1:2], target[1:2])
+
+        torch.testing.assert_close(batched.compute(), torch.tensor(0.5))
+        torch.testing.assert_close(split.compute(), batched.compute())
+
+
+def _image_averaging_example() -> tuple[torch.Tensor, torch.Tensor]:
+    """Two images whose pooled pixel metric differs from their image average."""
+    preds = torch.tensor(
+        [
+            [[0.0, 1.0], [0.9, 0.8]],
+            [[0.7, 0.6], [0.5, 0.4]],
+        ]
+    )
+    target = torch.tensor(
+        [
+            [[0, 1], [1, 1]],
+            [[0, 0], [0, 1]],
+        ]
+    )
+    return preds, target
 
 
 class TestPAvPU:

--- a/tests/metrics/test_sparsification.py
+++ b/tests/metrics/test_sparsification.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import pytest
 import torch
 
 from torch_uncertainty.metrics import AUSE
@@ -12,6 +13,30 @@ class TestAUSE:
         metric = AUSE()
         metric.update(values, values)
         assert metric.compute() == 0
+
+    def test_known_reverse_ranking(self) -> None:
+        errors = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        scores = -errors
+        metric = AUSE()
+
+        metric.update(scores, errors)
+
+        model_curve, oracle_curve = metric.partial_compute()
+        torch.testing.assert_close(model_curve, torch.tensor([1.0, 1.2, 1.4, 1.6]))
+        torch.testing.assert_close(oracle_curve, torch.tensor([1.0, 0.8, 0.6, 0.4]))
+        torch.testing.assert_close(metric.compute(), torch.tensor(0.45))
+
+    def test_zero_errors_have_zero_ause(self) -> None:
+        metric = AUSE()
+        metric.update(torch.tensor([0.3, 0.1, 0.2]), torch.zeros(3))
+        torch.testing.assert_close(metric.compute(), torch.tensor(0.0))
+
+    def test_preserves_dtype(self) -> None:
+        metric = AUSE()
+        scores = torch.tensor([0.3, 0.1, 0.2], dtype=torch.float64)
+        errors = torch.tensor([3.0, 1.0, 2.0], dtype=torch.float64)
+        metric.update(scores, errors)
+        assert metric.compute().dtype == torch.float64
 
     def test_plot(self) -> None:
         scores = torch.as_tensor([0.2, 0.1, 0.5, 0.3, 0.4])
@@ -35,7 +60,16 @@ class TestAUSE:
         plt.close(fig)
 
     def test_compute_nan(self) -> None:
-        probs = torch.Tensor([[0.1, 0.9]])
-        targets = torch.Tensor([1]).long()
+        probs = torch.tensor([0.9])
+        targets = torch.tensor([1.0])
         metric = AUSE()
-        assert torch.isnan(metric(probs, targets)).all()
+        assert torch.isnan(metric(probs, targets))
+
+    def test_invalid_inputs(self) -> None:
+        metric = AUSE()
+        with pytest.raises(ValueError, match="one-dimensional"):
+            metric.update(torch.ones(1, 2), torch.ones(1, 2))
+        with pytest.raises(ValueError, match="same shape"):
+            metric.update(torch.ones(2), torch.ones(3))
+        with pytest.raises(ValueError, match="non-negative"):
+            metric.update(torch.ones(2), torch.tensor([1.0, -1.0]))

--- a/tests/routines/test_classification.py
+++ b/tests/routines/test_classification.py
@@ -584,3 +584,45 @@ class TestClassification:
                 model=nn.Module(),
                 loss=None,
             ).training_step((torch.tensor(float("nan")), torch.tensor(float("nan"))))
+
+    def test_binary_ensemble_uses_categorical_probs_for_uncertainty_metrics(self) -> None:
+        positive_probs = torch.tensor(
+            [
+                [[0.9], [0.1]],
+                [[0.2], [0.8]],
+            ]
+        )
+        # ClassificationRoutine expects estimator-major model outputs: (M * B, C).
+        logits = torch.logit(positive_probs).transpose(0, 1).reshape(-1, 1)
+        targets = torch.tensor([0, 1])
+        routine = ClassificationRoutine(
+            model=nn.Identity(),
+            num_classes=1,
+            loss=None,
+            is_ensemble=True,
+            ood_criterion=EntropyCriterion(),
+        )
+        routine.test_num_flops = 0
+        criterion_inputs = []
+        hook = routine.ood_criterion.register_forward_pre_hook(
+            lambda _, args: criterion_inputs.append(args[0])
+        )
+
+        routine.test_step((logits, targets), batch_idx=0)
+        hook.remove()
+
+        categorical_probs = torch.cat((1 - positive_probs, positive_probs), dim=-1)
+        mean_probs = categorical_probs.mean(dim=1)
+        predictive_entropy = torch.special.entr(mean_probs).sum(dim=-1)
+        expected_entropy = torch.special.entr(categorical_probs).sum(dim=-1).mean()
+        expected_mi = (
+            predictive_entropy - torch.special.entr(categorical_probs).sum(dim=-1).mean(dim=1)
+        ).mean()
+        ensemble_metrics = routine.test_id_ens_metrics.compute()
+
+        assert criterion_inputs[0].shape == (2, 2, 2)
+        torch.testing.assert_close(criterion_inputs[0].sum(dim=-1), torch.ones(2, 2))
+        torch.testing.assert_close(routine.test_id_entropy.compute(), predictive_entropy.mean())
+        torch.testing.assert_close(ensemble_metrics["test/ens_Entropy"], expected_entropy)
+        torch.testing.assert_close(ensemble_metrics["test/ens_MI"], expected_mi)
+        torch.testing.assert_close(ensemble_metrics["test/ens_Disagreement"], torch.tensor(1.0))


### PR DESCRIPTION
## Description

AUSE, FPRx, Brier score, segmentation metrics, and quantile calibration had weak points. This PR aims to improve those.

Fixes # <!-- issue number, if applicable -->

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [ ] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
