### PR TITLE
:sparkles:(ImageNet200): add ds and dm

### DIFF
--- a/src/torch_uncertainty/datamodules/__init__.py
+++ b/src/torch_uncertainty/datamodules/__init__.py
@@ -12,6 +12,7 @@ from .classification import (
     GermanCreditDataModule,
     HiggsBosonDataModule,
     HTRU2DataModule,
+    ImageNet200DataModule,
     ImageNetDataModule,
     KDDChurnDataModule,
     MNISTDataModule,

--- a/src/torch_uncertainty/datamodules/classification/__init__.py
+++ b/src/torch_uncertainty/datamodules/classification/__init__.py
@@ -2,6 +2,7 @@
 from .cifar10 import CIFAR10DataModule
 from .cifar100 import CIFAR100DataModule
 from .imagenet import ImageNetDataModule
+from .imagenet200 import ImageNet200
 from .mnist import MNISTDataModule
 from .tabular import (
     AdultCensusIncomeDataModule,

--- a/src/torch_uncertainty/datamodules/classification/__init__.py
+++ b/src/torch_uncertainty/datamodules/classification/__init__.py
@@ -2,7 +2,7 @@
 from .cifar10 import CIFAR10DataModule
 from .cifar100 import CIFAR100DataModule
 from .imagenet import ImageNetDataModule
-from .imagenet200 import ImageNet200
+from .imagenet200 import ImageNet200DataModule
 from .mnist import MNISTDataModule
 from .tabular import (
     AdultCensusIncomeDataModule,

--- a/src/torch_uncertainty/datamodules/classification/imagenet200.py
+++ b/src/torch_uncertainty/datamodules/classification/imagenet200.py
@@ -1,0 +1,215 @@
+import copy
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import torch
+import yaml
+from numpy.typing import ArrayLike
+from timm.data.auto_augment import rand_augment_transform
+from torch import nn
+from torch.utils.data import Subset
+from torchvision.transforms import v2
+
+from torch_uncertainty.datamodules import TUDataModule
+from torch_uncertainty.datasets.classification import ImageNet200
+from torch_uncertainty.datasets.utils import create_train_val_split
+from torch_uncertainty.utils import interpolation_modes_from_str
+
+
+class ImageNet200DataModule(TUDataModule):
+    """DataModule for the ImageNet-200 subset of ImageNet-1K.
+
+    ImageNet-200 uses the 200 ImageNet-1K classes represented in ImageNet-R. The
+    underlying images are loaded from an existing torchvision-compatible ImageNet
+    directory. This datamodule only provides in-distribution train, validation, and
+    test loaders.
+
+    Args:
+        root: Root directory of the ImageNet dataset.
+        batch_size: Number of samples per training batch.
+        eval_batch_size: Number of samples per validation and test batch. Set to
+            ``batch_size`` when ``None``. Defaults to ``None``.
+        val_split: Share of training samples used for validation, or a path to a YAML
+            file containing ``train`` and ``val`` index lists. When ``None``, the
+            ImageNet validation split is used. Defaults to ``None``.
+        num_tta: Number of test-time augmentations. Defaults to ``1``.
+        postprocess_set: Split used to fit post-processing methods. Defaults to
+            ``"val"``.
+        train_transform: Custom training transform. A default ImageNet transform is
+            used when ``None``. Defaults to ``None``.
+        test_transform: Custom evaluation transform. A default ImageNet transform is
+            used when ``None``. Defaults to ``None``.
+        train_size: Size of the random crop used for training. Defaults to ``224``.
+        interpolation: Interpolation mode used by resize operations. Defaults to
+            ``"bilinear"``.
+        basic_augment: Whether to apply random resized crop and horizontal flip when
+            using the default training transform. Defaults to ``True``.
+        rand_augment_opt: timm RandAugment configuration string. Defaults to ``None``.
+        num_workers: Number of data-loading workers. Defaults to ``1``.
+        pin_memory: Whether to pin memory in data loaders. Defaults to ``True``.
+        persistent_workers: Whether data-loading workers persist across epochs.
+            Defaults to ``True``.
+    """
+
+    num_classes = 200
+    num_channels = 3
+    input_shape = (3, 224, 224)
+    training_task = "classification"
+    mean = (0.485, 0.456, 0.406)
+    std = (0.229, 0.224, 0.225)
+    dataset: type[ImageNet200]
+
+    def __init__(
+        self,
+        root: str | Path,
+        batch_size: int,
+        eval_batch_size: int | None = None,
+        val_split: float | str | Path | None = None,
+        num_tta: int = 1,
+        postprocess_set: Literal["val", "test"] = "val",
+        train_transform: nn.Module | None = None,
+        test_transform: nn.Module | None = None,
+        train_size: int = 224,
+        interpolation: str = "bilinear",
+        basic_augment: bool = True,
+        rand_augment_opt: str | None = None,
+        num_workers: int = 1,
+        pin_memory: bool = True,
+        persistent_workers: bool = True,
+    ) -> None:
+        super().__init__(
+            root=Path(root),
+            batch_size=batch_size,
+            eval_batch_size=eval_batch_size,
+            val_split=val_split,
+            num_tta=num_tta,
+            postprocess_set=postprocess_set,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
+        )
+
+        self.train_indices: list[int] | None = None
+        self.val_indices: list[int] | None = None
+        if val_split is not None and not isinstance(val_split, float):
+            val_split = Path(val_split)
+            self.train_indices, self.val_indices = _read_indices(val_split)
+        self.val_split = val_split
+        self.dataset = ImageNet200
+
+        interpolation_mode = interpolation_modes_from_str(interpolation)
+
+        if train_transform is not None:
+            self.train_transform = train_transform
+        else:
+            if basic_augment:
+                basic_transform = v2.Compose(
+                    [
+                        v2.RandomResizedCrop(train_size, interpolation=interpolation_mode),
+                        v2.RandomHorizontalFlip(),
+                    ]
+                )
+            else:
+                basic_transform = nn.Identity()
+
+            if rand_augment_opt is not None:
+                main_transform = v2.Compose(
+                    [
+                        v2.ToPILImage(),
+                        rand_augment_transform(rand_augment_opt, {}),
+                        v2.ToImage(),
+                    ]
+                )
+            else:
+                main_transform = nn.Identity()
+
+            self.train_transform = v2.Compose(
+                [
+                    v2.ToImage(),
+                    basic_transform,
+                    main_transform,
+                    v2.ToDtype(dtype=torch.float32, scale=True),
+                    v2.Normalize(mean=self.mean, std=self.std),
+                ]
+            )
+
+        if num_tta != 1:
+            self.test_transform = self.train_transform
+        elif test_transform is not None:
+            self.test_transform = test_transform
+        else:
+            self.test_transform = v2.Compose(
+                [
+                    v2.ToImage(),
+                    v2.Resize(256, interpolation=interpolation_mode),
+                    v2.CenterCrop(224),
+                    v2.ToDtype(dtype=torch.float32, scale=True),
+                    v2.Normalize(mean=self.mean, std=self.std),
+                ]
+            )
+
+    def _verify_splits(self, split: str) -> None:
+        if not (self.root / split).is_dir():
+            raise FileNotFoundError(
+                f"An ImageNet {split} split was not found in {self.root}. "
+                f"Make sure {self.root / split} exists."
+            )
+
+    def prepare_data(self) -> None:
+        """ImageNet must be downloaded manually."""
+
+    def setup(self, stage: str | None = None) -> None:
+        if stage not in ("fit", "test", None):
+            raise ValueError(f"Stage {stage} is not supported.")
+
+        if stage == "fit" or stage is None:
+            full = self.dataset(
+                self.root,
+                split="train",
+                transform=self.train_transform,
+            )
+            if isinstance(self.val_split, float) and self.val_split:
+                self.train, self.val = create_train_val_split(
+                    full,
+                    self.val_split,
+                    self.test_transform,
+                )
+            elif isinstance(self.val_split, Path):
+                self.train = Subset(full, self.train_indices or [])
+                self.val = copy.deepcopy(Subset(full, self.val_indices or []))
+                self.val.dataset.transform = self.test_transform
+            else:
+                self.train = full
+                self.val = self.dataset(
+                    self.root,
+                    split="val",
+                    transform=self.test_transform,
+                )
+
+        if stage == "test" or stage is None:
+            self.test = self.dataset(
+                self.root,
+                split="val",
+                transform=self.test_transform,
+            )
+
+    def _get_train_data(self) -> ArrayLike:
+        if isinstance(self.train, Subset):
+            samples = np.asarray(self.train.dataset.samples, dtype=object)
+            return samples[self.train.indices]
+        return np.asarray(self.train.samples, dtype=object)
+
+    def _get_train_targets(self) -> ArrayLike:
+        if isinstance(self.train, Subset):
+            targets = np.asarray(self.train.dataset.targets)
+            return targets[self.train.indices]
+        return np.asarray(self.train.targets)
+
+
+def _read_indices(path: Path) -> tuple[list[int], list[int]]:
+    if not path.is_file():
+        raise ValueError(f"{path} is not a file.")
+    with path.open() as file:
+        indices = yaml.safe_load(file)
+    return indices["train"], indices["val"]

--- a/src/torch_uncertainty/datasets/__init__.py
+++ b/src/torch_uncertainty/datasets/__init__.py
@@ -17,6 +17,7 @@ from .classification import (
     DOTA2Games,
     GermanCredit,
     HiggsBoson,
+    ImageNet200,
     ImageNetA,
     ImageNetC,
     ImageNetO,

--- a/src/torch_uncertainty/datasets/classification/__init__.py
+++ b/src/torch_uncertainty/datasets/classification/__init__.py
@@ -2,6 +2,7 @@
 from .cifar import CIFAR10C, CIFAR10H, CIFAR10N, CIFAR100C, CIFAR100N
 from .cub import CUB
 from .imagenet import (
+    ImageNet200,
     ImageNetA,
     ImageNetC,
     ImageNetO,

--- a/src/torch_uncertainty/datasets/classification/imagenet/__init__.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401
+from .imagenet200 import ImageNet200
 from .imagenet_a import ImageNetA
 from .imagenet_c import ImageNetC
 from .imagenet_o import ImageNetO

--- a/src/torch_uncertainty/datasets/classification/imagenet/imagenet200.py
+++ b/src/torch_uncertainty/datasets/classification/imagenet/imagenet200.py
@@ -1,0 +1,268 @@
+from collections.abc import Callable
+from pathlib import Path
+
+from torchvision.datasets import ImageNet
+
+# ImageNet-200 uses the 200 ImageNet-1K classes represented in ImageNet-R.
+# The WNIDs are sorted in ImageNet-1K class order so that labels are stable.
+IMAGENET_200_WNIDS = (
+    "n01443537",
+    "n01484850",
+    "n01494475",
+    "n01498041",
+    "n01514859",
+    "n01518878",
+    "n01531178",
+    "n01534433",
+    "n01614925",
+    "n01616318",
+    "n01630670",
+    "n01632777",
+    "n01644373",
+    "n01677366",
+    "n01694178",
+    "n01748264",
+    "n01770393",
+    "n01774750",
+    "n01784675",
+    "n01806143",
+    "n01820546",
+    "n01833805",
+    "n01843383",
+    "n01847000",
+    "n01855672",
+    "n01860187",
+    "n01882714",
+    "n01910747",
+    "n01944390",
+    "n01983481",
+    "n01986214",
+    "n02007558",
+    "n02009912",
+    "n02051845",
+    "n02056570",
+    "n02066245",
+    "n02071294",
+    "n02077923",
+    "n02085620",
+    "n02086240",
+    "n02088094",
+    "n02088238",
+    "n02088364",
+    "n02088466",
+    "n02091032",
+    "n02091134",
+    "n02092339",
+    "n02094433",
+    "n02096585",
+    "n02097298",
+    "n02098286",
+    "n02099601",
+    "n02099712",
+    "n02102318",
+    "n02106030",
+    "n02106166",
+    "n02106550",
+    "n02106662",
+    "n02108089",
+    "n02108915",
+    "n02109525",
+    "n02110185",
+    "n02110341",
+    "n02110958",
+    "n02112018",
+    "n02112137",
+    "n02113023",
+    "n02113624",
+    "n02113799",
+    "n02114367",
+    "n02117135",
+    "n02119022",
+    "n02123045",
+    "n02128385",
+    "n02128757",
+    "n02129165",
+    "n02129604",
+    "n02130308",
+    "n02134084",
+    "n02138441",
+    "n02165456",
+    "n02190166",
+    "n02206856",
+    "n02219486",
+    "n02226429",
+    "n02233338",
+    "n02236044",
+    "n02268443",
+    "n02279972",
+    "n02317335",
+    "n02325366",
+    "n02346627",
+    "n02356798",
+    "n02363005",
+    "n02364673",
+    "n02391049",
+    "n02395406",
+    "n02398521",
+    "n02410509",
+    "n02423022",
+    "n02437616",
+    "n02445715",
+    "n02447366",
+    "n02480495",
+    "n02480855",
+    "n02481823",
+    "n02483362",
+    "n02486410",
+    "n02510455",
+    "n02526121",
+    "n02607072",
+    "n02655020",
+    "n02672831",
+    "n02701002",
+    "n02749479",
+    "n02769748",
+    "n02793495",
+    "n02797295",
+    "n02802426",
+    "n02808440",
+    "n02814860",
+    "n02823750",
+    "n02841315",
+    "n02843684",
+    "n02883205",
+    "n02906734",
+    "n02909870",
+    "n02939185",
+    "n02948072",
+    "n02950826",
+    "n02951358",
+    "n02966193",
+    "n02980441",
+    "n02992529",
+    "n03124170",
+    "n03272010",
+    "n03345487",
+    "n03372029",
+    "n03424325",
+    "n03452741",
+    "n03467068",
+    "n03481172",
+    "n03494278",
+    "n03495258",
+    "n03498962",
+    "n03594945",
+    "n03602883",
+    "n03630383",
+    "n03649909",
+    "n03676483",
+    "n03710193",
+    "n03773504",
+    "n03775071",
+    "n03888257",
+    "n03930630",
+    "n03947888",
+    "n04086273",
+    "n04118538",
+    "n04133789",
+    "n04141076",
+    "n04146614",
+    "n04147183",
+    "n04192698",
+    "n04254680",
+    "n04266014",
+    "n04275548",
+    "n04310018",
+    "n04325704",
+    "n04347754",
+    "n04389033",
+    "n04409515",
+    "n04465501",
+    "n04487394",
+    "n04522168",
+    "n04536866",
+    "n04552348",
+    "n04591713",
+    "n07614500",
+    "n07693725",
+    "n07695742",
+    "n07697313",
+    "n07697537",
+    "n07714571",
+    "n07714990",
+    "n07718472",
+    "n07720875",
+    "n07734744",
+    "n07742313",
+    "n07745940",
+    "n07749582",
+    "n07753275",
+    "n07753592",
+    "n07768694",
+    "n07873807",
+    "n07880968",
+    "n07920052",
+    "n09472597",
+    "n09835506",
+    "n10565667",
+    "n12267677",
+)
+
+
+class ImageNet200(ImageNet):
+    """The ImageNet-200 subset used by the OpenOOD benchmark.
+
+    ImageNet-200 contains the 200 ImageNet-1K classes represented in ImageNet-R. This
+    dataset reads an existing torchvision-compatible ImageNet directory, keeps only those
+    classes, and remaps their targets to the contiguous range ``[0, 199]``.
+
+    Args:
+        root: Root directory of the ImageNet dataset.
+        split: Dataset split, either ``"train"`` or ``"val"``.
+        transform: Transform applied to images.
+        target_transform: Transform applied to the remapped targets.
+    """
+
+    dataset_name = "imagenet200"
+    wnids_200 = IMAGENET_200_WNIDS
+
+    def __init__(
+        self,
+        root: str | Path,
+        split: str = "train",
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
+    ) -> None:
+        super().__init__(
+            root=root,
+            split=split,
+            transform=transform,
+            target_transform=target_transform,
+        )
+
+        classes_by_wnid = dict(zip(self.wnids, self.classes, strict=True))
+        missing_wnids = set(self.wnids_200).difference(classes_by_wnid)
+        if missing_wnids:
+            raise RuntimeError(
+                "The ImageNet dataset is missing "
+                f"{len(missing_wnids)} of the 200 classes required by ImageNet-200."
+            )
+
+        wnid_to_idx = {wnid: index for index, wnid in enumerate(self.wnids_200)}
+        samples = []
+        for path, _ in self.samples:
+            wnid = Path(path).parent.name
+            if wnid in wnid_to_idx:
+                samples.append((path, wnid_to_idx[wnid]))
+
+        self.wnids = list(self.wnids_200)
+        self.wnid_to_idx = wnid_to_idx
+        self.classes = [classes_by_wnid[wnid] for wnid in self.wnids]
+        self.class_to_idx = {
+            class_name: index
+            for index, class_names in enumerate(self.classes)
+            for class_name in class_names
+        }
+        self.samples = samples
+        self.imgs = self.samples
+        self.targets = [target for _, target in self.samples]

--- a/tests/datamodules/classification/test_imagenet200.py
+++ b/tests/datamodules/classification/test_imagenet200.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 import pytest
 from torch import nn
+from torch.utils.data import Subset
+from torchvision.transforms import v2
 
 from tests._dummies.dataset import DummyClassificationDataset
 from torch_uncertainty.datamodules.classification.imagenet200 import (
@@ -27,6 +31,91 @@ def test_imagenet200() -> None:
     dm.train_dataloader()
     dm.val_dataloader()
     dm.test_dataloader()
+    assert len(dm._get_train_data()) == len(dm.train)
+    assert len(dm._get_train_targets()) == len(dm.train)
 
     with pytest.raises(ValueError):
         dm.setup("other")
+
+
+def test_imagenet200_default_transforms() -> None:
+    dm = ImageNet200DataModule(root="./data/", batch_size=128)
+    assert isinstance(dm.train_transform, v2.Compose)
+    assert isinstance(dm.test_transform, v2.Compose)
+
+    dm = ImageNet200DataModule(
+        root="./data/",
+        batch_size=128,
+        basic_augment=False,
+        rand_augment_opt="rand-m9-n1",
+        num_tta=2,
+    )
+    assert dm.test_transform is dm.train_transform
+
+
+def test_imagenet200_float_val_split() -> None:
+    dm = ImageNet200DataModule(
+        root="./data/",
+        batch_size=2,
+        val_split=0.5,
+        train_transform=nn.Identity(),
+        test_transform=nn.Identity(),
+    )
+    dm.dataset = DummyClassificationDataset
+    dm.setup("fit")
+
+    assert isinstance(dm.train, Subset)
+    assert isinstance(dm.val, Subset)
+    assert len(dm._get_train_data()) == len(dm.train)
+    assert len(dm._get_train_targets()) == len(dm.train)
+
+
+def test_imagenet200_indices_val_split() -> None:
+    path = Path(__file__).parent.resolve() / "../../assets/dummy_indices.yaml"
+    dm = ImageNet200DataModule(
+        root="./data/",
+        batch_size=2,
+        val_split=path,
+        train_transform=nn.Identity(),
+        test_transform=nn.Identity(),
+    )
+    dm.dataset = lambda root, split, transform: DummyClassificationDataset(
+        root,
+        split=split,
+        transform=transform,
+        num_images=10,
+    )
+    dm.setup("fit")
+    dm.setup("test")
+
+    assert isinstance(dm.train, Subset)
+    assert isinstance(dm.val, Subset)
+    assert len(dm.train) == 6
+    assert len(dm.val) == 2
+    assert len(dm._get_train_data()) == len(dm.train)
+    assert len(dm._get_train_targets()) == len(dm.train)
+    dm.train_dataloader()
+    dm.val_dataloader()
+    dm.test_dataloader()
+
+
+def test_imagenet200_verify_splits(tmp_path: Path) -> None:
+    dm = ImageNet200DataModule(
+        root=tmp_path,
+        batch_size=2,
+        train_transform=nn.Identity(),
+        test_transform=nn.Identity(),
+    )
+
+    (tmp_path / "train").mkdir()
+    dm._verify_splits("train")
+
+    with pytest.raises(FileNotFoundError, match="ImageNet val split"):
+        dm._verify_splits("val")
+
+    with pytest.raises(ValueError, match="is not a file"):
+        ImageNet200DataModule(
+            root=tmp_path,
+            batch_size=2,
+            val_split=tmp_path / "missing.yaml",
+        )

--- a/tests/datamodules/classification/test_imagenet200.py
+++ b/tests/datamodules/classification/test_imagenet200.py
@@ -1,0 +1,32 @@
+import pytest
+from torch import nn
+
+from tests._dummies.dataset import DummyClassificationDataset
+from torch_uncertainty.datamodules.classification.imagenet200 import (
+    ImageNet200DataModule,
+)
+from torch_uncertainty.datasets.classification import ImageNet200
+
+
+def test_imagenet200() -> None:
+    dm = ImageNet200DataModule(
+        root="./data/",
+        batch_size=128,
+        train_transform=nn.Identity(),
+        test_transform=nn.Identity(),
+    )
+
+    assert dm.dataset == ImageNet200
+    assert isinstance(dm.train_transform, nn.Identity)
+    assert isinstance(dm.test_transform, nn.Identity)
+
+    dm.dataset = DummyClassificationDataset
+    dm.prepare_data()
+    dm.setup()
+
+    dm.train_dataloader()
+    dm.val_dataloader()
+    dm.test_dataloader()
+
+    with pytest.raises(ValueError):
+        dm.setup("other")


### PR DESCRIPTION
## Description

Add support for ImageNet200 as defined in OpenOOD.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [ ] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
