### PR TITLE
:sparkles:(RQR)! add and add tests, rework the regression loss file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To date, the following deep-learning uncertainty quantification methods have bee
 - Stochastic Weight Averaging & Stochastic Weight Averaging Gaussian
 - [Deep Evidential Classification](https://torch-uncertainty.github.io/auto_tutorials/Classification/tutorial_evidential_classification.html) & [Regression](https://torch-uncertainty.github.io/auto_tutorials/Regression/tutorial_der_cubic.html)
 - Regression with Beta Gaussian NLL Loss
-- Quantile Regression with Pinball Loss
+- Quantile Regression with Pinball Loss and RQR
 - Test-time adaptation with Zero
 
 ### Augmentation methods

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -41,6 +41,17 @@ For Pinball / Quantile Regression, consider citing:
 * Paper: `Econometrica 1978 <https://www.jstor.org/stable/1913643>`__.
 
 
+Relaxed Quantile Regression
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For Relaxed Quantile Regression, consider citing:
+
+**Relaxed Quantile Regression: Prediction Intervals for Asymmetric Noise**
+
+* Authors: *Thomas Pouplin, Alan Jeffares, Nabeel Seedat, and Mihaela van der Schaar*
+* Paper: `ICML 2024 <https://arxiv.org/abs/2406.03258>`__.
+
+
 Deep Evidential Regression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/torch_uncertainty/losses/__init__.py
+++ b/src/torch_uncertainty/losses/__init__.py
@@ -9,4 +9,5 @@ from .classification import (
     FocalLoss,
     MixupMPLoss,
 )
-from .regression import BetaNLL, DERLoss, DistributionNLLLoss, PinballLoss
+from .quantile import PinballLoss, RQRLoss
+from .regression import BetaNLL, DERLoss, DistributionNLLLoss

--- a/src/torch_uncertainty/losses/quantile.py
+++ b/src/torch_uncertainty/losses/quantile.py
@@ -1,0 +1,164 @@
+import math
+
+import torch
+from torch import Tensor, nn
+
+
+class PinballLoss(nn.Module):
+    def __init__(self, quantile: float, reduction: str | None = "mean") -> None:
+        r"""The Pinball loss for quantile regression.
+
+        Also known as the quantile loss or check loss, the pinball loss at
+        quantile level :math:`\tau \in (0, 1)` is:
+
+        .. math::
+            \mathcal{L}_\tau(y, \hat{y}) =
+            \max\!\left(\tau\,(y - \hat{y}),\,(\tau - 1)\,(y - \hat{y})\right)
+            = \begin{cases}
+                \tau\,(y - \hat{y}) & \text{if } y \geq \hat{y}, \\
+                (1 - \tau)\,(\hat{y} - y) & \text{if } y < \hat{y}.
+            \end{cases}
+
+        For :math:`\tau = 0.5` the loss coincides with the mean absolute error
+        (MAE) scaled by :math:`\tfrac{1}{2}`.
+
+        Args:
+            quantile: The quantile level :math:`\tau \in (0, 1)`.
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``. Defaults
+                to ``"mean"``.
+
+        References:
+            [1] `Koenker, R., & Bassett Jr, G. (1978). Regression quantiles.
+            Econometrica, <https://www.jstor.org/stable/1913643>`_.
+        """
+        super().__init__()
+
+        if not 0 < quantile < 1:
+            raise ValueError(f"The quantile parameter should be in (0, 1), but got {quantile}.")
+        self.quantile = quantile
+
+        if reduction not in ("none", "mean", "sum"):
+            raise ValueError(f"{reduction} is not a valid value for reduction.")
+        self.reduction = reduction
+
+    def forward(self, predictions: Tensor, targets: Tensor) -> Tensor:
+        """Compute the pinball loss.
+
+        Args:
+            predictions: The predicted quantile values.
+            targets: The target values.
+        """
+        residual = targets - predictions
+        loss = torch.maximum(self.quantile * residual, (self.quantile - 1) * residual)
+
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss
+
+
+class RQRLoss(nn.Module):
+    def __init__(
+        self,
+        coverage_level: float,
+        width_weight: float | None = None,
+        reduction: str | None = "mean",
+    ) -> None:
+        r"""The Relaxed Quantile Regression (RQR) loss.
+
+        RQR directly learns the two endpoints :math:`(\mu_1, \mu_2)` of a
+        prediction interval with target coverage :math:`\alpha`, without assigning
+        either endpoint to a predefined quantile. Let
+
+        .. math::
+            \kappa = (y - \mu_1)(y - \mu_2).
+
+        Since :math:`\kappa < 0` exactly when :math:`y` is inside the interval, the
+        unregularized loss is
+
+        .. math::
+            \mathcal{L}^{\mathrm{RQR}}_\alpha =
+            \begin{cases}
+                \alpha \kappa & \text{if } \kappa \geq 0, \\
+                (\alpha - 1)\kappa & \text{if } \kappa < 0.
+            \end{cases}
+
+        When :attr:`width_weight` is positive, this implements the width-minimizing
+        RQR-W variant. Its squared-width penalty biases coverage by
+        :math:`-2\lambda`; therefore, the loss uses the corrected level
+        :math:`\hat{\alpha} = \alpha + 2\lambda`:
+
+        .. math::
+            \mathcal{L}^{\mathrm{RQR-W}}_\alpha =
+            \mathcal{L}^{\mathrm{RQR}}_{\alpha + 2\lambda}
+            + \frac{\lambda}{2}(\mu_2-\mu_1)^2.
+
+        Args:
+            coverage_level: The target coverage level :math:`\alpha \in (0, 1)`.
+            width_weight: The width regularization weight :math:`\lambda`, which
+                must satisfy :math:`0 \leq \lambda \leq (1-\alpha)/2`. A value of
+                ``0`` recovers the unregularized RQR loss. Defaults to ``0.0``.
+            reduction: Specifies the reduction to apply to the output.
+                Must be one of ``'none'``, ``'mean'`` or ``'sum'``. Defaults to
+                ``"mean"``.
+
+        References:
+            [1] `Pouplin, T., Jeffares, A., Seedat, N., & van der Schaar, M. (2024).
+            Relaxed quantile regression: Prediction intervals for asymmetric noise.
+            ICML 2024 <https://arxiv.org/abs/2406.03258>`_.
+        """
+        super().__init__()
+
+        if not 0 < coverage_level < 1:
+            raise ValueError(f"The coverage level should be in (0, 1), but got {coverage_level}.")
+        self.coverage_level = coverage_level
+
+        if width_weight is None:
+            width_weight = 0.0
+        corrected_level = coverage_level + 2 * width_weight
+        if width_weight < 0 or not math.isfinite(width_weight) or corrected_level > 1:
+            raise ValueError(
+                "The width weight should be in "
+                f"[0, (1 - coverage_level) / 2], but got {width_weight}."
+            )
+        self.width_weight = width_weight
+
+        if reduction not in ("none", "mean", "sum"):
+            raise ValueError(f"{reduction} is not a valid value for reduction.")
+        self.reduction = reduction
+
+    def forward(self, predictions: Tensor, targets: Tensor) -> Tensor:
+        """Compute the RQR loss.
+
+        Args:
+            predictions: The two interval endpoints, with shape ``(..., 2)``.
+            targets: The target values, with shape ``(...)``.
+        """
+        if predictions.ndim == 0 or predictions.shape[-1] != 2:
+            raise ValueError(
+                "Expected `predictions` to have exactly two interval endpoints "
+                f"in its last dimension, but got shape {predictions.shape}."
+            )
+        if targets.shape != predictions.shape[:-1]:
+            raise ValueError(
+                "Expected `targets` to have the same shape as `predictions` "
+                f"without its last dimension, but got {targets.shape=} and "
+                f"{predictions.shape=}."
+            )
+
+        endpoint_1, endpoint_2 = predictions.unbind(dim=-1)
+        interval_product = (targets - endpoint_1) * (targets - endpoint_2)
+        corrected_level = self.coverage_level + 2 * self.width_weight
+        loss = torch.maximum(
+            corrected_level * interval_product,
+            (corrected_level - 1) * interval_product,
+        )
+        loss += self.width_weight * (endpoint_2 - endpoint_1).square() / 2
+
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss

--- a/src/torch_uncertainty/losses/regression.py
+++ b/src/torch_uncertainty/losses/regression.py
@@ -7,62 +7,6 @@ from torch.distributions import Distribution, Independent
 from torch_uncertainty.utils.distributions import NormalInverseGamma
 
 
-class PinballLoss(nn.Module):
-    def __init__(self, quantile: float = 0.5, reduction: str | None = "mean") -> None:
-        r"""The Pinball loss for quantile regression.
-
-        Also known as the quantile loss or check loss, the pinball loss at
-        quantile level :math:`\tau \in (0, 1)` is:
-
-        .. math::
-            \mathcal{L}_\tau(y, \hat{y}) =
-            \max\!\left(\tau\,(y - \hat{y}),\,(\tau - 1)\,(y - \hat{y})\right)
-            = \begin{cases}
-                \tau\,(y - \hat{y}) & \text{if } y \geq \hat{y}, \\
-                (1 - \tau)\,(\hat{y} - y) & \text{if } y < \hat{y}.
-            \end{cases}
-
-        For :math:`\tau = 0.5` the loss coincides with the mean absolute error
-        (MAE) scaled by :math:`\tfrac{1}{2}`.
-
-        Args:
-            quantile: The quantile level :math:`\tau \in (0, 1)`. Defaults to
-                ``0.5``.
-            reduction: Specifies the reduction to apply to the output.
-                Must be one of ``'none'``, ``'mean'`` or ``'sum'``. Defaults
-                to ``"mean"``.
-
-        References:
-            [1] `Koenker, R., & Bassett Jr, G. (1978). Regression quantiles.
-            Econometrica, <https://www.jstor.org/stable/1913643>`_.
-        """
-        super().__init__()
-
-        if not 0 < quantile < 1:
-            raise ValueError(f"The quantile parameter should be in (0, 1), but got {quantile}.")
-        self.quantile = quantile
-
-        if reduction not in ("none", "mean", "sum"):
-            raise ValueError(f"{reduction} is not a valid value for reduction.")
-        self.reduction = reduction
-
-    def forward(self, predictions: Tensor, targets: Tensor) -> Tensor:
-        """Compute the pinball loss.
-
-        Args:
-            predictions: The predicted quantile values.
-            targets: The target values.
-        """
-        residual = targets - predictions
-        loss = torch.maximum(self.quantile * residual, (self.quantile - 1) * residual)
-
-        if self.reduction == "mean":
-            return loss.mean()
-        if self.reduction == "sum":
-            return loss.sum()
-        return loss
-
-
 class DistributionNLLLoss(nn.Module):
     def __init__(self, reduction: Literal["mean", "sum"] | None = "mean") -> None:
         r"""Negative Log-Likelihood loss for probabilistic regression.

--- a/tests/losses/test_quantile.py
+++ b/tests/losses/test_quantile.py
@@ -1,0 +1,135 @@
+import pytest
+import torch
+
+from torch_uncertainty.losses.quantile import PinballLoss, RQRLoss
+
+
+class TestPinballLoss:
+    """Testing the PinballLoss class."""
+
+    def test_main(self) -> None:
+        # At τ=0.5 and perfect prediction the loss is zero.
+        loss = PinballLoss(quantile=0.5)
+        pred = torch.tensor([1.0])
+        target = torch.tensor([1.0])
+        assert loss(pred, target) == pytest.approx(0.0)
+
+        # tau 0.5 is MAE/2: underestimate and overestimate are symmetric.
+        pred_low = torch.tensor([0.0])
+        pred_high = torch.tensor([1.0])
+        target_one = torch.tensor([1.0])
+        target_zero = torch.tensor([0.0])
+        assert loss(pred_low, target_one) == pytest.approx(0.5)
+        assert loss(pred_high, target_zero) == pytest.approx(0.5)
+
+        # tau 0.9 penalises underestimation more heavily than overestimation.
+        loss_q90 = PinballLoss(quantile=0.9)
+        assert loss_q90(pred_low, target_one) == pytest.approx(0.9)
+        assert loss_q90(pred_high, target_zero) == pytest.approx(0.1)
+
+        # reduction "sum"
+        loss_sum = PinballLoss(quantile=0.5, reduction="sum")
+        preds = torch.tensor([0.0, 1.0])
+        targets = torch.tensor([1.0, 0.0])
+        assert loss_sum(preds, targets) == pytest.approx(1.0)
+
+        # reduction "none"
+        loss_none = PinballLoss(quantile=0.5, reduction="none")
+        result = loss_none(preds, targets)
+        assert result.tolist() == pytest.approx([0.5, 0.5])
+
+    def test_failures(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"The quantile parameter should be in \(0, 1\)",
+        ):
+            PinballLoss(quantile=0.0)
+
+        with pytest.raises(
+            ValueError,
+            match=r"The quantile parameter should be in \(0, 1\)",
+        ):
+            PinballLoss(quantile=1.0)
+
+        with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
+            PinballLoss(quantile=0.5, reduction="median")
+
+
+class TestRQRLoss:
+    """Testing the RQRLoss class."""
+
+    def test_values_and_reductions(self) -> None:
+        predictions = torch.tensor([[0.0, 2.0], [0.0, 2.0], [0.0, 2.0]])
+        targets = torch.tensor([1.0, 3.0, 0.0])
+
+        loss = RQRLoss(coverage_level=0.8, reduction="none")
+        assert loss(predictions, targets).tolist() == pytest.approx([0.2, 2.4, 0.0])
+
+        assert RQRLoss(coverage_level=0.8)(predictions, targets) == pytest.approx(2.6 / 3)
+        assert RQRLoss(coverage_level=0.8, reduction="sum")(predictions, targets) == pytest.approx(
+            2.6
+        )
+
+    def test_permutation_invariance(self) -> None:
+        predictions = torch.tensor([[0.0, 2.0], [4.0, 1.0]])
+        targets = torch.tensor([1.0, 5.0])
+        loss = RQRLoss(coverage_level=0.8, reduction="none")
+
+        assert torch.equal(loss(predictions, targets), loss(predictions.flip(-1), targets))
+
+    def test_width_regularization(self) -> None:
+        predictions = torch.tensor([[0.0, 2.0], [0.0, 2.0]])
+        targets = torch.tensor([1.0, 3.0])
+
+        loss = RQRLoss(coverage_level=0.8, width_weight=0.05, reduction="none")
+
+        # The corrected coverage level is 0.8 + 2 * 0.05 = 0.9 and the
+        # squared-width penalty is 0.05 * (2 - 0) ** 2 / 2 = 0.1.
+        assert loss(predictions, targets).tolist() == pytest.approx([0.2, 2.8])
+
+        # The largest valid width weight remains accepted despite floating-point
+        # representation of (1 - coverage_level) / 2.
+        RQRLoss(coverage_level=0.9, width_weight=0.05)
+
+    def test_gradients(self) -> None:
+        predictions = torch.tensor([[0.0, 2.0], [0.0, 2.0]], requires_grad=True)
+        targets = torch.tensor([1.0, 3.0])
+
+        RQRLoss(coverage_level=0.8, reduction="sum")(predictions, targets).backward()
+
+        assert predictions.grad is not None
+        torch.testing.assert_close(
+            predictions.grad,
+            torch.tensor([[-0.2, 0.2], [-0.8, -2.4]]),
+        )
+
+    @pytest.mark.parametrize("coverage_level", [0.0, 1.0])
+    def test_invalid_coverage_level(self, coverage_level: float) -> None:
+        with pytest.raises(ValueError, match=r"The coverage level should be in \(0, 1\)"):
+            RQRLoss(coverage_level=coverage_level)
+
+    @pytest.mark.parametrize("width_weight", [-0.1, 0.0501, float("nan")])
+    def test_invalid_width_weight(self, width_weight: float) -> None:
+        with pytest.raises(ValueError, match="The width weight should be in"):
+            RQRLoss(coverage_level=0.9, width_weight=width_weight)
+
+    def test_invalid_reduction(self) -> None:
+        with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
+            RQRLoss(coverage_level=0.9, reduction="median")
+
+    @pytest.mark.parametrize(
+        ("predictions", "targets", "message"),
+        [
+            (torch.tensor(1.0), torch.tensor(1.0), "exactly two interval endpoints"),
+            (torch.ones(2, 3), torch.ones(2), "exactly two interval endpoints"),
+            (torch.ones(2, 2), torch.ones(2, 1), "same shape"),
+        ],
+    )
+    def test_invalid_shapes(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        message: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            RQRLoss(coverage_level=0.9)(predictions, targets)

--- a/tests/losses/test_regression.py
+++ b/tests/losses/test_regression.py
@@ -8,7 +8,6 @@ from torch_uncertainty.losses import (
     BetaNLL,
     DERLoss,
     DistributionNLLLoss,
-    PinballLoss,
 )
 from torch_uncertainty.utils.distributions import NormalInverseGamma
 
@@ -112,54 +111,3 @@ class TestBetaNLL:
 
         with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
             BetaNLL(beta=1.0, reduction="median")
-
-
-class TestPinballLoss:
-    """Testing the PinballLoss class."""
-
-    def test_main(self) -> None:
-        # At τ=0.5 and perfect prediction the loss is zero.
-        loss = PinballLoss(quantile=0.5)
-        pred = torch.tensor([1.0])
-        target = torch.tensor([1.0])
-        assert loss(pred, target) == pytest.approx(0.0)
-
-        # tau 0.5 is MAE/2: underestimate and overestimate are symmetric.
-        pred_low = torch.tensor([0.0])
-        pred_high = torch.tensor([1.0])
-        target_one = torch.tensor([1.0])
-        target_zero = torch.tensor([0.0])
-        assert loss(pred_low, target_one) == pytest.approx(0.5)
-        assert loss(pred_high, target_zero) == pytest.approx(0.5)
-
-        # tau 0.9 penalises underestimation more heavily than overestimation.
-        loss_q90 = PinballLoss(quantile=0.9)
-        assert loss_q90(pred_low, target_one) == pytest.approx(0.9)
-        assert loss_q90(pred_high, target_zero) == pytest.approx(0.1)
-
-        # reduction "sum"
-        loss_sum = PinballLoss(quantile=0.5, reduction="sum")
-        preds = torch.tensor([0.0, 1.0])
-        targets = torch.tensor([1.0, 0.0])
-        assert loss_sum(preds, targets) == pytest.approx(1.0)
-
-        # reduction "none"
-        loss_none = PinballLoss(quantile=0.5, reduction="none")
-        result = loss_none(preds, targets)
-        assert result.tolist() == pytest.approx([0.5, 0.5])
-
-    def test_failures(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match=r"The quantile parameter should be in \(0, 1\)",
-        ):
-            PinballLoss(quantile=0.0)
-
-        with pytest.raises(
-            ValueError,
-            match=r"The quantile parameter should be in \(0, 1\)",
-        ):
-            PinballLoss(quantile=1.0)
-
-        with pytest.raises(ValueError, match=r"is not a valid value for reduction."):
-            PinballLoss(quantile=0.5, reduction="median")


### PR DESCRIPTION
## Description

Regularized Quantile Regression loss. Rework the loss.regression file to split quantile regression losses from classical regression losses.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [x] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
