### PR TITLE
:sparkles:(ECE): add ECE direction

### DIFF
--- a/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
+++ b/src/torch_uncertainty/metrics/classification/calibration/calibration_error.py
@@ -5,6 +5,7 @@ import matplotlib.ticker as mticker
 import numpy as np
 import seaborn as sns
 import torch
+from torch import Tensor
 from torchmetrics.classification.calibration_error import (
     BinaryCalibrationError,
     MulticlassCalibrationError,
@@ -229,8 +230,35 @@ def custom_plot(
     )
 
 
-# overwrite the plot method of the original metrics
+def _calibration_error_compute(self: Any) -> Tensor:
+    confidences = dim_zero_cat(self.confidences)
+    accuracies = dim_zero_cat(self.accuracies)
+    bin_boundaries = torch.linspace(0, 1, self.n_bins + 1, device=confidences.device)
+    acc_bin, conf_bin, prop_bin = _binning_bucketize(confidences, accuracies, bin_boundaries)
+    gap = conf_bin - acc_bin
+    if self.direction == "over":
+        return (gap.clamp_min(0) * prop_bin).sum()
+    if self.direction == "under":
+        return ((-gap).clamp_min(0) * prop_bin).sum()
+    if self.norm == "l1":
+        return (gap.abs() * prop_bin).sum()
+    if self.norm == "l2":
+        return torch.sqrt((gap.square() * prop_bin).sum())
+    return gap.abs().max()
+
+
 class TUBinaryCalibrationError(BinaryCalibrationError):
+    def __init__(
+        self,
+        *args: Any,
+        direction: Literal["over", "under"] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.direction = direction
+
+    compute = _calibration_error_compute
+
     def plot(
         self,
         title: str = "Reliability Diagram",
@@ -243,6 +271,17 @@ class TUBinaryCalibrationError(BinaryCalibrationError):
 
 
 class TUMulticlassCalibrationError(MulticlassCalibrationError):
+    def __init__(
+        self,
+        *args: Any,
+        direction: Literal["over", "under"] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.direction = direction
+
+    compute = _calibration_error_compute
+
     def plot(
         self,
         title: str = "Reliability Diagram",
@@ -261,6 +300,7 @@ class CalibrationError:
         adaptive: bool = False,
         num_bins: int = 10,
         norm: Literal["l1", "l2", "max"] = "l1",
+        direction: Literal["over", "under"] | None = None,
         num_classes: int | None = None,
         ignore_index: int | None = None,
         validate_args: bool = True,
@@ -284,6 +324,19 @@ class CalibrationError:
 
             \text{ECE} = \sum_{m=1}^{M} \frac{|B_m|}{N}
             \left| \operatorname{acc}(B_m) - \operatorname{conf}(B_m) \right|
+
+        For the L1 norm, setting ``direction="over"`` gives ECE+ by retaining
+        only overconfidence gaps, while ``direction="under"`` gives ECE- by
+        retaining only underconfidence gaps:
+
+        .. math::
+
+            \begin{aligned}
+            \operatorname{ECE}^{+} &= \sum_{m=1}^{M} \frac{|B_m|}{N}
+            [\operatorname{conf}(B_m) - \operatorname{acc}(B_m)]_{+}, \\
+            \operatorname{ECE}^{-} &= \sum_{m=1}^{M} \frac{|B_m|}{N}
+            [\operatorname{acc}(B_m) - \operatorname{conf}(B_m)]_{+}.
+            \end{aligned}
 
         **Maximum Calibration Error (MCE):**
 
@@ -314,6 +367,9 @@ class CalibrationError:
             num_bins : Number of bins to divide the probability space. Defaults to ``10``.
             norm: Specifies the type of norm to use: ``"l1"``, ``"l2"``, or ``"max"``.
                 Defaults to ``"l1"``.
+            direction: Whether to retain only overconfidence (``"over"``) or
+                underconfidence (``"under"``) terms. Only available with the
+                L1 norm and non-adaptive binning. Defaults to ``None``.
             num_classes: Number of classes for ``"multiclass"`` tasks.
                 Required when task is ``"multiclass"``. Defaults to ``None``.
             ignore_index: Index to ignore during calculations. Defaults to ``None``.
@@ -362,6 +418,10 @@ class CalibrationError:
         """
         if kwargs.get("n_bins") is not None:
             raise ValueError("`n_bins` does not exist in TorchUncertainty, use `num_bins`.")
+        if direction not in (None, "over", "under"):
+            raise ValueError("`direction` must be one of `None`, `'over'`, or `'under'`.")
+        if direction is not None and (adaptive or norm != "l1"):
+            raise ValueError("`direction` is only supported for non-adaptive L1 ECE.")
         if adaptive:
             return AdaptiveCalibrationError(
                 task=task,
@@ -377,6 +437,7 @@ class CalibrationError:
             {
                 "n_bins": num_bins,
                 "norm": norm,
+                "direction": direction,
                 "ignore_index": ignore_index,
                 "validate_args": validate_args,
             }

--- a/src/torch_uncertainty/routines/classification.py
+++ b/src/torch_uncertainty/routines/classification.py
@@ -203,6 +203,18 @@ class ClassificationRoutine(LightningModule):
                 num_bins=self.num_bins_calibration_error,
                 num_classes=self.num_classes,
             ),
+            "cal/ECE+": CalibrationError(
+                task=task,
+                num_bins=self.num_bins_calibration_error,
+                num_classes=self.num_classes,
+                direction="over",
+            ),
+            "cal/ECE-": CalibrationError(
+                task=task,
+                num_bins=self.num_bins_calibration_error,
+                num_classes=self.num_classes,
+                direction="under",
+            ),
             "cal/MCE": CalibrationError(
                 task=task,
                 num_bins=self.num_bins_calibration_error,
@@ -225,7 +237,7 @@ class ClassificationRoutine(LightningModule):
             ["cls/Acc"],
             ["cls/Brier"],
             ["cls/NLL"],
-            ["cal/ECE", "cal/SmECE", "cal/MCE", "cal/aECE"],
+            ["cal/ECE", "cal/ECE+", "cal/ECE-", "cal/SmECE", "cal/MCE", "cal/aECE"],
             ["sc/AURC", "sc/AUGRC", "sc/Cov_5Risk", "sc/Risk_80Cov"],
         ]
 

--- a/src/torch_uncertainty/utils/evaluation_loop.py
+++ b/src/torch_uncertainty/utils/evaluation_loop.py
@@ -22,6 +22,8 @@ PERCENTAGE_METRICS = [
     "AUGRC",
     "mAcc",
     "ECE",
+    "ECE+",
+    "ECE-",
     "MCE",
     "aECE",
     "SmECE",

--- a/tests/metrics/classification/test_calibration.py
+++ b/tests/metrics/classification/test_calibration.py
@@ -61,6 +61,29 @@ class TestCalibrationError:
             ValueError, match=r"`n_bins` does not exist in TorchUncertainty, use `num_bins`."
         ):
             CalibrationError(task="multiclass", num_classes=2, n_bins=1)
+        with pytest.raises(ValueError, match="`direction` must be one of"):
+            CalibrationError(task="binary", direction="invalid")
+        with pytest.raises(ValueError, match="only supported for non-adaptive L1 ECE"):
+            CalibrationError(task="binary", direction="over", norm="l2")
+
+    @pytest.mark.parametrize("task", ["binary", "multiclass"])
+    def test_directional_ece(self, task: Literal["binary", "multiclass"]) -> None:
+        if task == "binary":
+            preds = torch.tensor([0.55, 0.55, 0.90, 0.90])
+        else:
+            preds = torch.tensor([[0.45, 0.55], [0.45, 0.55], [0.10, 0.90], [0.10, 0.90]])
+        target = torch.tensor([1, 1, 1, 0])
+        kwargs = {"task": task, "num_bins": 4}
+        if task == "multiclass":
+            kwargs["num_classes"] = 2
+
+        ece = CalibrationError(**kwargs)(preds, target)
+        ece_plus = CalibrationError(**kwargs, direction="over")(preds, target)
+        ece_minus = CalibrationError(**kwargs, direction="under")(preds, target)
+
+        assert ece_plus.item() == pytest.approx(0.20)
+        assert ece_minus.item() == pytest.approx(0.225)
+        assert ece.item() == pytest.approx((ece_plus + ece_minus).item())
 
 
 class TestAdaptiveCalibrationError:


### PR DESCRIPTION
## Description

Add ECE direction: shows whether the model is generally over/under-confident without looking at the reliablity diagram.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [x] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
