### PR TITLE
:sparkles:(ambiguity): add the ambiguity metric

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -524,6 +524,28 @@ For the grouping loss, consider citing:
 * Paper: `ICLR 2023 <https://arxiv.org/pdf/2210.16315.pdf>`__.
 
 
+Ambiguity
+^^^^^^^^^
+
+For the ambiguity, consider citing:
+
+**Neural Network Ensembles, Cross Validation, and Active Learning**
+
+* Authors: *Anders Krogh and Jesper Vedelsby*
+* Paper: `NeurIPS 1994 <https://proceedings.neurips.cc/paper/1994/hash/b8c37e33defde51cf91e1e03e51657da-Abstract.html>`__.
+
+
+Disagreement
+^^^^^^^^^^^^
+
+For the disagreement, consider citing:
+
+**The Random Subspace Method for Constructing Decision Forests**
+
+* Authors: *Tin Kam Ho*
+* Paper: `IEEE Transactions on Pattern Analysis and Machine Intelligence 1998 <https://doi.org/10.1109/34.709601>`__.
+
+
 Interval (Winkler) Score
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/torch_uncertainty/metrics/__init__.py
+++ b/src/torch_uncertainty/metrics/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401
+from .ambiguity import Ambiguity
 from .classification import (
     AUGRC,
     AURC,

--- a/src/torch_uncertainty/metrics/ambiguity.py
+++ b/src/torch_uncertainty/metrics/ambiguity.py
@@ -1,0 +1,133 @@
+from typing import Any, Literal
+
+import torch
+from torch import Tensor
+from torchmetrics import Metric
+from torchmetrics.utilities.data import dim_zero_cat
+
+
+class Ambiguity(Metric):
+    is_differentiable = False
+    higher_is_better = None
+    full_state_update = False
+
+    values: list[Tensor]
+    total: Tensor
+
+    def __init__(
+        self,
+        reduction: Literal["mean", "sum", "none"] | None = "mean",
+        relative: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        r"""Compute the ambiguity of an ensemble of regression models.
+
+        For predictions :math:`f_m(x_b)` from :math:`M` ensemble members, the
+        ambiguity is the population variance around the ensemble prediction
+        :math:`\bar f(x_b)`:
+
+        .. math::
+
+            A(x_b) = \frac{1}{M}\sum_{m=1}^M
+            \left(f_m(x_b) - \bar f(x_b)\right)^2.
+
+        If :attr:`relative` is ``True``, the ambiguity is normalized elementwise
+        by the squared ensemble prediction:
+
+        .. math::
+
+            A_{\mathrm{rel}}(x_b) = \frac{A(x_b)}
+            {\max\!\left(\bar f(x_b)^2, \epsilon\right)},
+
+        where :math:`\epsilon` is the machine epsilon of the prediction dtype.
+        This is the squared coefficient of variation of the ensemble predictions.
+        For vector-valued predictions, the metric averages over the output
+        dimensions to produce one value per sample. :attr:`relative` is intended
+        for regression settings only.
+
+        Args:
+            reduction: Determines how to reduce over the batch dimension:
+
+                - ``"mean"`` [default]: Average score across samples.
+                - ``"sum"``: Sum score across samples.
+                - ``"none"`` or ``None``: Return one score per sample.
+
+            relative: If ``True``, normalize the ambiguity by the squared
+                ensemble prediction. Defaults to ``False``.
+            kwargs: Additional keyword arguments, see `Advanced metric settings
+                <https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metric-kwargs>`_.
+
+        Inputs:
+            - :attr:`preds`: :math:`(B, M, ...)` floating-point ensemble
+              predictions, where :math:`B` is the batch size and :math:`M` is
+              the number of ensemble members.
+
+        Reference:
+            `Neural Network Ensembles, Cross Validation, and Active Learning,
+            NeurIPS 1994
+            <https://proceedings.neurips.cc/paper/1994/hash/b8c37e33defde51cf91e1e03e51657da-Abstract.html>`_.
+
+        Raises:
+            ValueError: If :attr:`reduction` is invalid, :attr:`preds` is not a
+                floating-point tensor of at least two dimensions, or fewer than
+                two ensemble members are provided.
+        """
+        super().__init__(**kwargs)
+
+        allowed_reduction = ("sum", "mean", "none", None)
+        if reduction not in allowed_reduction:
+            raise ValueError(
+                "Expected argument `reduction` to be one of "
+                f"{allowed_reduction} but got {reduction}."
+            )
+
+        self.reduction = reduction
+        self.relative = relative
+
+        if reduction in ("mean", "sum"):
+            self.add_state("values", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        else:
+            self.add_state("values", default=[], dist_reduce_fx="cat")
+        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def _compute_ambiguity(self, preds: Tensor) -> Tensor:
+        ensemble_preds = preds.mean(dim=1, keepdim=True)
+        ambiguity = (preds - ensemble_preds).square().mean(dim=1)
+        if self.relative:
+            scale = ensemble_preds.squeeze(1).square().clamp_min(torch.finfo(preds.dtype).eps)
+            ambiguity = ambiguity / scale
+        if ambiguity.ndim > 1:
+            ambiguity = ambiguity.flatten(start_dim=1).mean(dim=1)
+        return ambiguity
+
+    def update(self, preds: Tensor) -> None:  # pyrefly: ignore[bad-override]
+        """Update the metric state with ensemble predictions.
+
+        Args:
+            preds: Floating-point ensemble predictions of shape :math:`(B, M, ...)`.
+        """
+        if preds.ndim < 2:
+            raise ValueError(
+                "Expected `preds` to have shape (batch, estimators, ...), "
+                f"but got {tuple(preds.shape)}."
+            )
+        if preds.size(1) < 2:
+            raise ValueError("Expected at least two ensemble members.")
+        if not preds.is_floating_point():
+            raise ValueError("Expected `preds` to be a floating-point tensor.")
+
+        ambiguity = self._compute_ambiguity(preds)
+        if self.reduction is None or self.reduction == "none":
+            self.values.append(ambiguity)
+        else:
+            self.values += ambiguity.sum()
+            self.total += ambiguity.numel()
+
+    def compute(self) -> Tensor:
+        """Compute ambiguity from the inputs passed to :meth:`update`."""
+        values = dim_zero_cat(self.values)
+        if self.reduction == "sum":
+            return values.sum()
+        if self.reduction == "mean":
+            return values.sum() / self.total
+        return values

--- a/tests/metrics/test_ambiguity.py
+++ b/tests/metrics/test_ambiguity.py
@@ -1,0 +1,68 @@
+import pytest
+import torch
+
+from torch_uncertainty.metrics import Ambiguity
+
+
+class TestAmbiguity:
+    """Testing the Ambiguity metric class."""
+
+    @pytest.mark.parametrize(
+        ("reduction", "expected"),
+        [("mean", 5 / 3), ("sum", 10 / 3), ("none", [2 / 3, 8 / 3]), (None, [2 / 3, 8 / 3])],
+    )
+    def test_reductions(self, reduction: str | None, expected: float | list[float]) -> None:
+        preds = torch.tensor([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]])
+        result = Ambiguity(reduction=reduction)(preds)
+        torch.testing.assert_close(result, torch.as_tensor(expected))
+
+    def test_accumulation(self) -> None:
+        metric = Ambiguity()
+        metric.update(torch.tensor([[1.0, 3.0]]))
+        metric.update(torch.tensor([[2.0, 6.0]]))
+        torch.testing.assert_close(metric.compute(), torch.tensor(2.5))
+
+    def test_multidimensional_outputs(self) -> None:
+        preds = torch.tensor([[[1.0, 2.0], [3.0, 6.0]]])
+        torch.testing.assert_close(Ambiguity()(preds), torch.tensor(2.5))
+
+    def test_relative_ambiguity(self) -> None:
+        preds = torch.tensor([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]])
+        result = Ambiguity(relative=True, reduction="none")(preds)
+        torch.testing.assert_close(result, torch.tensor([1 / 6, 1 / 6]))
+
+    def test_relative_ambiguity_multidimensional(self) -> None:
+        preds = torch.tensor([[[1.0, -3.0], [3.0, -1.0]]])
+        result = Ambiguity(relative=True)(preds)
+        torch.testing.assert_close(result, torch.tensor(0.25))
+
+    def test_relative_ambiguity_is_scale_invariant(self) -> None:
+        preds = torch.tensor([[1.0, 2.0, 3.0]])
+        metric = Ambiguity(relative=True)
+        torch.testing.assert_close(metric(preds), metric(10 * preds))
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.float64])
+    def test_relative_ambiguity_zero_ensemble_prediction(self, dtype: torch.dtype) -> None:
+        result = Ambiguity(relative=True)(torch.tensor([[-1.0, 1.0]], dtype=dtype))
+        assert torch.isfinite(result)
+        assert result > 0
+
+    def test_ambiguity_decomposition(self) -> None:
+        preds = torch.tensor([[1.0, 2.0, 4.0], [2.0, 5.0, 8.0]])
+        target = torch.tensor([3.0, 4.0])
+        ensemble_error = (preds.mean(dim=1) - target).square().mean()
+        mean_member_error = (preds - target.unsqueeze(1)).square().mean()
+
+        torch.testing.assert_close(ensemble_error, mean_member_error - Ambiguity()(preds))
+
+    @pytest.mark.parametrize(
+        "preds",
+        [torch.tensor([1.0, 2.0]), torch.tensor([[1.0]]), torch.tensor([[1, 2]])],
+    )
+    def test_invalid_predictions(self, preds: torch.Tensor) -> None:
+        with pytest.raises(ValueError):
+            Ambiguity().update(preds)
+
+    def test_invalid_reduction(self) -> None:
+        with pytest.raises(ValueError, match="reduction"):
+            Ambiguity(reduction="geometric_mean")


### PR DESCRIPTION
## Description

Add the ambiguity metric for regression and classification ensemble disagreement estimation.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [x] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed
